### PR TITLE
Add account username in reset password email

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/notification/DefaultNotificationService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/notification/DefaultNotificationService.java
@@ -134,6 +134,7 @@ public class DefaultNotificationService implements NotificationService {
     model.put(RECIPIENT_FIELD, recipient);
     model.put("resetPasswordUrl", resetPasswordUrl);
     model.put("organisationName", organisationName);
+    model.put("username", account.getUsername());
 
     return createMessage("resetPassword.vm", model, IamNotificationType.RESETPASSWD,
         properties.getSubject().get("resetPassword"), account.getUserInfo().getEmail());

--- a/iam-login-service/src/main/resources/templates/resetPassword.vm
+++ b/iam-login-service/src/main/resources/templates/resetPassword.vm
@@ -4,5 +4,6 @@ Follow this link to set a new password for your $organisationName account:
 
 $resetPasswordUrl
 
+After updating the password, you can login into IAM with the username: $username
 
 The $organisationName registration service

--- a/iam-login-service/src/main/resources/templates/resetPassword.vm
+++ b/iam-login-service/src/main/resources/templates/resetPassword.vm
@@ -4,6 +4,8 @@ Follow this link to set a new password for your $organisationName account:
 
 $resetPasswordUrl
 
-After updating the password, you can login into IAM with the username: $username
+Once your password has been reset, you can login to the IAM using the following username:
+
+$username
 
 The $organisationName registration service

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/notification/NotificationConcurrentTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/notification/NotificationConcurrentTests.java
@@ -2,6 +2,9 @@ package it.infn.mw.iam.test.notification;
 
 import static it.infn.mw.iam.test.RegistrationUtils.createRegistrationRequest;
 import static it.infn.mw.iam.test.RegistrationUtils.deleteUser;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -14,7 +17,6 @@ import java.util.concurrent.Future;
 
 import org.apache.commons.lang.time.DateUtils;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -106,7 +108,7 @@ public class NotificationConcurrentTests {
     }
 
     int count = wiserSmtpServer.getMessages().size();
-    Assert.assertEquals(1, count);
+    assertThat(count, equalTo(1));
 
   }
 
@@ -114,7 +116,7 @@ public class NotificationConcurrentTests {
   public void testConcurrentCleanUp() throws Exception {
 
     notificationService.sendPendingNotifications();
-    Assert.assertEquals(1, wiserSmtpServer.getMessages().size());
+    assertThat(wiserSmtpServer.getMessages(), hasSize(1));
 
     Date fakeDate = DateUtils.addDays(new Date(), (notificationCleanUpAge + 1));
     timeProvider.setTime(fakeDate.getTime());
@@ -136,7 +138,7 @@ public class NotificationConcurrentTests {
     }
 
     int count = notificationRepository.countAllMessages();
-    Assert.assertEquals(0, count);
+    assertThat(count, equalTo(0));
   }
 
   public class WorkerSend implements Callable<Integer> {

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/notification/NotificationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/notification/NotificationTests.java
@@ -1,8 +1,15 @@
 package it.infn.mw.iam.test.notification;
 
+import static it.infn.mw.iam.test.RegistrationUtils.approveRequest;
 import static it.infn.mw.iam.test.RegistrationUtils.confirmRegistrationRequest;
 import static it.infn.mw.iam.test.RegistrationUtils.createRegistrationRequest;
 import static it.infn.mw.iam.test.RegistrationUtils.deleteUser;
+import static it.infn.mw.iam.test.RegistrationUtils.rejectRequest;
+import static java.lang.String.format;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -12,9 +19,7 @@ import java.util.List;
 import javax.mail.MessagingException;
 
 import org.apache.commons.lang.time.DateUtils;
-import org.hamcrest.Matchers;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -30,6 +35,7 @@ import org.subethamail.wiser.WiserMessage;
 
 import it.infn.mw.iam.IamLoginService;
 import it.infn.mw.iam.api.account.password_reset.PasswordResetController;
+import it.infn.mw.iam.api.account.password_reset.PasswordResetService;
 import it.infn.mw.iam.core.IamDeliveryStatus;
 import it.infn.mw.iam.notification.MockTimeProvider;
 import it.infn.mw.iam.notification.NotificationProperties;
@@ -38,7 +44,6 @@ import it.infn.mw.iam.persistence.model.IamEmailNotification;
 import it.infn.mw.iam.persistence.repository.IamEmailNotificationRepository;
 import it.infn.mw.iam.registration.PersistentUUIDTokenGenerator;
 import it.infn.mw.iam.registration.RegistrationRequestDto;
-import it.infn.mw.iam.test.RegistrationUtils;
 import it.infn.mw.iam.test.TestUtils;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -67,6 +72,9 @@ public class NotificationTests {
 
   @Autowired
   private IamEmailNotificationRepository notificationRepository;
+
+  @Autowired
+  private PasswordResetService passwordResetService;
 
   @Autowired
   private MockTimeProvider timeProvider;
@@ -107,17 +115,17 @@ public class NotificationTests {
     RegistrationRequestDto reg = createRegistrationRequest(username);
     notificationService.sendPendingNotifications();
 
-    Assert.assertEquals(1, wiser.getMessages().size());
+    assertEquals(1, wiser.getMessages().size());
     WiserMessage message = wiser.getMessages().get(0);
 
-    Assert.assertEquals(properties.getMailFrom(), message.getEnvelopeSender());
-    Assert.assertTrue("receiver", message.getEnvelopeReceiver().startsWith(username));
-    Assert.assertEquals(properties.getSubject().get("confirmation"),
+    assertEquals(properties.getMailFrom(), message.getEnvelopeSender());
+    assertTrue("receiver", message.getEnvelopeReceiver().startsWith(username));
+    assertEquals(properties.getSubject().get("confirmation"),
         message.getMimeMessage().getSubject());
 
     Iterable<IamEmailNotification> queue = notificationRepository.findAll();
     for (IamEmailNotification elem : queue) {
-      Assert.assertEquals(IamDeliveryStatus.DELIVERED, elem.getDeliveryStatus());
+      assertEquals(IamDeliveryStatus.DELIVERED, elem.getDeliveryStatus());
     }
 
     deleteUser(reg.getAccountId());
@@ -132,11 +140,11 @@ public class NotificationTests {
     properties.setDisable(true);
     notificationService.sendPendingNotifications();
 
-    Assert.assertEquals(0, wiser.getMessages().size());
+    assertEquals(0, wiser.getMessages().size());
 
     Iterable<IamEmailNotification> queue = notificationRepository.findAll();
     for (IamEmailNotification elem : queue) {
-      Assert.assertEquals(IamDeliveryStatus.DELIVERED, elem.getDeliveryStatus());
+      assertEquals(IamDeliveryStatus.DELIVERED, elem.getDeliveryStatus());
     }
 
     deleteUser(reg.getAccountId());
@@ -156,11 +164,11 @@ public class NotificationTests {
 
     notificationService.sendPendingNotifications();
 
-    Assert.assertEquals(count, wiser.getMessages().size());
+    assertEquals(count, wiser.getMessages().size());
 
     Iterable<IamEmailNotification> queue = notificationRepository.findAll();
     for (IamEmailNotification elem : queue) {
-      Assert.assertEquals(IamDeliveryStatus.DELIVERED, elem.getDeliveryStatus());
+      assertEquals(IamDeliveryStatus.DELIVERED, elem.getDeliveryStatus());
     }
 
     for (RegistrationRequestDto elem : requestList) {
@@ -172,7 +180,7 @@ public class NotificationTests {
   public void testSendWithEmptyQueue() {
 
     notificationService.sendPendingNotifications();
-    Assert.assertEquals(0, wiser.getMessages().size());
+    assertEquals(0, wiser.getMessages().size());
   }
 
   @Test
@@ -186,7 +194,7 @@ public class NotificationTests {
 
     Iterable<IamEmailNotification> queue = notificationRepository.findAll();
     for (IamEmailNotification elem : queue) {
-      Assert.assertEquals(IamDeliveryStatus.DELIVERY_ERROR, elem.getDeliveryStatus());
+      assertEquals(IamDeliveryStatus.DELIVERY_ERROR, elem.getDeliveryStatus());
     }
 
     deleteUser(reg.getAccountId());
@@ -200,36 +208,34 @@ public class NotificationTests {
     RegistrationRequestDto reg = createRegistrationRequest(username);
     notificationService.sendPendingNotifications();
 
-    Assert.assertEquals(1, wiser.getMessages().size());
+    assertEquals(1, wiser.getMessages().size());
 
     WiserMessage message = wiser.getMessages().get(0);
 
-    Assert.assertEquals(message.getMimeMessage().getSubject(),
+    assertEquals(message.getMimeMessage().getSubject(),
         properties.getSubject().get("confirmation"));
 
     String confirmationKey = generator.getLastToken();
     confirmRegistrationRequest(confirmationKey);
     notificationService.sendPendingNotifications();
 
-    Assert.assertEquals(2, wiser.getMessages().size());
+    assertEquals(2, wiser.getMessages().size());
 
     message = wiser.getMessages().get(1);
 
-    Assert.assertEquals(properties.getSubject().get("adminHandleRequest"),
+    assertEquals(properties.getSubject().get("adminHandleRequest"),
         message.getMimeMessage().getSubject());
 
-    Assert.assertTrue("receiver",
-        message.getEnvelopeReceiver().startsWith(properties.getAdminAddress()));
+    assertTrue("receiver", message.getEnvelopeReceiver().startsWith(properties.getAdminAddress()));
 
-    RegistrationUtils.approveRequest(reg.getUuid());
+    approveRequest(reg.getUuid());
     notificationService.sendPendingNotifications();
 
-    Assert.assertEquals(3, wiser.getMessages().size());
+    assertEquals(3, wiser.getMessages().size());
 
     message = wiser.getMessages().get(2);
 
-    Assert.assertEquals(properties.getSubject().get("activated"),
-        message.getMimeMessage().getSubject());
+    assertEquals(properties.getSubject().get("activated"), message.getMimeMessage().getSubject());
 
     deleteUser(reg.getAccountId());
   }
@@ -241,31 +247,29 @@ public class NotificationTests {
     RegistrationRequestDto reg = createRegistrationRequest(username);
     notificationService.sendPendingNotifications();
 
-    Assert.assertEquals(1, wiser.getMessages().size());
+    assertEquals(1, wiser.getMessages().size());
 
     WiserMessage message = wiser.getMessages().get(0);
-    Assert.assertEquals(properties.getSubject().get("confirmation"),
+    assertEquals(properties.getSubject().get("confirmation"),
         message.getMimeMessage().getSubject());
 
     String confirmationKey = generator.getLastToken();
     confirmRegistrationRequest(confirmationKey);
     notificationService.sendPendingNotifications();
 
-    Assert.assertEquals(2, wiser.getMessages().size());
+    assertEquals(2, wiser.getMessages().size());
     message = wiser.getMessages().get(1);
-    Assert.assertEquals(properties.getSubject().get("adminHandleRequest"),
+    assertEquals(properties.getSubject().get("adminHandleRequest"),
         message.getMimeMessage().getSubject());
-    Assert.assertTrue("receiver",
-        message.getEnvelopeReceiver().startsWith(properties.getAdminAddress()));
+    assertTrue("receiver", message.getEnvelopeReceiver().startsWith(properties.getAdminAddress()));
 
-    RegistrationUtils.rejectRequest(reg.getUuid());
+    rejectRequest(reg.getUuid());
     notificationService.sendPendingNotifications();
 
-    Assert.assertEquals(3, wiser.getMessages().size());
+    assertEquals(3, wiser.getMessages().size());
 
     message = wiser.getMessages().get(2);
-    Assert.assertEquals(properties.getSubject().get("rejected"),
-        message.getMimeMessage().getSubject());
+    assertEquals(properties.getSubject().get("rejected"), message.getMimeMessage().getSubject());
   }
 
   @Test
@@ -274,7 +278,7 @@ public class NotificationTests {
 
     RegistrationRequestDto reg = createRegistrationRequest(username);
     notificationService.sendPendingNotifications();
-    Assert.assertEquals(1, wiser.getMessages().size());
+    assertEquals(1, wiser.getMessages().size());
 
     Date fakeDate = DateUtils.addDays(new Date(), (properties.getCleanupAge() + 1));
     timeProvider.setTime(fakeDate.getTime());
@@ -284,7 +288,7 @@ public class NotificationTests {
     deleteUser(reg.getAccountId());
 
     int count = notificationRepository.countAllMessages();
-    Assert.assertEquals(0, count);
+    assertEquals(0, count);
 
 
   }
@@ -298,14 +302,14 @@ public class NotificationTests {
     RegistrationRequestDto reg = createRegistrationRequest(username);
     String confirmationKey = generator.getLastToken();
     confirmRegistrationRequest(confirmationKey);
-    RegistrationUtils.approveRequest(reg.getUuid());
+    approveRequest(reg.getUuid());
 
     notificationService.sendPendingNotifications();
 
     for (WiserMessage message : wiser.getMessages()) {
-      Assert.assertTrue("text/plain", message.getMimeMessage().isMimeType("text/plain"));
+      assertTrue("text/plain", message.getMimeMessage().isMimeType("text/plain"));
       String content = message.getMimeMessage().getContent().toString();
-      Assert.assertThat(content, Matchers.containsString(signature));
+      assertThat(content, containsString(signature));
     }
 
     deleteUser(reg.getAccountId());
@@ -320,15 +324,15 @@ public class NotificationTests {
     RegistrationRequestDto reg = createRegistrationRequest(username);
     String confirmationKey = generator.getLastToken();
 
-    String confirmURL = String.format("%s/registration/verify/%s", baseUrl, confirmationKey);
+    String confirmURL = format("%s/registration/verify/%s", baseUrl, confirmationKey);
 
     notificationService.sendPendingNotifications();
 
     WiserMessage message = wiser.getMessages().get(0);
 
-    Assert.assertTrue("text/plain", message.getMimeMessage().isMimeType("text/plain"));
+    assertTrue("text/plain", message.getMimeMessage().isMimeType("text/plain"));
     String content = message.getMimeMessage().getContent().toString();
-    Assert.assertThat(content, Matchers.containsString(confirmURL));
+    assertThat(content, containsString(confirmURL));
 
     deleteUser(reg.getAccountId());
   }
@@ -341,20 +345,20 @@ public class NotificationTests {
 
     RegistrationRequestDto reg = createRegistrationRequest(username);
     String confirmationKey = generator.getLastToken();
-    RegistrationUtils.confirmRegistrationRequest(confirmationKey);
-    RegistrationUtils.approveRequest(reg.getUuid());
+    confirmRegistrationRequest(confirmationKey);
+    approveRequest(reg.getUuid());
     String resetKey = generator.getLastToken();
 
     String resetPasswordUrl =
-        String.format("%s%s/%s", baseUrl, PasswordResetController.BASE_TOKEN_URL, resetKey);
+        format("%s%s/%s", baseUrl, PasswordResetController.BASE_TOKEN_URL, resetKey);
 
     notificationService.sendPendingNotifications();
 
     WiserMessage message = wiser.getMessages().get(2);
 
-    Assert.assertTrue("text/plain", message.getMimeMessage().isMimeType("text/plain"));
+    assertTrue("text/plain", message.getMimeMessage().isMimeType("text/plain"));
     String content = message.getMimeMessage().getContent().toString();
-    Assert.assertThat(content, Matchers.containsString(resetPasswordUrl));
+    assertThat(content, containsString(resetPasswordUrl));
 
     deleteUser(reg.getAccountId());
   }
@@ -367,17 +371,40 @@ public class NotificationTests {
 
     RegistrationRequestDto reg = createRegistrationRequest(username);
     String confirmationKey = generator.getLastToken();
-    RegistrationUtils.confirmRegistrationRequest(confirmationKey);
+    confirmRegistrationRequest(confirmationKey);
 
-    String dashboardUrl = String.format("%s/dashboard#/requests", baseUrl);
+    String dashboardUrl = format("%s/dashboard#/requests", baseUrl);
 
     notificationService.sendPendingNotifications();
 
     WiserMessage message = wiser.getMessages().get(1);
 
-    Assert.assertTrue("text/plain", message.getMimeMessage().isMimeType("text/plain"));
+    assertTrue("text/plain", message.getMimeMessage().isMimeType("text/plain"));
     String content = message.getMimeMessage().getContent().toString();
-    Assert.assertThat(content, Matchers.containsString(dashboardUrl));
+    assertThat(content, containsString(dashboardUrl));
+
+    deleteUser(reg.getAccountId());
+  }
+
+  @Test
+  public void testPasswordResetMailShouldContainsUsername() throws MessagingException, IOException {
+
+    String username = "test_user";
+
+    RegistrationRequestDto reg = createRegistrationRequest(username);
+    String confirmationKey = generator.getLastToken();
+    confirmRegistrationRequest(confirmationKey);
+    approveRequest(reg.getUuid());
+    passwordResetService.createPasswordResetToken(reg.getEmail());
+
+    notificationService.sendPendingNotifications();
+
+    List<WiserMessage> msgList = wiser.getMessages();
+    WiserMessage message = wiser.getMessages().get(msgList.size() - 1);
+
+    assertTrue("text/plain", message.getMimeMessage().isMimeType("text/plain"));
+    String content = message.getMimeMessage().getContent().toString();
+    assertThat(content, containsString(username));
 
     deleteUser(reg.getAccountId());
   }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/notification/NotificationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/notification/NotificationTests.java
@@ -7,6 +7,10 @@ import static it.infn.mw.iam.test.RegistrationUtils.deleteUser;
 import static it.infn.mw.iam.test.RegistrationUtils.rejectRequest;
 import static java.lang.String.format;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -115,17 +119,17 @@ public class NotificationTests {
     RegistrationRequestDto reg = createRegistrationRequest(username);
     notificationService.sendPendingNotifications();
 
-    assertEquals(1, wiser.getMessages().size());
+    assertThat(wiser.getMessages(), hasSize(1));
     WiserMessage message = wiser.getMessages().get(0);
 
-    assertEquals(properties.getMailFrom(), message.getEnvelopeSender());
-    assertTrue("receiver", message.getEnvelopeReceiver().startsWith(username));
-    assertEquals(properties.getSubject().get("confirmation"),
-        message.getMimeMessage().getSubject());
+    assertThat(message.getEnvelopeSender(), equalTo(properties.getMailFrom()));
+    assertThat(message.getEnvelopeReceiver(), startsWith(username));
+    assertThat(message.getMimeMessage().getSubject(),
+        equalTo(properties.getSubject().get("confirmation")));
 
     Iterable<IamEmailNotification> queue = notificationRepository.findAll();
     for (IamEmailNotification elem : queue) {
-      assertEquals(IamDeliveryStatus.DELIVERED, elem.getDeliveryStatus());
+      assertThat(elem.getDeliveryStatus(), equalTo(IamDeliveryStatus.DELIVERED));
     }
 
     deleteUser(reg.getAccountId());
@@ -140,11 +144,11 @@ public class NotificationTests {
     properties.setDisable(true);
     notificationService.sendPendingNotifications();
 
-    assertEquals(0, wiser.getMessages().size());
+    assertThat(wiser.getMessages(), hasSize(0));
 
     Iterable<IamEmailNotification> queue = notificationRepository.findAll();
     for (IamEmailNotification elem : queue) {
-      assertEquals(IamDeliveryStatus.DELIVERED, elem.getDeliveryStatus());
+      assertThat(elem.getDeliveryStatus(), equalTo(IamDeliveryStatus.DELIVERED));
     }
 
     deleteUser(reg.getAccountId());
@@ -164,11 +168,11 @@ public class NotificationTests {
 
     notificationService.sendPendingNotifications();
 
-    assertEquals(count, wiser.getMessages().size());
+    assertThat(wiser.getMessages(), hasSize(count));
 
     Iterable<IamEmailNotification> queue = notificationRepository.findAll();
     for (IamEmailNotification elem : queue) {
-      assertEquals(IamDeliveryStatus.DELIVERED, elem.getDeliveryStatus());
+      assertThat(elem.getDeliveryStatus(), equalTo(IamDeliveryStatus.DELIVERED));
     }
 
     for (RegistrationRequestDto elem : requestList) {
@@ -180,7 +184,7 @@ public class NotificationTests {
   public void testSendWithEmptyQueue() {
 
     notificationService.sendPendingNotifications();
-    assertEquals(0, wiser.getMessages().size());
+    assertThat(wiser.getMessages(), hasSize(0));
   }
 
   @Test
@@ -194,7 +198,7 @@ public class NotificationTests {
 
     Iterable<IamEmailNotification> queue = notificationRepository.findAll();
     for (IamEmailNotification elem : queue) {
-      assertEquals(IamDeliveryStatus.DELIVERY_ERROR, elem.getDeliveryStatus());
+      assertThat(elem.getDeliveryStatus(), equalTo(IamDeliveryStatus.DELIVERY_ERROR));
     }
 
     deleteUser(reg.getAccountId());
@@ -208,34 +212,35 @@ public class NotificationTests {
     RegistrationRequestDto reg = createRegistrationRequest(username);
     notificationService.sendPendingNotifications();
 
-    assertEquals(1, wiser.getMessages().size());
+    assertThat(wiser.getMessages(), hasSize(1));
 
     WiserMessage message = wiser.getMessages().get(0);
 
-    assertEquals(message.getMimeMessage().getSubject(),
-        properties.getSubject().get("confirmation"));
+    assertThat(message.getMimeMessage().getSubject(),
+        equalTo(properties.getSubject().get("confirmation")));
 
     String confirmationKey = generator.getLastToken();
     confirmRegistrationRequest(confirmationKey);
     notificationService.sendPendingNotifications();
 
-    assertEquals(2, wiser.getMessages().size());
+    assertThat(wiser.getMessages(), hasSize(2));
 
     message = wiser.getMessages().get(1);
 
     assertEquals(properties.getSubject().get("adminHandleRequest"),
         message.getMimeMessage().getSubject());
 
-    assertTrue("receiver", message.getEnvelopeReceiver().startsWith(properties.getAdminAddress()));
+    assertThat(message.getEnvelopeReceiver(), startsWith(properties.getAdminAddress()));
 
     approveRequest(reg.getUuid());
     notificationService.sendPendingNotifications();
 
-    assertEquals(3, wiser.getMessages().size());
+    assertThat(wiser.getMessages(), hasSize(3));
 
     message = wiser.getMessages().get(2);
 
-    assertEquals(properties.getSubject().get("activated"), message.getMimeMessage().getSubject());
+    assertThat(message.getMimeMessage().getSubject(),
+        equalTo(properties.getSubject().get("activated")));
 
     deleteUser(reg.getAccountId());
   }
@@ -247,29 +252,30 @@ public class NotificationTests {
     RegistrationRequestDto reg = createRegistrationRequest(username);
     notificationService.sendPendingNotifications();
 
-    assertEquals(1, wiser.getMessages().size());
+    assertThat(wiser.getMessages(), hasSize(1));
 
     WiserMessage message = wiser.getMessages().get(0);
-    assertEquals(properties.getSubject().get("confirmation"),
-        message.getMimeMessage().getSubject());
+    assertThat(message.getMimeMessage().getSubject(),
+        equalTo(properties.getSubject().get("confirmation")));
 
     String confirmationKey = generator.getLastToken();
     confirmRegistrationRequest(confirmationKey);
     notificationService.sendPendingNotifications();
 
-    assertEquals(2, wiser.getMessages().size());
+    assertThat(wiser.getMessages(), hasSize(2));
     message = wiser.getMessages().get(1);
-    assertEquals(properties.getSubject().get("adminHandleRequest"),
-        message.getMimeMessage().getSubject());
-    assertTrue("receiver", message.getEnvelopeReceiver().startsWith(properties.getAdminAddress()));
+    assertThat(message.getMimeMessage().getSubject(),
+        equalTo(properties.getSubject().get("adminHandleRequest")));
+    assertThat(message.getEnvelopeReceiver(), startsWith(properties.getAdminAddress()));
 
     rejectRequest(reg.getUuid());
     notificationService.sendPendingNotifications();
 
-    assertEquals(3, wiser.getMessages().size());
+    assertThat(wiser.getMessages(), hasSize(3));
 
     message = wiser.getMessages().get(2);
-    assertEquals(properties.getSubject().get("rejected"), message.getMimeMessage().getSubject());
+    assertThat(message.getMimeMessage().getSubject(),
+        equalTo(properties.getSubject().get("rejected")));
   }
 
   @Test
@@ -278,7 +284,7 @@ public class NotificationTests {
 
     RegistrationRequestDto reg = createRegistrationRequest(username);
     notificationService.sendPendingNotifications();
-    assertEquals(1, wiser.getMessages().size());
+    assertThat(wiser.getMessages(), hasSize(1));
 
     Date fakeDate = DateUtils.addDays(new Date(), (properties.getCleanupAge() + 1));
     timeProvider.setTime(fakeDate.getTime());
@@ -289,8 +295,6 @@ public class NotificationTests {
 
     int count = notificationRepository.countAllMessages();
     assertEquals(0, count);
-
-
   }
 
   @Test
@@ -330,7 +334,7 @@ public class NotificationTests {
 
     WiserMessage message = wiser.getMessages().get(0);
 
-    assertTrue("text/plain", message.getMimeMessage().isMimeType("text/plain"));
+    assertThat(message.getMimeMessage().isMimeType("text/plain"), is(true));
     String content = message.getMimeMessage().getContent().toString();
     assertThat(content, containsString(confirmURL));
 
@@ -356,7 +360,7 @@ public class NotificationTests {
 
     WiserMessage message = wiser.getMessages().get(2);
 
-    assertTrue("text/plain", message.getMimeMessage().isMimeType("text/plain"));
+    assertThat(message.getMimeMessage().isMimeType("text/plain"), is(true));
     String content = message.getMimeMessage().getContent().toString();
     assertThat(content, containsString(resetPasswordUrl));
 
@@ -379,7 +383,7 @@ public class NotificationTests {
 
     WiserMessage message = wiser.getMessages().get(1);
 
-    assertTrue("text/plain", message.getMimeMessage().isMimeType("text/plain"));
+    assertThat(message.getMimeMessage().isMimeType("text/plain"), is(true));
     String content = message.getMimeMessage().getContent().toString();
     assertThat(content, containsString(dashboardUrl));
 
@@ -387,7 +391,7 @@ public class NotificationTests {
   }
 
   @Test
-  public void testPasswordResetMailShouldContainsUsername() throws MessagingException, IOException {
+  public void testPasswordResetMailContainsUsername() throws MessagingException, IOException {
 
     String username = "test_user";
 
@@ -402,11 +406,10 @@ public class NotificationTests {
     List<WiserMessage> msgList = wiser.getMessages();
     WiserMessage message = wiser.getMessages().get(msgList.size() - 1);
 
-    assertTrue("text/plain", message.getMimeMessage().isMimeType("text/plain"));
+    assertThat(message.getMimeMessage().isMimeType("text/plain"), is(true));
     String content = message.getMimeMessage().getContent().toString();
     assertThat(content, containsString(username));
 
     deleteUser(reg.getAccountId());
   }
-
 }


### PR DESCRIPTION
This PR resolve issue #108.
Main changes:
- edit mail template;
- add username field into model;
- add unit test.