### PR TITLE
Customizable logo and title

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/MitreConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/MitreConfig.java
@@ -12,25 +12,31 @@ public class MitreConfig {
 
   @Value("${iam.issuer}")
   private String issuer;
-  
+
   @Value("${iam.baseUrl}")
   private String baseUrl;
 
   @Value("${iam.token.lifetime}")
   private Long tokenLifeTime;
 
+  @Value("${iam.logoImageUrl}")
+  private String logoImageUrl;
+
+  @Value("${iam.topbarTitle}")
+  private String topbarTitle;
+
   @Bean
   public ConfigurationPropertiesBean config() {
 
     ConfigurationPropertiesBean config = new ConfigurationPropertiesBean();
 
-    config.setLogoImageUrl("resources/images/indigo-logo.png");
-    config.setTopbarTitle("INDIGO IAM server");
-    
-    if (!issuer.endsWith("/")){
+    config.setLogoImageUrl(logoImageUrl);
+    config.setTopbarTitle(topbarTitle);
+
+    if (!issuer.endsWith("/")) {
       issuer = issuer + "/";
     }
-    
+
     config.setIssuer(issuer);
     config.setRegTokenLifeTime(tokenLifeTime);
     config.setForceHttps(false);

--- a/iam-login-service/src/main/resources/application-prod.yml
+++ b/iam-login-service/src/main/resources/application-prod.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    include: mysql,google
+    include: mysql
     
 flyway:
   locations:

--- a/iam-login-service/src/main/resources/application.yml
+++ b/iam-login-service/src/main/resources/application.yml
@@ -34,6 +34,8 @@ iam:
   host: ${IAM_HOST:localhost}
   baseUrl: ${IAM_BASE_URL:http://${iam.host}:8080}
   issuer: ${IAM_ISSUER:http://${iam.host}:8080}
+  logoImageUrl: ${IAM_LOGO_URL:resources/images/indigo-logo.png}
+  topbarTitle: ${IAM_TOPBAR_TITLE:INDIGO IAM for ${iam.organisation.name}}
 
   token:
     # This is the registration access token lifetime

--- a/iam-login-service/src/main/webapp/WEB-INF/tags/iam/page.tag
+++ b/iam-login-service/src/main/webapp/WEB-INF/tags/iam/page.tag
@@ -93,7 +93,7 @@
 <body>
   <div class="container">
     <div class="absolute-center">
-      <div id="logo-container">
+      <div id="logo-container" style="background-image: url(${config.logoImageUrl})">
         <a href="/"></a>
       </div>
       <div class="container-fluid page-content">

--- a/iam-login-service/src/main/webapp/WEB-INF/tags/landingPageWelcome.tag
+++ b/iam-login-service/src/main/webapp/WEB-INF/tags/landingPageWelcome.tag
@@ -1,6 +1,6 @@
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags"%>
 <div class="row-fluid">
-	<div class="span2 visible-desktop"><img src="resources/images/indigo-logo.png"/></div>
+	<div class="span2 visible-desktop"><img src="${config.logoImageUrl}"/></div>
 	
 	<div class="span10">
 		<h1><spring:message code="home.welcome.title"/></h1>

--- a/iam-login-service/src/main/webapp/WEB-INF/views/iam/expiredsession.jsp
+++ b/iam-login-service/src/main/webapp/WEB-INF/views/iam/expiredsession.jsp
@@ -7,7 +7,7 @@
 
     <div class="absolute-center is-responsive">
 
-        <div id="logo-container"></div>
+        <div id="logo-container" style="background-image: url(${config.logoImageUrl})"></div>
 
         <div style="text-align: center;">
             <h3>Session Expired</h3>


### PR DESCRIPTION
This PR include some small fixes to enable the customization of the main logo and the page title using environment variables.
Moreover, remove the 'google' profile from  the defaults in the production configuration.