### PR TITLE
Support audience enforcement on access tokens

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/oidc/OidcTokenEnhancer.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/oidc/OidcTokenEnhancer.java
@@ -30,19 +30,21 @@ public class OidcTokenEnhancer extends ConnectTokenEnhancer {
 
   @Autowired
   private OIDCTokenService connectTokenService;
-
-  private SignedJWT signClaims(JWTClaimsSet claims){
+  
+  private static final String AUD_KEY = "aud";
+  
+  private SignedJWT signClaims(JWTClaimsSet claims) {
     JWSAlgorithm signingAlg = getJwtService().getDefaultSigningAlgorithm();
-    
+
     JWSHeader header = new JWSHeader(signingAlg, null, null, null, null, null, null, null, null,
         null, getJwtService().getDefaultSignerKeyId(), null, null);
     SignedJWT signedJWT = new SignedJWT(header, claims);
 
     getJwtService().signJwt(signedJWT);
     return signedJWT;
-    
+
   }
-  
+
   protected OAuth2AccessTokenEntity buildAccessToken(OAuth2AccessToken accessToken,
       OAuth2Authentication authentication, UserInfo userInfo, Date issueTime) {
 
@@ -66,7 +68,7 @@ public class OidcTokenEnhancer extends ConnectTokenEnhancer {
           .jwtID(UUID.randomUUID().toString());
     // @formatter:on
 
-    String audience = (String) authentication.getOAuth2Request().getExtensions().get("aud");
+    String audience = (String) authentication.getOAuth2Request().getExtensions().get(AUD_KEY);
 
     if (!Strings.isNullOrEmpty(audience)) {
       builder.audience(Lists.newArrayList(audience));
@@ -74,7 +76,7 @@ public class OidcTokenEnhancer extends ConnectTokenEnhancer {
 
     JWTClaimsSet claims = builder.build();
     token.setJwt(signClaims(claims));
-    
+
     return token;
 
   }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/MitreServicesConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/MitreServicesConfig.java
@@ -14,7 +14,6 @@ import org.mitre.oauth2.service.impl.DefaultSystemScopeService;
 import org.mitre.oauth2.token.StructuredScopeAwareOAuth2RequestValidator;
 import org.mitre.oauth2.web.CorsFilter;
 import org.mitre.openid.connect.filter.AuthorizationRequestFilter;
-import org.mitre.openid.connect.request.ConnectOAuth2RequestFactory;
 import org.mitre.openid.connect.service.ApprovedSiteService;
 import org.mitre.openid.connect.service.BlacklistedSiteService;
 import org.mitre.openid.connect.service.ClientLogoLoadingService;
@@ -56,6 +55,8 @@ import org.springframework.security.oauth2.provider.token.TokenEnhancer;
 import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
 import org.springframework.web.servlet.AsyncHandlerInterceptor;
 
+import it.infn.mw.iam.core.IamOAuth2RequestFactory;
+
 @Configuration
 public class MitreServicesConfig {
 
@@ -79,8 +80,8 @@ public class MitreServicesConfig {
 
   @Bean
   OAuth2RequestFactory requestFactory() {
-
-    return new ConnectOAuth2RequestFactory(clientDetailsService());
+    
+    return new IamOAuth2RequestFactory(clientDetailsService());
   }
 
   @Bean

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/IamOAuth2RequestFactory.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/IamOAuth2RequestFactory.java
@@ -1,0 +1,44 @@
+package it.infn.mw.iam.core;
+
+import org.mitre.oauth2.service.ClientDetailsEntityService;
+import org.mitre.openid.connect.request.ConnectOAuth2RequestFactory;
+import org.springframework.security.oauth2.provider.ClientDetails;
+import org.springframework.security.oauth2.provider.OAuth2Request;
+import org.springframework.security.oauth2.provider.TokenRequest;
+
+public class IamOAuth2RequestFactory extends ConnectOAuth2RequestFactory {
+
+  public static final String[] AUDIENCE_KEYS = {"aud", "audience"};
+  public static final String AUD = "aud";
+
+
+  public IamOAuth2RequestFactory(ClientDetailsEntityService clientDetailsService) {
+    super(clientDetailsService);
+  }
+
+  /**
+   * This implementation extends what's already done by MitreID implementation with audience request
+   * parameter handling (both "aud" and "audience" are accepted).
+   *
+   *    
+   */
+  @Override
+  public OAuth2Request createOAuth2Request(ClientDetails client, TokenRequest tokenRequest) {
+
+    OAuth2Request request = super.createOAuth2Request(client, tokenRequest);
+
+    for (String audienceKey : AUDIENCE_KEYS) {
+      if (tokenRequest.getRequestParameters().containsKey(audienceKey)) {
+
+        if (!request.getExtensions().containsKey(AUD)) {
+          request.getExtensions().put(AUD, tokenRequest.getRequestParameters().get(audienceKey));
+        }
+
+        break;
+      }
+    }
+
+    return request;
+  }
+
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/AudienceTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/AudienceTests.java
@@ -1,0 +1,69 @@
+package it.infn.mw.iam.test.oauth;
+
+import static it.infn.mw.iam.test.TestUtils.passwordTokenGetter;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import java.text.ParseException;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.JWTParser;
+
+import it.infn.mw.iam.IamLoginService;
+import it.infn.mw.iam.test.TestUtils;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = IamLoginService.class)
+@WebIntegrationTest
+public class AudienceTests {
+
+  public static final String TEST_USERNAME = "test";
+  public static final String TEST_PASSWORD = "password";
+
+
+  @Value("${server.port}")
+  private Integer iamPort;
+
+  @Test
+  public void testAudienceRequestPasswordFlow() throws ParseException {
+
+    String accessToken = passwordTokenGetter().username(TEST_USERNAME)
+      .password(TEST_PASSWORD)
+      .audience("example-audience")
+      .getAccessToken();
+
+    JWT token = JWTParser.parse(accessToken);
+
+    JWTClaimsSet claims = token.getJWTClaimsSet();
+
+    assertNotNull(claims.getAudience());
+    assertThat(claims.getAudience().size(), equalTo(1));
+    assertThat(claims.getAudience(), contains("example-audience"));
+  }
+
+  @Test
+  public void testAudienceRequestClientCredentialsFlow() throws ParseException {
+
+    String accessToken =
+        TestUtils.clientCredentialsTokenGetter().audience("example-audience").getAccessToken();
+
+    JWT token = JWTParser.parse(accessToken);
+
+    JWTClaimsSet claims = token.getJWTClaimsSet();
+
+    assertNotNull(claims.getAudience());
+    assertThat(claims.getAudience().size(), equalTo(1));
+    assertThat(claims.getAudience(), contains("example-audience"));
+  }
+
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/OpenIDConnectAudienceTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/OpenIDConnectAudienceTests.java
@@ -1,0 +1,152 @@
+package it.infn.mw.iam.test.oauth;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.springframework.security.core.authority.AuthorityUtils.commaSeparatedStringToAuthorityList;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.forwardedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.net.URI;
+
+import javax.transaction.Transactional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.JWTParser;
+
+import it.infn.mw.iam.IamLoginService;
+import it.infn.mw.iam.test.util.oidc.TokenResponse;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = IamLoginService.class)
+@WebAppConfiguration
+@Transactional
+public class OpenIDConnectAudienceTests {
+
+  public static final String TEST_CLIENT_ID = "client";
+  public static final String TEST_CLIENT_SECRET = "secret";
+  public static final String TEST_CLIENT_REDIRECT_URI =
+      "https://iam.local.io/iam-test-client/openid_connect_login";
+
+  public static final String LOGIN_URL = "http://localhost/login";
+  public static final String AUTHORIZE_URL = "http://localhost/authorize";
+
+  public static final String RESPONSE_TYPE_CODE = "code";
+  public static final String AUTHORIZATION_ENDPOINT = "/authorize";
+  public static final String SCOPE = "openid profile";
+
+  public static final String TEST_USER_ID = "test";
+  public static final String TEST_USER_PASSWORD = "password";
+
+  @Autowired
+  WebApplicationContext context;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  MockMvc mvc;
+
+  @Before
+  public void setup() {
+    mvc = MockMvcBuilders.webAppContextSetup(context)
+      .apply(springSecurity())
+      .alwaysDo(print())
+      .build();
+  }
+
+
+  @Test
+  public void testOidcAuthorizationRequestWithAudience() throws Exception {
+
+    User testUser = new User(TEST_USER_ID, TEST_USER_PASSWORD,
+        commaSeparatedStringToAuthorityList("ROLE_USER"));
+
+    MockHttpSession session = (MockHttpSession) mvc
+      .perform(get(AUTHORIZATION_ENDPOINT).param("response_type", RESPONSE_TYPE_CODE)
+        .param("client_id", TEST_CLIENT_ID)
+        .param("redirect_uri", TEST_CLIENT_REDIRECT_URI)
+        .param("scope", SCOPE)
+        .param("nonce", "1")
+        .param("state", "1")
+        .param("aud", "example-audience")
+        .with(SecurityMockMvcRequestPostProcessors.user(testUser)))
+      .andExpect(status().isOk())
+      .andExpect(forwardedUrl("/oauth/confirm_access"))
+      .andReturn()
+      .getRequest()
+      .getSession();
+
+    MvcResult result = mvc
+      .perform(post("/authorize").session(session)
+        .param("user_oauth_approval", "true")
+        .param("scope_openid", "openid")
+        .param("scope_profile", "profile")
+        .param("authorize", "Authorize")
+        .param("remember", "none")
+        .with(csrf()))
+      .andExpect(status().is3xxRedirection())
+      .andReturn();
+
+    String redirectUrl = result.getResponse().getRedirectedUrl();
+    session = (MockHttpSession) result.getRequest().getSession();
+
+    assertThat(redirectUrl, startsWith(TEST_CLIENT_REDIRECT_URI));
+    UriComponents redirectUri = UriComponentsBuilder.fromUri(new URI(redirectUrl)).build();
+    String code = redirectUri.getQueryParams().getFirst("code");
+
+    String tokenResponse = mvc
+      .perform(post("/token").param("grant_type", "authorization_code")
+        .param("code", code)
+        .param("redirect_uri", TEST_CLIENT_REDIRECT_URI)
+        .with(SecurityMockMvcRequestPostProcessors.httpBasic(TEST_CLIENT_ID, TEST_CLIENT_SECRET)))
+      .andExpect(status().isOk())
+      .andReturn()
+      .getResponse()
+      .getContentAsString();
+
+    TokenResponse response = objectMapper.readValue(tokenResponse, TokenResponse.class);
+
+    response.getAccessToken();
+
+    JWT token = JWTParser.parse(response.getAccessToken());
+    JWTClaimsSet claims = token.getJWTClaimsSet();
+
+    assertNotNull(claims.getAudience());
+    assertThat(claims.getAudience().size(), equalTo(1));
+    assertThat(claims.getAudience(), contains("example-audience"));
+
+    JWT idToken = JWTParser.parse(response.getIdToken());
+
+    JWTClaimsSet idTokenClaims = idToken.getJWTClaimsSet();
+    assertNotNull(idTokenClaims.getAudience());
+    assertThat(idTokenClaims.getAudience().size(), equalTo(1));
+    assertThat(idTokenClaims.getAudience(), contains(TEST_CLIENT_ID));
+
+  }
+}


### PR DESCRIPTION
This commit introduces support for setting the audience as requested by
a client for the OAuth password and client-credentials grant types
(audience enforcement was already supported for the token exchange grant
type).

Fixes #92.