### PR TITLE
Fixed editing first name/family name fails on the dashboard

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/controller/ScimGroupController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/controller/ScimGroupController.java
@@ -141,7 +141,9 @@ public class ScimGroupController {
       consumes = ScimConstants.SCIM_CONTENT_TYPE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
   public void updateGroup(@PathVariable final String id,
-      @RequestBody @Validated final ScimGroupPatchRequest groupPatchRequest) {
+      @RequestBody @Validated final ScimGroupPatchRequest groupPatchRequest, final BindingResult validationResult) {
+
+    handleValidationError("Invalid Scim Group", validationResult);
 
     groupProvisioningService.update(id, groupPatchRequest.getOperations());
   }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/controller/ScimUserController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/controller/ScimUserController.java
@@ -148,10 +148,12 @@ public class ScimUserController {
   @PreAuthorize("#oauth2.hasScope('scim:write') or hasRole('ADMIN')")
   @RequestMapping(value = "/{id}", method = RequestMethod.PATCH,
       consumes = ScimConstants.SCIM_CONTENT_TYPE)
-
   @ResponseStatus(HttpStatus.NO_CONTENT)
   public void updateUser(@PathVariable final String id,
-      @RequestBody final ScimUserPatchRequest patchRequest) {
+      @RequestBody @Validated(ScimUser.UpdateUserValidation.class) final ScimUserPatchRequest patchRequest,
+      final BindingResult validationResult) {
+
+    handleValidationError("Invalid Scim User", validationResult);
 
     userProvisioningService.update(id, patchRequest.getOperations());
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/converter/UserConverter.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/converter/UserConverter.java
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Service;
 
 import it.infn.mw.iam.api.scim.exception.ScimException;
 import it.infn.mw.iam.api.scim.model.ScimAddress;
-import it.infn.mw.iam.api.scim.model.ScimEmail;
 import it.infn.mw.iam.api.scim.model.ScimGroupRef;
 import it.infn.mw.iam.api.scim.model.ScimIndigoUser;
 import it.infn.mw.iam.api.scim.model.ScimMeta;
@@ -158,7 +157,7 @@ public class UserConverter implements Converter<ScimUser, IamAccount> {
       .profileUrl(entity.getUserInfo().getProfile())
       .picture(entity.getUserInfo().getPicture())
       .timezone(entity.getUserInfo().getZoneinfo())
-      .addEmail(getScimEmail(entity))
+      .buildEmail(entity.getUserInfo().getEmail())
       .indigoUserInfo(indigoUser);
 
     if (address != null) {
@@ -188,11 +187,6 @@ public class UserConverter implements Converter<ScimUser, IamAccount> {
       .familyName(entity.getUserInfo().getFamilyName())
       .middleName(entity.getUserInfo().getMiddleName())
       .build();
-  }
-
-  private ScimEmail getScimEmail(IamAccount entity) {
-
-    return ScimEmail.builder().email(entity.getUserInfo().getEmail()).build();
   }
 
   private ScimIndigoUser getScimIndigoUser(IamAccount entity) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimEmail.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimEmail.java
@@ -1,9 +1,16 @@
 package it.infn.mw.iam.api.scim.model;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
 import org.hibernate.validator.constraints.Email;
+import org.hibernate.validator.constraints.NotEmpty;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import it.infn.mw.iam.api.scim.model.ScimUser.NewUserValidation;
+import it.infn.mw.iam.api.scim.model.ScimUser.UpdateUserValidation;
 
 public class ScimEmail {
 
@@ -11,11 +18,15 @@ public class ScimEmail {
     work, home, other;
   }
 
+  @NotNull
+  @Valid
   private final ScimEmailType type;
 
-  @Email(groups = ScimUser.NewUserValidation.class)
+  @NotEmpty(groups = {NewUserValidation.class, UpdateUserValidation.class})
+  @Email(groups = {NewUserValidation.class, UpdateUserValidation.class})
   private final String value;
 
+  @NotNull(groups = {NewUserValidation.class, UpdateUserValidation.class})
   private final Boolean primary;
 
   @JsonCreator
@@ -59,13 +70,23 @@ public class ScimEmail {
     private Boolean primary;
 
     public Builder() {
-      type = ScimEmailType.work;
-      primary = true;
     }
 
     public Builder email(String value) {
 
       this.value = value;
+      return this;
+    }
+
+    public Builder type(ScimEmailType type) {
+
+      this.type = type;
+      return this;
+    }
+
+    public Builder primary(Boolean isPrimary) {
+
+      this.primary = isPrimary;
       return this;
     }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimGroup.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimGroup.java
@@ -4,6 +4,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.validation.Valid;
+
 import org.hibernate.validator.constraints.NotBlank;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -22,6 +24,7 @@ public final class ScimGroup extends ScimResource {
   @NotBlank
   private final String displayName;
 
+  @Valid
   private final Set<ScimMemberRef> members;
 
   @JsonCreator

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimGroupPatchRequest.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimGroupPatchRequest.java
@@ -5,6 +5,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import javax.validation.Valid;
+
+import org.hibernate.validator.constraints.NotEmpty;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -16,6 +20,9 @@ public class ScimGroupPatchRequest {
   public static final String PATCHOP_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:PatchOp";
 
   private final Set<String> schemas;
+
+  @NotEmpty
+  @Valid
   private final List<ScimPatchOperation<List<ScimMemberRef>>> operations;
 
   @JsonCreator

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimMemberRef.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimMemberRef.java
@@ -1,5 +1,7 @@
 package it.infn.mw.iam.api.scim.model;
 
+import org.hibernate.validator.constraints.NotEmpty;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -7,8 +9,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public final class ScimMemberRef {
 
+  @NotEmpty
   private final String value;
+
+  @NotEmpty
   private final String display;
+
+  @NotEmpty
   private final String ref;
 
   @JsonCreator

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimPatchOperation.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimPatchOperation.java
@@ -1,5 +1,6 @@
 package it.infn.mw.iam.api.scim.model;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -13,9 +14,12 @@ public class ScimPatchOperation<T> {
     add, remove, replace
   }
 
-  private final ScimPatchOperationType op;
-  private final String path;
   @NotNull
+  private final ScimPatchOperationType op;
+
+  private final String path;
+
+  @Valid
   private final T value;
 
   @JsonCreator

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimUser.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimUser.java
@@ -16,12 +16,17 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 
+import it.infn.mw.iam.api.scim.model.ScimEmail.ScimEmailType;
+
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @JsonFilter("attributeFilter")
 public class ScimUser extends ScimResource {
 
   public interface NewUserValidation {
-  }
+  };
+
+  public interface UpdateUserValidation {
+  };
 
   public static final String USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User";
   public static final String RESOURCE_TYPE = "User";
@@ -378,21 +383,13 @@ public class ScimUser extends ScimResource {
 
     public Builder buildEmail(String email) {
 
-      emails.add(ScimEmail.builder().email(email).build());
+      emails.add(ScimEmail.builder().email(email).primary(true).type(ScimEmailType.work).build());
       return this;
     }
 
     public Builder buildName(String givenName, String familyName) {
 
       this.name = ScimName.builder().givenName(givenName).familyName(familyName).build();
-      return this;
-    }
-
-    public Builder addEmail(ScimEmail scimEmail) {
-
-      Preconditions.checkNotNull(scimEmail, "Null email");
-
-      emails.add(scimEmail);
       return this;
     }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimUserPatchRequest.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimUserPatchRequest.java
@@ -5,6 +5,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import javax.validation.Valid;
+
+import org.hibernate.validator.constraints.NotEmpty;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -18,6 +22,9 @@ public class ScimUserPatchRequest {
   public static final String PATCHOP_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:PatchOp";
 
   private final Set<String> schemas;
+
+  @NotEmpty
+  @Valid
   private final List<ScimPatchOperation<ScimUser>> operations;
 
   @JsonCreator

--- a/iam-login-service/src/main/webapp/resources/iam/js/dashboard-app/controllers/edit-user.controller.js
+++ b/iam-login-service/src/main/webapp/resources/iam/js/dashboard-app/controllers/edit-user.controller.js
@@ -11,7 +11,19 @@ function EditUserController($scope, $state, $uibModalInstance, Utils,
 
 	var editUserCtrl = this;
 	
-	editUserCtrl.userToEdit = user;
+	console.info("Editing user ", user);
+
+	editUserCtrl.id = user.id;
+
+	editUserCtrl.userToEdit = {
+		name : user.name.givenName,
+		surname: user.name.familyName,
+		username : user.userName,
+		email : user.emails[0].value,
+		picture : user.picture
+	};
+
+	console.info("Copied user ", editUserCtrl.userToEdit);
 
 	editUserCtrl.submit = submit;
 	editUserCtrl.reset = reset;
@@ -25,28 +37,38 @@ function EditUserController($scope, $state, $uibModalInstance, Utils,
 
 		var scimUser = {};
 
-		scimUser.id = user.id;
-		scimUser.schemas = [];
-		scimUser.schemas[0] = "urn:ietf:params:scim:schemas:core:2.0:User";
-		scimUser.displayName = editUserCtrl.user.givenName + " "
-				+ editUserCtrl.user.familyName;
-		scimUser.name = {
-			givenName : editUserCtrl.user.givenName,
-			familyName : editUserCtrl.user.familyName,
-			middleName : ""
-		};
-		scimUser.emails = [ {
-			type : "work",
-			value : editUserCtrl.user.email,
-			primary : true
-		} ];
-		scimUser.userName = editUserCtrl.user.userName;
-		scimUser.active = true;
-		scimUser.picture = editUserCtrl.user.picture;
+		console.info($scope.userUpdateForm.name.$pristine);
+		console.info($scope.userUpdateForm.surname.$pristine);
+		console.info($scope.userUpdateForm.email.$pristine);
+		console.info($scope.userUpdateForm.username.$pristine);
+		console.info($scope.userUpdateForm.picture.$pristine);
 
-		console.info("Adding user ... ", scimUser);
+		if ($scope.userUpdateForm.name.$dirty || $scope.userUpdateForm.surname.$dirty) {
+			scimUser.displayName = editUserCtrl.user.name + " "
+					+ editUserCtrl.user.surname;
+			scimUser.name = {
+					givenName : editUserCtrl.user.name,
+					familyName : editUserCtrl.user.surname,
+					middleName : ""
+			};
+		}
+		if ($scope.userUpdateForm.email.$dirty) {
+			scimUser.emails = [ {
+				type : "work",
+				value : editUserCtrl.user.email,
+				primary : true
+			} ];
+		}
+		if ($scope.userUpdateForm.username.$dirty) {
+			scimUser.userName = editUserCtrl.user.username;
+		}
+		if ($scope.userUpdateForm.picture.$dirty) {
+			scimUser.picture = editUserCtrl.user.picture;
+		}
 
-		scimFactory.updateUser(scimUser).then(
+		console.info("Edited user ... ", scimUser);
+
+		scimFactory.updateUser(user.id, scimUser).then(
 			function(response) {
 				$uibModalInstance.close(response);
 				editUserCtrl.enabled = true;
@@ -58,14 +80,8 @@ function EditUserController($scope, $state, $uibModalInstance, Utils,
 	}
 
 	function reset() {
-		editUserCtrl.user = {
-				givenName : user.name.givenName,
-				familyName : user.name.familyName,
-				userName : user.userName,
-				email : user.emails[0].value,
-				picture : user.picture,
-				id: user.id
-			};
+		editUserCtrl.user = angular.copy(editUserCtrl.userToEdit);
+		console.info(editUserCtrl.user);
 		if ($scope.userUpdateForm) {
 			$scope.userUpdateForm.$setPristine();
 		}

--- a/iam-login-service/src/main/webapp/resources/iam/js/dashboard-app/controllers/edit-user.controller.js
+++ b/iam-login-service/src/main/webapp/resources/iam/js/dashboard-app/controllers/edit-user.controller.js
@@ -20,7 +20,7 @@ function EditUserController($scope, $state, $uibModalInstance, Utils,
 		surname: user.name.familyName,
 		username : user.userName,
 		email : user.emails[0].value,
-		picture : user.picture
+		picture : user.picture == undefined ? "" : user.picture
 	};
 
 	console.info("Copied user ", editUserCtrl.userToEdit);
@@ -28,6 +28,7 @@ function EditUserController($scope, $state, $uibModalInstance, Utils,
 	editUserCtrl.submit = submit;
 	editUserCtrl.reset = reset;
 	editUserCtrl.dismiss = dismiss;
+	editUserCtrl.isSubmitDisabled = isSubmitDisabled;
 
 	editUserCtrl.reset();
 
@@ -90,5 +91,19 @@ function EditUserController($scope, $state, $uibModalInstance, Utils,
 
 	function dismiss() {
 		$uibModalInstance.dismiss('Cancel');
+	}
+
+	function isSubmitDisabled() {
+		console.log(!editUserCtrl.enabled, !$scope.userUpdateForm.$dirty, 
+				$scope.userUpdateForm.name.$invalid, $scope.userUpdateForm.surname.$invalid, 
+				$scope.userUpdateForm.email.$invalid, $scope.userUpdateForm.username.$invalid, 
+				$scope.userUpdateForm.picture.$invalid);
+		return !editUserCtrl.enabled 
+				|| !$scope.userUpdateForm.$dirty 
+				|| $scope.userUpdateForm.name.$invalid
+				|| $scope.userUpdateForm.surname.$invalid
+				|| $scope.userUpdateForm.email.$invalid
+				|| $scope.userUpdateForm.username.$invalid
+				|| $scope.userUpdateForm.picture.$invalid;
 	}
 }

--- a/iam-login-service/src/main/webapp/resources/iam/js/dashboard-app/controllers/users.controller.js
+++ b/iam-login-service/src/main/webapp/resources/iam/js/dashboard-app/controllers/users.controller.js
@@ -61,6 +61,9 @@ function UsersController($scope, $rootScope, $uibModal, $state, $filter, filterF
 			if (user.emails[0].value.toLowerCase().indexOf(query) != -1) {
 				return true;
 			}
+			if (user.id.toLowerCase().indexOf(query) != -1) {
+				return true;
+			}
 			return false;
 		});
 		users.filtered = $filter('orderBy')(users.filtered,	"name.formatted", false);

--- a/iam-login-service/src/main/webapp/resources/iam/js/dashboard-app/services/scim-factory.service.js
+++ b/iam-login-service/src/main/webapp/resources/iam/js/dashboard-app/services/scim-factory.service.js
@@ -403,9 +403,9 @@ angular.module('dashboardApp').factory("scimFactory", [ '$http', '$httpParamSeri
 		return $http.patch(url, data, config);
 	};
 	
-	function updateUser(scimUser) {
+	function updateUser(userId, scimUser) {
 		
-		console.info("Patch user ", scimUser);
+		console.info("Patch user ", userId, scimUser);
 		
 		var config = {
 				headers: { 'Content-Type': 'application/scim+json' }
@@ -417,7 +417,7 @@ angular.module('dashboardApp').factory("scimFactory", [ '$http', '$httpParamSeri
 					value: scimUser
 				}]
 			};
-		var url = urlUsers + '/' + scimUser.id;
+		var url = urlUsers + '/' + userId;
 		
 		return $http.patch(url, data, config);
 	};

--- a/iam-login-service/src/main/webapp/resources/iam/template/dashboard/user/edituser.html
+++ b/iam-login-service/src/main/webapp/resources/iam/template/dashboard/user/edituser.html
@@ -11,7 +11,7 @@
             <label class="control-label col-sm-2" for="name">Name</label>
             <div ng-class="{'has-error': userUpdateForm.name.$dirty && userUpdateForm.name.$invalid, 'has-success': userUpdateForm.name.$dirty && userUpdateForm.name.$valid}">
                 <div class="col-sm-10">
-                    <input class="form-control" name="name" id="name" type="text" ng-model="editUserCtrl.user.givenName" placeholder="First name" required ng-minlength="3"/>
+                    <input class="form-control" name="name" id="name" type="text" ng-model="editUserCtrl.user.name" placeholder="First name" required ng-minlength="3"/>
                     <span class="glyphicon form-control-feedback" ng-class="{'glyphicon-remove': userUpdateForm.name.$dirty && userUpdateForm.name.$invalid, 'glyphicon-ok': userUpdateForm.name.$dirty && userUpdateForm.name.$valid}" style="right: 15px"></span>
                     <span class="help-block" ng-show="userUpdateForm.name.$dirty && userUpdateForm.name.$error.required">
                         This is a required field</span>
@@ -24,7 +24,7 @@
             <label class="control-label col-sm-2" for="surname">Surname</label>
             <div ng-class="{'has-error': userUpdateForm.surname.$dirty && userUpdateForm.surname.$invalid, 'has-success': userUpdateForm.surname.$dirty && userUpdateForm.surname.$valid}">
                 <div class="col-sm-10">
-                    <input class="form-control" name="surname" id="surname" type="text" ng-model="editUserCtrl.user.familyName" placeholder="Family name" required ng-minlength="3"/>
+                    <input class="form-control" name="surname" id="surname" type="text" ng-model="editUserCtrl.user.surname" placeholder="Family name" required ng-minlength="3"/>
                     <span class="glyphicon form-control-feedback" ng-class="{'glyphicon-remove': userUpdateForm.surname.$dirty && userUpdateForm.surname.$invalid, 'glyphicon-ok': userUpdateForm.surname.$dirty && userUpdateForm.surname.$valid}" style="right: 15px"></span>
                     <span class="help-block" ng-show="userUpdateForm.surname.$dirty && userUpdateForm.surname.$error.required">
                         This is a required field</span>
@@ -71,9 +71,9 @@
                         class="form-control"
                         id="username"
                         name="username"
-                        ng-disabled="$root.loggedUser.info.sub == editUserCtrl.user.id"
+                        ng-disabled="$root.loggedUser.info.sub == editUserCtrl.id"
                         type="text"
-                        ng-model="editUserCtrl.user.userName"
+                        ng-model="editUserCtrl.user.username"
                         placeholder="Username"
                         required
                         ng-minlength="3"
@@ -102,7 +102,7 @@
                 </div>
                 <div class="col-sm-12">
                     <br/>
-                    <img ng-src="editUserCtrl.user.picture" ng-show="userUpdateForm.picture.$dirty && userUpdateForm.picture.$valid" class="profile-user-img img-responsive img-circle"/>
+                    <img ng-src="{{editUserCtrl.user.picture}}" ng-show="userUpdateForm.picture.$dirty && userUpdateForm.picture.$valid" class="profile-user-img img-responsive img-circle"/>
                 </div>
             </div>
         </div>

--- a/iam-login-service/src/main/webapp/resources/iam/template/dashboard/user/edituser.html
+++ b/iam-login-service/src/main/webapp/resources/iam/template/dashboard/user/edituser.html
@@ -1,4 +1,4 @@
-<form class="form-horizontal" ng-submit="editUserCtrl.submit()" name="userUpdateForm" id="userUpdateForm">
+<form class="form-horizontal" ng-submit="editUserCtrl.submit()" name="userUpdateForm">
 
     <div class="modal-header">
         <h3 class="modal-title">User update form</h3>
@@ -42,8 +42,7 @@
                         ng-model="editUserCtrl.user.email"
                         placeholder="Email"
                         required ng-minlength="3"
-                        iam-email-available-validator
-                        ng-model-options="{ debounce : { 'default' : 500 } }"/>
+                        iam-email-available-validator />
 
                     <span class="glyphicon form-control-feedback"
                       ng-class="{'glyphicon-remove': userUpdateForm.email.$dirty && userUpdateForm.email.$invalid, 'glyphicon-ok': userUpdateForm.email.$dirty && userUpdateForm.email.$valid}" style="right: 15px"></span>
@@ -110,7 +109,7 @@
     </div>
 
     <div class="modal-footer">
-        <button class="btn btn-primary btn-sm" type="submit" name="create" id="modal-btn-confirm" ng-disabled="userUpdateForm.$invalid || !userUpdateForm.$dirty || !editUserCtrl.enabled">Update</button>
+        <button class="btn btn-primary btn-sm" type="submit" name="create" id="modal-btn-confirm" ng-disabled="editUserCtrl.isSubmitDisabled()">Update</button>
         <button class="btn btn-warning btn-sm" type="button" name="reset" id="modal-btn-reset" ng-click="editUserCtrl.reset()" ng-disabled="userUpdateForm.$pristine">Reset Form</button>
         <button class="btn btn-danger btn-sm" type="button" name="dismiss" id="modal-btn-cancel" ng-click="editUserCtrl.dismiss()">Cancel</button>
     </div>

--- a/iam-login-service/src/main/webapp/resources/iam/template/dashboard/user/user.html
+++ b/iam-login-service/src/main/webapp/resources/iam/template/dashboard/user/user.html
@@ -68,7 +68,7 @@
 				</div>
 				<!-- /.box-body -->
 				<div class="box-footer">
-					<button class="btn btn-primary btn-block"
+					<button class="btn btn-primary btn-block" name="edit-user-info"
 						ng-click="user.openEditUserDialog()">
 						<strong>Edit</strong>
 					</button>

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/user/ScimUserProvisioningPatchReplaceTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/user/ScimUserProvisioningPatchReplaceTests.java
@@ -1,5 +1,7 @@
 package it.infn.mw.iam.test.scim.user;
 
+import static org.hamcrest.Matchers.containsString;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -270,5 +272,53 @@ public class ScimUserProvisioningPatchReplaceTests {
         ScimUser.builder().buildSshKey("fake_label", "fake_key", "fake_fingerprint", true).build());
 
     restUtils.doPatch(user.getMeta().getLocation(), req, HttpStatus.NOT_FOUND);
+  }
+
+
+  @Test
+  public void testReplaceEmailWithEmptyValue() {
+
+    ScimUser user = testUsers.get(0);
+
+    ScimUserPatchRequest req = getPatchReplaceRequest(
+        ScimUser.builder().buildEmail("").build());
+
+    restUtils.doPatch(user.getMeta().getLocation(), req, HttpStatus.BAD_REQUEST).body("detail",
+        containsString("scimUserPatchRequest.operations[0].value.emails[0].value : may not be empty"));
+  }
+
+  @Test
+  public void testReplaceEmailWithNullValue() {
+
+    ScimUser user = testUsers.get(0);
+
+    ScimUserPatchRequest req = getPatchReplaceRequest(
+        ScimUser.builder().buildEmail(null).build());
+
+    restUtils.doPatch(user.getMeta().getLocation(), req, HttpStatus.BAD_REQUEST).body("detail",
+        containsString("scimUserPatchRequest.operations[0].value.emails[0].value : may not be empty"));
+  }
+
+  @Test
+  public void testReplaceEmailWithSameValue() {
+
+    ScimUser user = testUsers.get(0);
+
+    ScimUserPatchRequest req = getPatchReplaceRequest(
+        ScimUser.builder().buildEmail(user.getEmails().get(0).getValue()).build());
+
+    restUtils.doPatch(user.getMeta().getLocation(), req, HttpStatus.NO_CONTENT);
+  }
+
+  @Test
+  public void testReplaceEmailWithInvalidValue() {
+
+    ScimUser user = testUsers.get(0);
+
+    ScimUserPatchRequest req = getPatchReplaceRequest(
+        ScimUser.builder().buildEmail("fakeEmail").build());
+
+    restUtils.doPatch(user.getMeta().getLocation(), req, HttpStatus.BAD_REQUEST).body("detail",
+        containsString("scimUserPatchRequest.operations[0].value.emails[0].value : not a well-formed email address"));;
   }
 }


### PR DESCRIPTION
Before:
- The dashboard invokes an SCIM patch operation, but sends an empty password, and this makes the database update fail.

Now:
- A patch with an empty email triggers a validation error before reaching the database
- The dashboard sends correctly the SCIM patch requests, with only the fields that are actually changed

In addiction:
- Added more validation at backend side (groups patch e.g.)
- Added tests
