### PR TITLE
Add timestamp parameter to the query in token repositories

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/IamTokenService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/IamTokenService.java
@@ -1,5 +1,6 @@
 package it.infn.mw.iam.core;
 
+import java.util.Date;
 import java.util.Set;
 
 import org.mitre.oauth2.model.OAuth2AccessTokenEntity;
@@ -33,7 +34,7 @@ public class IamTokenService extends DefaultOAuth2ProviderTokenService {
   public Set<OAuth2AccessTokenEntity> getAllAccessTokensForUser(String id) {
 
     Set<OAuth2AccessTokenEntity> results = Sets.newLinkedHashSet();
-    results.addAll(accessTokenRepo.findValidAccessTokensForUser(id));
+    results.addAll(accessTokenRepo.findValidAccessTokensForUser(id, new Date()));
     return results;
   }
 
@@ -41,7 +42,7 @@ public class IamTokenService extends DefaultOAuth2ProviderTokenService {
   @Override
   public Set<OAuth2RefreshTokenEntity> getAllRefreshTokensForUser(String id) {
     Set<OAuth2RefreshTokenEntity> results = Sets.newLinkedHashSet();
-    results.addAll(refreshTokenRepo.findValidRefreshTokensForUser(id));
+    results.addAll(refreshTokenRepo.findValidRefreshTokensForUser(id, new Date()));
     return results;
   }
 

--- a/iam-persistence/src/main/java/it/infn/mw/iam/persistence/repository/IamOAuthAccessTokenRepository.java
+++ b/iam-persistence/src/main/java/it/infn/mw/iam/persistence/repository/IamOAuthAccessTokenRepository.java
@@ -1,5 +1,6 @@
 package it.infn.mw.iam.persistence.repository;
 
+import java.util.Date;
 import java.util.List;
 
 import org.mitre.oauth2.model.OAuth2AccessTokenEntity;
@@ -11,6 +12,7 @@ public interface IamOAuthAccessTokenRepository
     extends PagingAndSortingRepository<OAuth2AccessTokenEntity, Long> {
 
   @Query("select t from OAuth2AccessTokenEntity t where t.authenticationHolder.userAuth.name = :userId "
-      + "and (t.expiration is NULL or t.expiration > CURRENT_TIMESTAMP)")
-  List<OAuth2AccessTokenEntity> findValidAccessTokensForUser(@Param("userId") String userId);
+      + "and (t.expiration is NULL or t.expiration > :timestamp)")
+  List<OAuth2AccessTokenEntity> findValidAccessTokensForUser(@Param("userId") String userId,
+      @Param("timestamp") Date timestamp);
 }

--- a/iam-persistence/src/main/java/it/infn/mw/iam/persistence/repository/IamOAuthRefreshTokenRepository.java
+++ b/iam-persistence/src/main/java/it/infn/mw/iam/persistence/repository/IamOAuthRefreshTokenRepository.java
@@ -1,5 +1,6 @@
 package it.infn.mw.iam.persistence.repository;
 
+import java.util.Date;
 import java.util.List;
 
 import org.mitre.oauth2.model.OAuth2RefreshTokenEntity;
@@ -9,7 +10,9 @@ import org.springframework.data.repository.query.Param;
 
 public interface IamOAuthRefreshTokenRepository
     extends PagingAndSortingRepository<OAuth2RefreshTokenEntity, Long> {
+
   @Query("select t from OAuth2RefreshTokenEntity t where t.authenticationHolder.userAuth.name = :userId "
-      + "and (t.expiration is NULL or t.expiration > CURRENT_TIMESTAMP)")
-  List<OAuth2RefreshTokenEntity> findValidRefreshTokensForUser(@Param("userId") String userId);
+      + "and (t.expiration is NULL or t.expiration > :timestamp)")
+  List<OAuth2RefreshTokenEntity> findValidRefreshTokensForUser(@Param("userId") String userId,
+      @Param("timestamp") Date timestamp);
 }


### PR DESCRIPTION
This PR resolve issue #112 .
The main change is add a Date parameter to the method in access and refresh token repositories, so the generated SQL query is independent from the DB server's time.