### PR TITLE
Leverage the database to lookup valid user tokens

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/IamTokenService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/IamTokenService.java
@@ -44,4 +44,15 @@ public class IamTokenService extends DefaultOAuth2ProviderTokenService {
     results.addAll(refreshTokenRepo.findValidRefreshTokensForUser(id));
     return results;
   }
+
+  @Override
+  public void revokeAccessToken(OAuth2AccessTokenEntity accessToken) {
+    accessTokenRepo.delete(accessToken);
+  }
+
+  @Override
+  public void revokeRefreshToken(OAuth2RefreshTokenEntity refreshToken) {
+    refreshTokenRepo.delete(refreshToken);
+  }
+
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/IamTokenService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/IamTokenService.java
@@ -32,7 +32,7 @@ public class IamTokenService extends DefaultOAuth2ProviderTokenService {
   @Override
   public Set<OAuth2AccessTokenEntity> getAllAccessTokensForUser(String id) {
 
-    Set<OAuth2AccessTokenEntity> results = Sets.newHashSet();
+    Set<OAuth2AccessTokenEntity> results = Sets.newLinkedHashSet();
     results.addAll(accessTokenRepo.findValidAccessTokensForUser(id));
     return results;
   }
@@ -40,7 +40,7 @@ public class IamTokenService extends DefaultOAuth2ProviderTokenService {
 
   @Override
   public Set<OAuth2RefreshTokenEntity> getAllRefreshTokensForUser(String id) {
-    Set<OAuth2RefreshTokenEntity> results = Sets.newHashSet();
+    Set<OAuth2RefreshTokenEntity> results = Sets.newLinkedHashSet();
     results.addAll(refreshTokenRepo.findValidRefreshTokensForUser(id));
     return results;
   }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/IamTokenService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/IamTokenService.java
@@ -1,0 +1,47 @@
+package it.infn.mw.iam.core;
+
+import java.util.Set;
+
+import org.mitre.oauth2.model.OAuth2AccessTokenEntity;
+import org.mitre.oauth2.model.OAuth2RefreshTokenEntity;
+import org.mitre.oauth2.service.impl.DefaultOAuth2ProviderTokenService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+import com.google.common.collect.Sets;
+
+import it.infn.mw.iam.persistence.repository.IamOAuthAccessTokenRepository;
+import it.infn.mw.iam.persistence.repository.IamOAuthRefreshTokenRepository;
+
+@Service("defaultOAuth2ProviderTokenService")
+@Primary
+public class IamTokenService extends DefaultOAuth2ProviderTokenService {
+
+  private final IamOAuthAccessTokenRepository accessTokenRepo;
+  private final IamOAuthRefreshTokenRepository refreshTokenRepo;
+
+  @Autowired
+  public IamTokenService(IamOAuthAccessTokenRepository atRepo,
+      IamOAuthRefreshTokenRepository rtRepo) {
+    this.accessTokenRepo = atRepo;
+    this.refreshTokenRepo = rtRepo;
+  }
+
+
+  @Override
+  public Set<OAuth2AccessTokenEntity> getAllAccessTokensForUser(String id) {
+
+    Set<OAuth2AccessTokenEntity> results = Sets.newHashSet();
+    results.addAll(accessTokenRepo.findValidAccessTokensForUser(id));
+    return results;
+  }
+
+
+  @Override
+  public Set<OAuth2RefreshTokenEntity> getAllRefreshTokensForUser(String id) {
+    Set<OAuth2RefreshTokenEntity> results = Sets.newHashSet();
+    results.addAll(refreshTokenRepo.findValidRefreshTokensForUser(id));
+    return results;
+  }
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/repository/IamTokenRepositoryTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/repository/IamTokenRepositoryTests.java
@@ -1,0 +1,131 @@
+package it.infn.mw.iam.test.repository;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.iterableWithSize;
+import static org.junit.Assert.assertThat;
+
+import java.util.Date;
+
+import javax.persistence.EntityManager;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mitre.oauth2.model.ClientDetailsEntity;
+import org.mitre.oauth2.model.OAuth2AccessTokenEntity;
+import org.mitre.oauth2.service.ClientDetailsEntityService;
+import org.mitre.oauth2.service.impl.DefaultOAuth2ProviderTokenService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import it.infn.mw.iam.IamLoginService;
+import it.infn.mw.iam.persistence.repository.IamOAuthAccessTokenRepository;
+import it.infn.mw.iam.persistence.repository.IamOAuthRefreshTokenRepository;
+import it.infn.mw.iam.test.util.oauth.MockOAuth2Request;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = {IamLoginService.class})
+@WebIntegrationTest
+@Transactional
+public class IamTokenRepositoryTests {
+
+  public static final String TEST_USER = "test";
+  public static final String ADMIN_USER = "admin";
+  public static final String ISSUER = "issuer";
+  public static final String TEST_CLIEND_ID = "client";
+
+  public static final String[] SCOPES = {"openid", "profile", "offline_access"};
+
+  @Autowired
+  IamOAuthAccessTokenRepository accessTokenRepo;
+
+  @Autowired
+  IamOAuthRefreshTokenRepository refreshTokenRepo;
+
+  @Autowired
+  ClientDetailsEntityService clientDetailsService;
+
+  @Autowired
+  DefaultOAuth2ProviderTokenService tokenService;
+
+  @Autowired
+  EntityManager em;
+
+  private OAuth2Authentication oauth2Authentication(ClientDetailsEntity client, String username) {
+
+    String[] scopes = {};
+    Authentication userAuth = null;
+
+    if (username != null) {
+      scopes = SCOPES;
+      userAuth = new UsernamePasswordAuthenticationToken(username, "");
+    }
+
+    MockOAuth2Request req = new MockOAuth2Request(client.getClientId(), scopes);
+    OAuth2Authentication auth = new OAuth2Authentication(req, userAuth);
+
+    return auth;
+  }
+
+  private ClientDetailsEntity loadTestClient() {
+    return clientDetailsService.loadClientByClientId(TEST_CLIEND_ID);
+  }
+
+  private OAuth2AccessTokenEntity buildAccessToken(ClientDetailsEntity client, String username) {
+    OAuth2AccessTokenEntity token =
+        tokenService.createAccessToken(oauth2Authentication(client, username));
+    return token;
+  }
+
+  private OAuth2AccessTokenEntity buildAccessToken(ClientDetailsEntity client) {
+    return buildAccessToken(client, null);
+  }
+
+  @Test
+  public void testTokenResolutionCorrectlyEnforcesUsernameChecks() {
+
+    buildAccessToken(loadTestClient(), TEST_USER);
+
+    assertThat(accessTokenRepo.findValidAccessTokensForUser(ADMIN_USER), hasSize(0));
+    assertThat(refreshTokenRepo.findValidRefreshTokensForUser(ADMIN_USER), hasSize(0));
+
+    assertThat(accessTokenRepo.findValidAccessTokensForUser(TEST_USER), hasSize(2)); // access token
+                                                                                     // + ID token
+
+    assertThat(refreshTokenRepo.findValidRefreshTokensForUser(TEST_USER), hasSize(1));
+  }
+
+  @Test
+  public void testExpiredTokensAreNotReturned() {
+
+    OAuth2AccessTokenEntity at = buildAccessToken(loadTestClient(), TEST_USER);
+
+    Date now = new Date();
+    at.setExpiration(now);
+    at.getIdToken().setExpiration(now);
+    at.getRefreshToken().setExpiration(now);
+
+    tokenService.saveAccessToken(at);
+    tokenService.saveAccessToken(at.getIdToken());
+    tokenService.saveRefreshToken(at.getRefreshToken());
+
+    assertThat(accessTokenRepo.findValidAccessTokensForUser(TEST_USER), hasSize(0));
+    assertThat(refreshTokenRepo.findValidRefreshTokensForUser(TEST_USER), hasSize(0));
+  }
+
+  @Test
+  public void testClientTokensNotBoundToUsersAreIgnored() {
+    buildAccessToken(loadTestClient());
+
+    assertThat(accessTokenRepo.findAll(), iterableWithSize(1));
+    assertThat(refreshTokenRepo.findAll(), iterableWithSize(0));
+    assertThat(accessTokenRepo.findValidAccessTokensForUser(TEST_USER), hasSize(0));
+    assertThat(refreshTokenRepo.findValidRefreshTokensForUser(TEST_USER), hasSize(0));
+  }
+
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/repository/IamTokenRepositoryTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/repository/IamTokenRepositoryTests.java
@@ -1,7 +1,6 @@
 package it.infn.mw.iam.test.repository;
 
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.iterableWithSize;
 import static org.junit.Assert.assertThat;
 
 import java.util.Date;
@@ -34,10 +33,11 @@ import it.infn.mw.iam.test.util.oauth.MockOAuth2Request;
 @Transactional
 public class IamTokenRepositoryTests {
 
-  public static final String TEST_USER = "test";
-  public static final String ADMIN_USER = "admin";
+  public static final String TEST_347_USER = "test_347";
+  public static final String TEST_346_USER = "test_346";
+  
   public static final String ISSUER = "issuer";
-  public static final String TEST_CLIEND_ID = "client";
+  public static final String TEST_CLIEND_ID = "token-lookup-client";
 
   public static final String[] SCOPES = {"openid", "profile", "offline_access"};
 
@@ -89,21 +89,21 @@ public class IamTokenRepositoryTests {
   @Test
   public void testTokenResolutionCorrectlyEnforcesUsernameChecks() {
 
-    buildAccessToken(loadTestClient(), TEST_USER);
+    buildAccessToken(loadTestClient(), TEST_347_USER);
 
-    assertThat(accessTokenRepo.findValidAccessTokensForUser(ADMIN_USER), hasSize(0));
-    assertThat(refreshTokenRepo.findValidRefreshTokensForUser(ADMIN_USER), hasSize(0));
+    assertThat(accessTokenRepo.findValidAccessTokensForUser(TEST_346_USER), hasSize(0));
+    assertThat(refreshTokenRepo.findValidRefreshTokensForUser(TEST_346_USER), hasSize(0));
 
-    assertThat(accessTokenRepo.findValidAccessTokensForUser(TEST_USER), hasSize(2)); // access token
+    assertThat(accessTokenRepo.findValidAccessTokensForUser(TEST_347_USER), hasSize(2)); // access token
                                                                                      // + ID token
 
-    assertThat(refreshTokenRepo.findValidRefreshTokensForUser(TEST_USER), hasSize(1));
+    assertThat(refreshTokenRepo.findValidRefreshTokensForUser(TEST_347_USER), hasSize(1));
   }
 
   @Test
   public void testExpiredTokensAreNotReturned() {
 
-    OAuth2AccessTokenEntity at = buildAccessToken(loadTestClient(), TEST_USER);
+    OAuth2AccessTokenEntity at = buildAccessToken(loadTestClient(), TEST_347_USER);
 
     Date now = new Date();
     at.setExpiration(now);
@@ -114,18 +114,16 @@ public class IamTokenRepositoryTests {
     tokenService.saveAccessToken(at.getIdToken());
     tokenService.saveRefreshToken(at.getRefreshToken());
 
-    assertThat(accessTokenRepo.findValidAccessTokensForUser(TEST_USER), hasSize(0));
-    assertThat(refreshTokenRepo.findValidRefreshTokensForUser(TEST_USER), hasSize(0));
+    assertThat(accessTokenRepo.findValidAccessTokensForUser(TEST_347_USER), hasSize(0));
+    assertThat(refreshTokenRepo.findValidRefreshTokensForUser(TEST_347_USER), hasSize(0));
   }
 
   @Test
   public void testClientTokensNotBoundToUsersAreIgnored() {
     buildAccessToken(loadTestClient());
 
-    assertThat(accessTokenRepo.findAll(), iterableWithSize(1));
-    assertThat(refreshTokenRepo.findAll(), iterableWithSize(0));
-    assertThat(accessTokenRepo.findValidAccessTokensForUser(TEST_USER), hasSize(0));
-    assertThat(refreshTokenRepo.findValidRefreshTokensForUser(TEST_USER), hasSize(0));
+    assertThat(accessTokenRepo.findValidAccessTokensForUser(TEST_347_USER), hasSize(0));
+    assertThat(refreshTokenRepo.findValidRefreshTokensForUser(TEST_347_USER), hasSize(0));
   }
 
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/repository/IamTokenRepositoryTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/repository/IamTokenRepositoryTests.java
@@ -16,7 +16,6 @@ import org.mitre.oauth2.service.ClientDetailsEntityService;
 import org.mitre.oauth2.service.impl.DefaultOAuth2ProviderTokenService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.SpringApplicationConfiguration;
-import org.springframework.boot.test.WebIntegrationTest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
@@ -30,7 +29,6 @@ import it.infn.mw.iam.test.util.oauth.MockOAuth2Request;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = {IamLoginService.class})
-@WebIntegrationTest
 @Transactional
 public class IamTokenRepositoryTests {
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/repository/IamTokenRepositoryTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/repository/IamTokenRepositoryTests.java
@@ -3,6 +3,7 @@ package it.infn.mw.iam.test.repository;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
 
+import java.util.Calendar;
 import java.util.Date;
 
 import javax.persistence.EntityManager;
@@ -35,7 +36,7 @@ public class IamTokenRepositoryTests {
 
   public static final String TEST_347_USER = "test_347";
   public static final String TEST_346_USER = "test_346";
-  
+
   public static final String ISSUER = "issuer";
   public static final String TEST_CLIEND_ID = "token-lookup-client";
 
@@ -94,8 +95,9 @@ public class IamTokenRepositoryTests {
     assertThat(accessTokenRepo.findValidAccessTokensForUser(TEST_346_USER), hasSize(0));
     assertThat(refreshTokenRepo.findValidRefreshTokensForUser(TEST_346_USER), hasSize(0));
 
-    assertThat(accessTokenRepo.findValidAccessTokensForUser(TEST_347_USER), hasSize(2)); // access token
-                                                                                     // + ID token
+    assertThat(accessTokenRepo.findValidAccessTokensForUser(TEST_347_USER), hasSize(2)); // access
+                                                                                         // token
+    // + ID token
 
     assertThat(refreshTokenRepo.findValidRefreshTokensForUser(TEST_347_USER), hasSize(1));
   }
@@ -105,10 +107,15 @@ public class IamTokenRepositoryTests {
 
     OAuth2AccessTokenEntity at = buildAccessToken(loadTestClient(), TEST_347_USER);
 
-    Date now = new Date();
-    at.setExpiration(now);
-    at.getIdToken().setExpiration(now);
-    at.getRefreshToken().setExpiration(now);
+    Calendar cal = Calendar.getInstance();
+
+    cal.add(Calendar.DAY_OF_YEAR, -1);
+
+    Date yesterday = cal.getTime();
+
+    at.setExpiration(yesterday);
+    at.getIdToken().setExpiration(yesterday);
+    at.getRefreshToken().setExpiration(yesterday);
 
     tokenService.saveAccessToken(at);
     tokenService.saveAccessToken(at.getIdToken());

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/util/oauth/MockOAuth2Request.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/util/oauth/MockOAuth2Request.java
@@ -7,7 +7,7 @@ import org.springframework.security.oauth2.provider.OAuth2Request;
 
 import com.google.common.collect.Sets;
 
-class MockOAuth2Request extends OAuth2Request {
+public class MockOAuth2Request extends OAuth2Request {
 
   private static final long serialVersionUID = -8547059375050883345L;
 

--- a/iam-persistence/src/main/java/it/infn/mw/iam/persistence/repository/IamOAuthAccessTokenRepository.java
+++ b/iam-persistence/src/main/java/it/infn/mw/iam/persistence/repository/IamOAuthAccessTokenRepository.java
@@ -1,0 +1,16 @@
+package it.infn.mw.iam.persistence.repository;
+
+import java.util.List;
+
+import org.mitre.oauth2.model.OAuth2AccessTokenEntity;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.repository.query.Param;
+
+public interface IamOAuthAccessTokenRepository
+    extends PagingAndSortingRepository<OAuth2AccessTokenEntity, Long> {
+
+  @Query("select t from OAuth2AccessTokenEntity t where t.authenticationHolder.userAuth.name = :userId "
+      + "and (t.expiration is NULL or t.expiration > CURRENT_TIMESTAMP)")
+  List<OAuth2AccessTokenEntity> findValidAccessTokensForUser(@Param("userId") String userId);
+}

--- a/iam-persistence/src/main/java/it/infn/mw/iam/persistence/repository/IamOAuthRefreshTokenRepository.java
+++ b/iam-persistence/src/main/java/it/infn/mw/iam/persistence/repository/IamOAuthRefreshTokenRepository.java
@@ -1,0 +1,15 @@
+package it.infn.mw.iam.persistence.repository;
+
+import java.util.List;
+
+import org.mitre.oauth2.model.OAuth2RefreshTokenEntity;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.repository.query.Param;
+
+public interface IamOAuthRefreshTokenRepository
+    extends PagingAndSortingRepository<OAuth2RefreshTokenEntity, Long> {
+  @Query("select t from OAuth2RefreshTokenEntity t where t.authenticationHolder.userAuth.name = :userId "
+      + "and (t.expiration is NULL or t.expiration > CURRENT_TIMESTAMP)")
+  List<OAuth2RefreshTokenEntity> findValidRefreshTokensForUser(@Param("userId") String userId);
+}

--- a/iam-persistence/src/main/resources/db/migration/test/V100000___test_data.sql
+++ b/iam-persistence/src/main/resources/db/migration/test/V100000___test_data.sql
@@ -8,7 +8,8 @@ INSERT INTO client_details (id, client_id, client_secret, client_name, dynamical
   (7, 'scim-client-rw', 'secret', 'SCIM client (read-write)', false, null, 3600, 600, true, 'SECRET_POST'),
   (8, 'token-exchange-actor', 'secret', 'Token Exchange grant client actor', false, null, 3600, 600, true, 'SECRET_POST'),
   (9, 'token-exchange-subject', 'secret', 'Token Exchange grant client subject', false, null, 3600, 600, true, 'SECRET_POST'),
-  (10, 'registration-client', 'secret', 'Registration service test client', false, null, 3600, 600, true, 'SECRET_POST');
+  (10, 'registration-client', 'secret', 'Registration service test client', false, null, 3600, 600, true, 'SECRET_POST'),
+  (11, 'token-lookup-client', 'secret', 'Token lookup client', false, null, 3600, 600, true, 'SECRET_BASIC');
 
 INSERT INTO client_scope (owner_id, scope) VALUES
   (1, 'openid'),
@@ -70,14 +71,23 @@ INSERT INTO client_scope (owner_id, scope) VALUES
   (10, 'registration:read'),
   (10, 'registration:write'),
   (10, 'scim:write'),
-  (10, 'scim:read');
+  (10, 'scim:read'),
+  (11, 'openid'),
+  (11, 'profile'),
+  (11, 'email'),
+  (11, 'address'),
+  (11, 'phone'),
+  (11, 'offline_access'),
+  (11, 'read-tasks'),
+  (11, 'write-tasks');
   
   
 INSERT INTO client_redirect_uri (owner_id, redirect_uri) VALUES
   (1, 'http://localhost:9090/iam-test-client/openid_connect_login'),
   (1, 'https://iam.local.io/iam-test-client/openid_connect_login'),
   (3, 'http://localhost:4000/callback'),
-  (4, 'http://localhost:5000/callback');
+  (4, 'http://localhost:5000/callback'),
+  (11, 'http://localhost:1234/callback');
 
 INSERT INTO client_grant_type (owner_id, grant_type) VALUES
   (1, 'authorization_code'),
@@ -97,7 +107,10 @@ INSERT INTO client_grant_type (owner_id, grant_type) VALUES
   (9, 'password'),
   (9, 'refresh_token'),
   (10, 'client_credentials'),
-  (10, 'refresh_token');
+  (10, 'refresh_token'),
+  (11, 'authorization_code'),
+  (11, 'refresh_token'),
+  (11, 'client_credentials');
     
 INSERT INTO iam_user_info(ID,GIVENNAME,FAMILYNAME, EMAIL, EMAILVERIFIED, BIRTHDATE, GENDER) VALUES
 (2, 'Test', 'User', 'test@iam.test', true, '1950-01-01','M');


### PR DESCRIPTION
MitreID implementation for the "find all valid access/refresh token for
user" queries loads all issued tokens in memory and then filters by user
id.

This can hardly scale, so we replace the mitre implementation with our
own to let the database do the heavy lifting.

Fixes #94