### PR TITLE
Log password grant logins

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/TimestamperSuccessHandler.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/TimestamperSuccessHandler.java
@@ -15,6 +15,8 @@ import org.slf4j.Logger;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 
+import it.infn.mw.iam.core.util.IamAuthenticationLogger;
+
 public class TimestamperSuccessHandler implements AuthenticationSuccessHandler {
 
   public static final Logger LOG = getLogger(TimestamperSuccessHandler.class);
@@ -30,8 +32,7 @@ public class TimestamperSuccessHandler implements AuthenticationSuccessHandler {
     Date timestamp = new Date();
     HttpSession session = request.getSession();
     session.setAttribute(AuthenticationTimeStamper.AUTH_TIMESTAMP, timestamp);
-    LOG.info("{} was authenticated successfully", authentication.getName());
-
+    IamAuthenticationLogger.INSTANCE.logAuthenticationSuccess(authentication);
   }
 
   @Override

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/AuthorizationServerConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/AuthorizationServerConfig.java
@@ -38,6 +38,7 @@ import org.springframework.security.oauth2.provider.password.ResourceOwnerPasswo
 import org.springframework.security.oauth2.provider.refresh.RefreshTokenGranter;
 
 import it.infn.mw.iam.core.oauth.TokenExchangeTokenGranter;
+import it.infn.mw.iam.core.util.IamAuthenticationEventPublisher;
 
 @Configuration
 @EnableAuthorizationServer
@@ -83,7 +84,12 @@ public class AuthorizationServerConfig extends AuthorizationServerConfigurerAdap
     DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
     provider.setUserDetailsService(iamUserDetailsService);
     provider.setPasswordEncoder(passwordEncoder);
-    return new ProviderManager(Collections.<AuthenticationProvider>singletonList(provider));
+
+    ProviderManager pm =
+        new ProviderManager(Collections.<AuthenticationProvider>singletonList(provider));
+
+    pm.setAuthenticationEventPublisher(new IamAuthenticationEventPublisher());
+    return pm;
 
   }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/IamOAuth2RequestFactory.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/IamOAuth2RequestFactory.java
@@ -2,6 +2,7 @@ package it.infn.mw.iam.core;
 
 import org.mitre.oauth2.service.ClientDetailsEntityService;
 import org.mitre.openid.connect.request.ConnectOAuth2RequestFactory;
+import org.mitre.openid.connect.web.AuthenticationTimeStamper;
 import org.springframework.security.oauth2.provider.ClientDetails;
 import org.springframework.security.oauth2.provider.OAuth2Request;
 import org.springframework.security.oauth2.provider.TokenRequest;
@@ -10,12 +11,20 @@ public class IamOAuth2RequestFactory extends ConnectOAuth2RequestFactory {
 
   public static final String[] AUDIENCE_KEYS = {"aud", "audience"};
   public static final String AUD = "aud";
+  public static final String PASSWORD_GRANT = "password";
 
 
   public IamOAuth2RequestFactory(ClientDetailsEntityService clientDetailsService) {
     super(clientDetailsService);
   }
 
+
+  private void handlePasswordGrantAuthenticationTimestamp(OAuth2Request request){
+    if (PASSWORD_GRANT.equals(request.getGrantType())){
+      String now = Long.toString(System.currentTimeMillis());
+      request.getExtensions().put(AuthenticationTimeStamper.AUTH_TIMESTAMP, now);
+    }
+  }
   /**
    * This implementation extends what's already done by MitreID implementation with audience request
    * parameter handling (both "aud" and "audience" are accepted).
@@ -26,6 +35,8 @@ public class IamOAuth2RequestFactory extends ConnectOAuth2RequestFactory {
   public OAuth2Request createOAuth2Request(ClientDetails client, TokenRequest tokenRequest) {
 
     OAuth2Request request = super.createOAuth2Request(client, tokenRequest);
+
+    handlePasswordGrantAuthenticationTimestamp(request);
 
     for (String audienceKey : AUDIENCE_KEYS) {
       if (tokenRequest.getRequestParameters().containsKey(audienceKey)) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/util/AuthenticationLogger.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/util/AuthenticationLogger.java
@@ -1,0 +1,9 @@
+package it.infn.mw.iam.core.util;
+
+import org.springframework.security.core.Authentication;
+
+public interface AuthenticationLogger {
+
+  public void logAuthenticationSuccess(Authentication auth);
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/util/IamAuthenticationEventPublisher.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/util/IamAuthenticationEventPublisher.java
@@ -1,0 +1,21 @@
+package it.infn.mw.iam.core.util;
+
+import org.springframework.security.authentication.AuthenticationEventPublisher;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+
+public class IamAuthenticationEventPublisher implements AuthenticationEventPublisher {
+
+  @Override
+  public void publishAuthenticationSuccess(Authentication authentication) {
+    IamAuthenticationLogger.INSTANCE.logAuthenticationSuccess(authentication);
+  }
+
+  @Override
+  public void publishAuthenticationFailure(AuthenticationException exception,
+      Authentication authentication) {
+
+
+  }
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/util/IamAuthenticationLogger.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/util/IamAuthenticationLogger.java
@@ -1,0 +1,32 @@
+package it.infn.mw.iam.core.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+
+public enum IamAuthenticationLogger implements AuthenticationLogger {
+
+  INSTANCE;
+
+  private final Logger LOG = LoggerFactory.getLogger(IamAuthenticationLogger.class);
+
+  @Override
+  public void logAuthenticationSuccess(Authentication auth) {
+    if (!(auth instanceof OAuth2Authentication)) {
+      LOG.info("{} was authenticated succesfully", auth.getName());
+      return;
+    }
+
+    final OAuth2Authentication oauth = (OAuth2Authentication) auth;
+    final String clientName = oauth.getName();
+
+    if (oauth.getUserAuthentication() != null) {
+      final String userName = oauth.getUserAuthentication().getName();
+      LOG.info("{} acting for {} was authenticated succesfully", clientName, userName);
+    } else {
+      LOG.info("Client {} was authenticated succesfully", clientName);
+    }
+  }
+
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/ResourceOwnerPasswordCredentialsTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/ResourceOwnerPasswordCredentialsTests.java
@@ -2,6 +2,9 @@ package it.infn.mw.iam.test.oauth;
 
 import static com.jayway.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertNotNull;
+
+import java.text.ParseException;
 
 import javax.transaction.Transactional;
 
@@ -10,6 +13,9 @@ import org.junit.runner.RunWith;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.boot.test.WebIntegrationTest;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTParser;
 
 import it.infn.mw.iam.IamLoginService;
 
@@ -90,4 +96,32 @@ public class ResourceOwnerPasswordCredentialsTests {
 
   }
 
+  @Test
+  public void testResourceOwnerPasswordCredentialAuthenticationTimestamp() throws ParseException {
+
+    String clientId = "password-grant";
+    String clientSecret = "secret";
+
+    String idToken = given().auth()
+      .preemptive()
+      .basic(clientId, clientSecret)
+      .port(8080)
+      .param("grant_type", "password")
+      .param("username", "test")
+      .param("password", "password")
+      .param("scope", "openid profile")
+      .when()
+      .post("/token")
+      .then()
+      .log()
+      .body(true)
+      .statusCode(200)
+      .extract()
+      .path("id_token");
+
+    JWT token = JWTParser.parse(idToken);
+    System.out.println(token.getJWTClaimsSet());
+    assertNotNull(token.getJWTClaimsSet().getClaim("auth_time"));
+
+  }
 }

--- a/iam-persistence/src/main/resources/db/migration/test/V100000___test_data.sql
+++ b/iam-persistence/src/main/resources/db/migration/test/V100000___test_data.sql
@@ -1,15 +1,17 @@
-INSERT INTO client_details (id, client_id, client_secret, client_name, dynamically_registered, refresh_token_validity_seconds, access_token_validity_seconds, id_token_validity_seconds, allow_introspection, token_endpoint_auth_method) VALUES
-  (1, 'client', 'secret', 'Test Client', false, null, 3600, 600, true, 'SECRET_BASIC'),
-  (2, 'tasks-app', 'secret', 'Tasks App', false, null, 0, 0, true, 'SECRET_BASIC'),
-  (3, 'post-client', 'secret', 'Post client', false, null, 3600,600, true, 'SECRET_POST'),
-  (4, 'client-cred', 'secret', 'Client credentials', false, null, 3600, 600, true, 'SECRET_BASIC'),
-  (5, 'password-grant', 'secret', 'Password grant client', false, null, 3600, 600, true, 'SECRET_BASIC'),
-  (6, 'scim-client-ro', 'secret', 'SCIM client (read-only)', false, null, 3600, 600, true, 'SECRET_POST'),
-  (7, 'scim-client-rw', 'secret', 'SCIM client (read-write)', false, null, 3600, 600, true, 'SECRET_POST'),
-  (8, 'token-exchange-actor', 'secret', 'Token Exchange grant client actor', false, null, 3600, 600, true, 'SECRET_POST'),
-  (9, 'token-exchange-subject', 'secret', 'Token Exchange grant client subject', false, null, 3600, 600, true, 'SECRET_POST'),
-  (10, 'registration-client', 'secret', 'Registration service test client', false, null, 3600, 600, true, 'SECRET_POST'),
-  (11, 'token-lookup-client', 'secret', 'Token lookup client', false, null, 3600, 600, true, 'SECRET_BASIC');
+INSERT INTO client_details (id, client_id, client_secret, client_name, dynamically_registered,
+  refresh_token_validity_seconds, access_token_validity_seconds, id_token_validity_seconds, allow_introspection,
+  token_endpoint_auth_method, require_auth_time) VALUES
+  (1, 'client', 'secret', 'Test Client', false, null, 3600, 600, true, 'SECRET_BASIC',false),
+  (2, 'tasks-app', 'secret', 'Tasks App', false, null, 0, 0, true, 'SECRET_BASIC',false),
+  (3, 'post-client', 'secret', 'Post client', false, null, 3600,600, true, 'SECRET_POST',false),
+  (4, 'client-cred', 'secret', 'Client credentials', false, null, 3600, 600, true, 'SECRET_BASIC',false),
+  (5, 'password-grant', 'secret', 'Password grant client', false, null, 3600, 600, true, 'SECRET_BASIC',true),
+  (6, 'scim-client-ro', 'secret', 'SCIM client (read-only)', false, null, 3600, 600, true, 'SECRET_POST',false),
+  (7, 'scim-client-rw', 'secret', 'SCIM client (read-write)', false, null, 3600, 600, true, 'SECRET_POST',false),
+  (8, 'token-exchange-actor', 'secret', 'Token Exchange grant client actor', false, null, 3600, 600, true, 'SECRET_POST',false),
+  (9, 'token-exchange-subject', 'secret', 'Token Exchange grant client subject', false, null, 3600, 600, true, 'SECRET_POST',false),
+  (10, 'registration-client', 'secret', 'Registration service test client', false, null, 3600, 600, true, 'SECRET_POST',false),
+  (11, 'token-lookup-client', 'secret', 'Token lookup client', false, null, 3600, 600, true, 'SECRET_BASIC', false);
 
 INSERT INTO client_scope (owner_id, scope) VALUES
   (1, 'openid'),


### PR DESCRIPTION
This commit introduces support for logging successful authentication
for the resource-owner password-credential flow.
It also sets correctly the authentication timestamp, that can be later
retrieved from id_tokens by interested relying parties.