### PR TITLE
Configurable token and approval cleanup period

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/TaskConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/TaskConfig.java
@@ -20,6 +20,12 @@ import it.infn.mw.iam.notification.NotificationService;
 @EnableScheduling
 public class TaskConfig implements SchedulingConfigurer {
 
+  public static final long ONE_SECOND_MSEC = 1000;
+  public static final long TEN_SECONDS_MSEC = 10 * ONE_SECOND_MSEC;
+  public static final long THIRTY_SECONDS_MSEC = 30 * ONE_SECOND_MSEC;
+  public static final long ONE_MINUTE_MSEC = 60 * ONE_SECOND_MSEC;
+  public static final long TEN_MINUTES_MSEC = 10 * ONE_MINUTE_MSEC;
+
   @Autowired
   OAuth2TokenEntityService tokenEntityService;
 
@@ -32,29 +38,28 @@ public class TaskConfig implements SchedulingConfigurer {
 
   @Bean(destroyMethod = "shutdown")
   public ScheduledExecutorService taskScheduler() {
-
-    // Do we need more than one executor here?
     return Executors.newSingleThreadScheduledExecutor();
   }
 
-  @Scheduled(fixedDelay = 60000 * 5, initialDelay = 60000 * 10)
+  @Scheduled(fixedDelayString = "${task.tokenCleanupPeriodMsec}", initialDelay = TEN_MINUTES_MSEC)
   public void clearExpiredTokens() {
 
     tokenEntityService.clearExpiredTokens();
   }
 
-  @Scheduled(fixedDelay = 30000, initialDelay = 60000)
+  @Scheduled(fixedDelayString = "${task.approvalCleanupPeriodMsec}",
+      initialDelay = TEN_MINUTES_MSEC)
   public void clearExpiredSites() {
 
     approvedSiteService.clearExpiredSites();
   }
 
-  @Scheduled(fixedDelayString = "${notification.taskDelay}", initialDelay = 10000)
+  @Scheduled(fixedDelayString = "${notification.taskDelay}", initialDelay = TEN_SECONDS_MSEC)
   public void sendNotifications() {
     notificationService.sendPendingNotifications();
   }
 
-  @Scheduled(fixedDelay = 30000, initialDelay = 60000)
+  @Scheduled(fixedDelay = THIRTY_SECONDS_MSEC, initialDelay = TEN_MINUTES_MSEC)
   public void clearExpiredNotifications() {
     notificationService.clearExpiredNotifications();
   }

--- a/iam-login-service/src/main/resources/application.yml
+++ b/iam-login-service/src/main/resources/application.yml
@@ -36,7 +36,8 @@ iam:
   issuer: ${IAM_ISSUER:http://${iam.host}:8080}
 
   token:
-    lifetime: 86400
+    # This is the registration access token lifetime
+    lifetime: ${IAM_REGISTRATION_TOKEN_LIFETIME:-1}  
 
   organisation:
     name: ${IAM_ORGANISATION_NAME:indigo-dc}
@@ -72,7 +73,7 @@ github:
 notification:
   disable: ${IAM_NOTIFICATION_DISABLE:false}
   mailFrom: ${IAM_NOTIFICATION_FROM:indigo@localhost}
-  taskDelay: ${IAM_NOTIFICATION_TASK_DELAY:30000}
+  taskDelay: ${IAM_NOTIFICATION_TASK_DELAY:5000}
   cleanupAge: ${IAM_NOTIFICATION_CLEANUP_AGE:30}
   adminAddress: ${IAM_NOTIFICATION_ADMIN_ADDRESS:indigo-alerts@localhost}
   subject:
@@ -81,3 +82,7 @@ notification:
     rejected: Indigo Account request rejected
     adminHandleRequest: New Indigo account request
     resetPassword: Indigo account reset password
+
+task:
+  tokenCleanupPeriodMsec: ${IAM_TOKEN_CLEANUP_PERIOD_MSEC:300000}
+  approvalCleanupPeriodMsec: ${IAM_APPROVAL_CLEANUP_PERIOD_MSEC:300000}


### PR DESCRIPTION
This commit introduces the ability to configure the token and approval
cleanup task period.

The cleanup period can be configured via the following environment
variables:

- IAM_TOKEN_CLEANUP_PERIOD_MSEC
- IAM_APPROVAL_CLEANUP_PERIOD_MSEC

which specify the cleanup period in milliseconds for the respective
tasks.

Fixes #96