### PR TITLE
Removed uuid from group creation params and fixed add-group button on dashboard

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/provisioning/ScimGroupProvisioning.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/provisioning/ScimGroupProvisioning.java
@@ -6,6 +6,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -78,8 +79,9 @@ public class ScimGroupProvisioning implements ScimProvisioning<ScimGroup, List<S
     IamGroup iamGroup = new IamGroup();
 
     Date creationTime = new Date();
+    String uuid = UUID.randomUUID().toString();
 
-    iamGroup.setUuid(group.getId());
+    iamGroup.setUuid(uuid);
     iamGroup.setName(group.getDisplayName());
     iamGroup.setCreationTime(creationTime);
     iamGroup.setLastUpdateTime(creationTime);

--- a/iam-login-service/src/main/webapp/resources/iam/js/dashboard-app/controllers/add-group.controller.js
+++ b/iam-login-service/src/main/webapp/resources/iam/js/dashboard-app/controllers/add-group.controller.js
@@ -17,9 +17,8 @@ function AddGroupController($scope, $rootScope, $uibModalInstance, Utils, scimFa
 
 	function resetGroup() {
 
-		addGroupCtrl.group.id = "";
 		addGroupCtrl.group.displayName = "";
-		addGroupCtrl.enableAdd = true;
+		addGroupCtrl.enabled = true;
 
 	}
 
@@ -29,7 +28,6 @@ function AddGroupController($scope, $rootScope, $uibModalInstance, Utils, scimFa
 
 		addGroupCtrl.enabled = false;
 
-		addGroupCtrl.group.id = Utils.uuid();
 		addGroupCtrl.group.schemas = [];
 		addGroupCtrl.group.schemas[0] = "urn:ietf:params:scim:schemas:core:2.0:Group";
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/group/ScimGroupProvisioningPatchTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/group/ScimGroupProvisioningPatchTests.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.hasSize;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 import org.junit.After;
 import org.junit.Before;
@@ -66,9 +65,7 @@ public class ScimGroupProvisioningPatchTests {
 
   private ScimGroup addTestGroup(String displayName) {
 
-    String uuid = UUID.randomUUID().toString();
-
-    ScimGroup group = ScimGroup.builder(displayName).id(uuid).build();
+    ScimGroup group = ScimGroup.builder(displayName).build();
 
     return restUtils.doPost("/scim/Groups/", group).extract().as(ScimGroup.class);
   }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/group/ScimGroupProvisioningTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/group/ScimGroupProvisioningTests.java
@@ -95,14 +95,12 @@ public class ScimGroupProvisioningTests {
   public void testCreateAndDeleteGroupSuccessResponse() {
 
     String name = "engineers";
-    String uuid = UUID.randomUUID().toString();
 
-    ScimGroup group = ScimGroup.builder(name).id(uuid).build();
+    ScimGroup group = ScimGroup.builder(name).build();
 
     ScimGroup createdGroup = restUtils.doPost("/scim/Groups/", group).extract().as(ScimGroup.class);
 
     restUtils.doGet(createdGroup.getMeta().getLocation())
-      .body("id", equalTo(uuid))
       .body("displayName", equalTo(name));
 
     restUtils.doDelete(createdGroup.getMeta().getLocation(), HttpStatus.NO_CONTENT);
@@ -111,17 +109,14 @@ public class ScimGroupProvisioningTests {
   @Test
   public void testUpdateGroupDisplaynameSuccessResponse() {
 
-    String uuid = UUID.randomUUID().toString();
-
-    ScimGroup requestedGroup = ScimGroup.builder("engineers").id(uuid).build();
+    ScimGroup requestedGroup = ScimGroup.builder("engineers").build();
 
     ScimGroup createdGroup =
         restUtils.doPost("/scim/Groups/", requestedGroup).extract().as(ScimGroup.class);
 
-    requestedGroup = ScimGroup.builder("engineers_updated").id(uuid).build();
+    requestedGroup = ScimGroup.builder("engineers_updated").build();
 
     restUtils.doPut(createdGroup.getMeta().getLocation(), requestedGroup)
-      .body("id", equalTo(createdGroup.getId()))
       .body("displayName", equalTo(requestedGroup.getDisplayName()));
 
     restUtils.doDelete(createdGroup.getMeta().getLocation(), HttpStatus.NO_CONTENT);
@@ -131,9 +126,8 @@ public class ScimGroupProvisioningTests {
   public void testCreateGroupEmptyDisplayNameValidationError() {
 
     String displayName = "";
-    String uuid = UUID.randomUUID().toString();
 
-    ScimGroup group = ScimGroup.builder(displayName).id(uuid).build();
+    ScimGroup group = ScimGroup.builder(displayName).build();
 
     restUtils.doPost("/scim/Groups/", group, HttpStatus.BAD_REQUEST).body("detail",
         containsString("scimGroup.displayName : may not be empty"));
@@ -143,14 +137,12 @@ public class ScimGroupProvisioningTests {
   @Test
   public void testUpdateGroupEmptyDisplayNameValidationErro() {
 
-    String uuid = UUID.randomUUID().toString();
-
-    ScimGroup requestedGroup = ScimGroup.builder("engineers").id(uuid).build();
+    ScimGroup requestedGroup = ScimGroup.builder("engineers").build();
 
     ScimGroup createdGroup =
         restUtils.doPost("/scim/Groups/", requestedGroup).extract().as(ScimGroup.class);
 
-    requestedGroup = ScimGroup.builder("").id(uuid).build();
+    requestedGroup = ScimGroup.builder("").build();
 
     restUtils.doPut(createdGroup.getMeta().getLocation(), requestedGroup, HttpStatus.BAD_REQUEST);
 
@@ -160,21 +152,18 @@ public class ScimGroupProvisioningTests {
   @Test
   public void testUpdateGroupAlreadyUsedDisplaynameError() {
 
-    String engineers_uuid = UUID.randomUUID().toString();
-    String artists_uuid = UUID.randomUUID().toString();
-
     ScimGroup engineers =
-        restUtils.doPost("/scim/Groups/", ScimGroup.builder("engineers").id(engineers_uuid).build())
+        restUtils.doPost("/scim/Groups/", ScimGroup.builder("engineers").build())
           .extract()
           .as(ScimGroup.class);
 
     ScimGroup artists =
-        restUtils.doPost("/scim/Groups/", ScimGroup.builder("artists").id(artists_uuid).build())
+        restUtils.doPost("/scim/Groups/", ScimGroup.builder("artists").build())
           .extract()
           .as(ScimGroup.class);
 
     restUtils.doPut(engineers.getMeta().getLocation(),
-        ScimGroup.builder("artists").id(engineers_uuid).build(), HttpStatus.CONFLICT);
+        ScimGroup.builder("artists").build(), HttpStatus.CONFLICT);
 
     restUtils.doDelete(engineers.getMeta().getLocation(), HttpStatus.NO_CONTENT);
     restUtils.doDelete(artists.getMeta().getLocation(), HttpStatus.NO_CONTENT);


### PR DESCRIPTION
Fixed:
- [The SCIM create group endpoint should not require clients to provide a uuid](https://github.com/indigo-iam/iam/issues/53)
- [Add group button does not work in admin dashboard](https://github.com/indigo-iam/iam/issues/34)
