### PR TITLE
Stronger SAML attribute linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.0 (xxxx-xx-xx)
+
+TBD
+
 ## 0.6.0 (2017-3-31)
 
 This release provides improvements and bug fixes:

--- a/iam-common/pom.xml
+++ b/iam-common/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>it.infn.mw</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>0.6.0</version>
+    <version>1.0.0.rc0-SNAPSHOT</version>
   </parent>
 
   <artifactId>iam-common</artifactId>

--- a/iam-login-service/pom.xml
+++ b/iam-login-service/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>it.infn.mw</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>0.6.0</version>
+    <version>1.0.0.rc0-SNAPSHOT</version>
   </parent>
 
   <artifactId>iam-login-service</artifactId>

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account_linking/AccountLinkingController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account_linking/AccountLinkingController.java
@@ -90,9 +90,10 @@ public class AccountLinkingController extends ExternalAuthenticationHandlerSuppo
   @RequestMapping(value = "/{type}", method = RequestMethod.DELETE)
   @ResponseStatus(value = HttpStatus.NO_CONTENT)
   public void unlinkAccount(@PathVariable ExternalAuthenticationType type, Principal principal,
-      @RequestParam("iss") String issuer, @RequestParam("sub") String subject) {
+      @RequestParam("iss") String issuer, @RequestParam("sub") String subject, 
+      @RequestParam(name="attr", required=false) String attributeId) {
 
-    linkingService.unlinkExternalAccount(principal, type, issuer, subject);
+    linkingService.unlinkExternalAccount(principal, type, issuer, subject, attributeId);
   }
 
   @ResponseStatus(value = HttpStatus.BAD_REQUEST)

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account_linking/AccountLinkingService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account_linking/AccountLinkingService.java
@@ -11,6 +11,6 @@ public interface AccountLinkingService {
       AbstractExternalAuthenticationToken<?> externalAuthenticationToken);
 
   void unlinkExternalAccount(Principal authenticatedUser, ExternalAuthenticationType type,
-      String iss, String sub);
+      String iss, String sub, String attributeId);
 
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account_linking/DefaultAccountLinkingService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account_linking/DefaultAccountLinkingService.java
@@ -54,25 +54,27 @@ public class DefaultAccountLinkingService
     externalAuthenticationToken.linkToIamAccount(externalAccountLinker, userAccount);
 
     eventPublisher.publishEvent(new AccountLinkedEvent(this, userAccount,
-        externalAuthenticationToken.toExernalAuthenticationInfo(),
+        externalAuthenticationToken.toExernalAuthenticationRegistrationInfo(),
         String.format("User %s has linked a new account of type %s", userAccount.getUsername(),
-            externalAuthenticationToken.toExernalAuthenticationInfo().getType().toString())));
+            externalAuthenticationToken.toExernalAuthenticationRegistrationInfo().getType().toString())));
   }
 
 
   @Override
   public void unlinkExternalAccount(Principal authenticatedUser, ExternalAuthenticationType type,
-      String iss, String sub) {
+      String iss, String sub, String attributeId) {
 
     IamAccount userAccount = findAccount(authenticatedUser);
 
     boolean modified = false;
+    
     if (SAML.equals(type)) {
 
       IamSamlId id = new IamSamlId();
       id.setIdpId(iss);
       id.setUserId(sub);
-
+      id.setAttributeId(attributeId);
+      
       userAccount.getSamlIds()
         .stream()
         .filter(o -> o.equals(id))

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/authn_info/AuthnInfoController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/authn_info/AuthnInfoController.java
@@ -23,7 +23,7 @@ public class AuthnInfoController {
 	(AbstractExternalAuthenticationToken<?>) SecurityContextHolder.getContext()
 	  .getAuthentication();
 
-    return extAuthnToken.toExernalAuthenticationInfo();
+    return extAuthnToken.toExernalAuthenticationRegistrationInfo();
 
   }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/converter/SamlIdConverter.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/converter/SamlIdConverter.java
@@ -23,6 +23,9 @@ public class SamlIdConverter implements Converter<ScimSamlId, IamSamlId> {
   @Override
   public ScimSamlId toScim(IamSamlId entity) {
 
-    return ScimSamlId.builder().idpId(entity.getIdpId()).userId(entity.getUserId()).build();
+    return ScimSamlId.builder().idpId(entity.getIdpId()).
+        userId(entity.getUserId())
+        .attributeId(entity.getAttributeId())
+        .build();
   }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/converter/SamlIdConverter.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/converter/SamlIdConverter.java
@@ -14,6 +14,7 @@ public class SamlIdConverter implements Converter<ScimSamlId, IamSamlId> {
     IamSamlId samlId = new IamSamlId();
     samlId.setIdpId(scim.getIdpId());
     samlId.setUserId(scim.getUserId());
+    samlId.setAttributeId(scim.getAttributeId());
     samlId.setAccount(null);
 
     return samlId;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimIndigoUser.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimIndigoUser.java
@@ -3,6 +3,8 @@ package it.infn.mw.iam.api.scim.model;
 import java.util.LinkedList;
 import java.util.List;
 
+import javax.validation.Valid;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -31,6 +33,8 @@ public class ScimIndigoUser {
 
   private final List<ScimSshKey> sshKeys;
   private final List<ScimOidcId> oidcIds;
+  
+  @Valid
   private final List<ScimSamlId> samlIds;
 
   @JsonCreator

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimSamlId.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimSamlId.java
@@ -22,7 +22,7 @@ public class ScimSamlId {
   private final String userId;
   
   @NotBlank
-  @Length(max = 64)
+  @Length(max = 256)
   private final String attributeId;
 
   @JsonCreator

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimSamlId.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimSamlId.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import it.infn.mw.iam.authn.saml.util.Saml2Attribute;
+
 @JsonInclude(Include.NON_EMPTY)
 public class ScimSamlId {
 
@@ -18,12 +20,18 @@ public class ScimSamlId {
   @NotBlank
   @Length(max = 256)
   private final String userId;
+  
+  @NotBlank
+  @Length(max = 64)
+  private final String attributeId;
 
   @JsonCreator
-  private ScimSamlId(@JsonProperty("idpId") String idpId, @JsonProperty("userId") String userId) {
+  private ScimSamlId(@JsonProperty("idpId") String idpId, @JsonProperty("userId") String userId,
+      @JsonProperty("attributeId") String attributeId) {
 
     this.userId = userId;
     this.idpId = idpId;
+    this.attributeId = attributeId;
   }
 
   public String getUserId() {
@@ -35,11 +43,16 @@ public class ScimSamlId {
 
     return idpId;
   }
+  
+  public String getAttributeId() {
+    return attributeId;
+  }
 
   private ScimSamlId(Builder b) {
 
     this.idpId = b.idpId;
     this.userId = b.userId;
+    this.attributeId = b.attributeId;
   }
 
   public static Builder builder() {
@@ -51,6 +64,7 @@ public class ScimSamlId {
 
     private String idpId;
     private String userId;
+    private String attributeId = Saml2Attribute.epuid.getAttributeName();
 
     public Builder idpId(String idpId) {
 
@@ -64,6 +78,11 @@ public class ScimSamlId {
       return this;
     }
 
+    public Builder attributeId(String attributeId){
+      this.attributeId = attributeId;
+      return this;
+    }
+    
     public ScimSamlId build() {
 
       return new ScimSamlId(this);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimUser.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimUser.java
@@ -60,6 +60,7 @@ public class ScimUser extends ScimResource {
 
   private final Set<ScimGroupRef> groups;
 
+  @Valid
   private final ScimIndigoUser indigoUser;
 
   @JsonCreator

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/provisioning/ScimUserProvisioning.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/provisioning/ScimUserProvisioning.java
@@ -282,7 +282,8 @@ public class ScimUserProvisioning
     Preconditions.checkNotNull(samlId);
     Preconditions.checkNotNull(samlId.getIdpId());
     Preconditions.checkNotNull(samlId.getUserId());
-    accountRepository.findBySamlId(samlId.getIdpId(), samlId.getUserId()).ifPresent(account -> {
+    Preconditions.checkNotNull(samlId.getAttributeId());
+    accountRepository.findBySamlId(samlId).ifPresent(account -> {
       throw new ScimResourceExistsException(
           String.format("SAML id (%s,%s) already bounded to another user", samlId.getIdpId(),
               samlId.getUserId()));

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/updater/builders/Adders.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/updater/builders/Adders.java
@@ -138,7 +138,7 @@ public class Adders extends Replacers {
     super(repo, encoder, account);
 
     findByOidcId = id -> repo.findByOidcId(id.getIssuer(), id.getSubject());
-    findBySamlId = id -> repo.findBySamlId(id.getIdpId(), id.getUserId());
+    findBySamlId = id -> repo.findBySamlId(id);
     findBySshKey = key -> repo.findBySshKeyValue(key.getValue());
     findByX509Certificate = cert -> repo.findByCertificate(cert.getCertificate());
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/updater/util/IdNotBoundChecker.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/updater/util/IdNotBoundChecker.java
@@ -2,6 +2,7 @@ package it.infn.mw.iam.api.scim.updater.util;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 
@@ -27,7 +28,10 @@ public class IdNotBoundChecker<T> implements Predicate<T> {
   public boolean test(T id) {
     checkNotNull(id);
 
-    finder.find(id).ifPresent(otherAccount -> {
+    Optional<IamAccount> a = finder.find(id);
+    
+    a.ifPresent(otherAccount -> {
+      System.out.println();
       if (!otherAccount.equals(account)) {
         action.accept(id, account);
       }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/AbstractExternalAuthenticationToken.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/AbstractExternalAuthenticationToken.java
@@ -41,6 +41,6 @@ public abstract class AbstractExternalAuthenticationToken<T>
 
   public abstract void linkToIamAccount(ExternalAccountLinker visitor, IamAccount account);
 
-  public abstract ExternalAuthenticationRegistrationInfo toExernalAuthenticationInfo();
+  public abstract ExternalAuthenticationRegistrationInfo toExernalAuthenticationRegistrationInfo();
 
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/DefaultExternalAuthenticationInfoBuilder.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/DefaultExternalAuthenticationInfoBuilder.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 
 import it.infn.mw.iam.authn.oidc.OidcExternalAuthenticationToken;
 import it.infn.mw.iam.authn.saml.SamlExternalAuthenticationToken;
-import it.infn.mw.iam.authn.saml.util.SamlIdResolvers;
+import it.infn.mw.iam.authn.saml.util.Saml2Attribute;
 
 @Component
 public class DefaultExternalAuthenticationInfoBuilder implements ExternalAuthenticationInfoBuilder {
@@ -40,16 +40,14 @@ public class DefaultExternalAuthenticationInfoBuilder implements ExternalAuthent
     result.put(TYPE_ATTR, SAML_TYPE);
 
     SAMLCredential cred = (SAMLCredential) token.getExternalAuthentication().getCredentials();
+    
     result.put("idpEntityId", cred.getRemoteEntityID());
 
-    // EPUID
-    if (cred.getAttributeAsString(SamlIdResolvers.EPUID_NAME) != null) {
-      result.put("epuid", cred.getAttributeAsString(SamlIdResolvers.EPUID_NAME));
-    }
-
-    // EPPN
-    if (cred.getAttributeAsString(SamlIdResolvers.EPPN_NAME) != null) {
-      result.put("eppn", cred.getAttributeAsString(SamlIdResolvers.EPPN_NAME));
+    for (Saml2Attribute attr: Saml2Attribute.values()){
+      String attrVal = cred.getAttributeAsString(attr.getAttributeName()); 
+      if ( attrVal != null) {
+        result.put(attr.name(), attrVal);
+      }
     }
 
     return result;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/ExternalAuthenticationRegistrationInfo.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/ExternalAuthenticationRegistrationInfo.java
@@ -14,6 +14,7 @@ public class ExternalAuthenticationRegistrationInfo {
 
   private String issuer;
   private String subject;
+  private String subjectAttribute;
 
   private String email;
 
@@ -27,6 +28,7 @@ public class ExternalAuthenticationRegistrationInfo {
   @JsonCreator
   public ExternalAuthenticationRegistrationInfo(@JsonProperty("type") String type,
       @JsonProperty("issuer") String issuer, @JsonProperty("subject") String subject,
+      @JsonProperty("subject_attribute") String subjectAttribute,
       @JsonProperty("email") String email, @JsonProperty("given_name") String givenName,
       @JsonProperty("family_name") String familyName) {
 
@@ -36,6 +38,7 @@ public class ExternalAuthenticationRegistrationInfo {
     this.email = email;
     this.givenName = givenName;
     this.familyName = familyName;
+    this.subjectAttribute = subjectAttribute;
   }
 
   public ExternalAuthenticationType getType() {
@@ -82,5 +85,14 @@ public class ExternalAuthenticationRegistrationInfo {
 
   public void setFamilyName(String familyName) {
     this.familyName = familyName;
+  }
+
+  @JsonProperty("subject_attribute")
+  public String getSubjectAttribute() {
+    return subjectAttribute;
+  }
+
+  public void setSubjectAttribute(String subjectAttribute) {
+    this.subjectAttribute = subjectAttribute;
   }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/oidc/OidcExternalAuthenticationToken.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/oidc/OidcExternalAuthenticationToken.java
@@ -36,7 +36,7 @@ public class OidcExternalAuthenticationToken
   }
 
   @Override
-  public ExternalAuthenticationRegistrationInfo toExernalAuthenticationInfo() {
+  public ExternalAuthenticationRegistrationInfo toExernalAuthenticationRegistrationInfo() {
 
     ExternalAuthenticationRegistrationInfo ri =
 	new ExternalAuthenticationRegistrationInfo(ExternalAuthenticationType.OIDC);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/IamSamlAuthenticationProvider.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/IamSamlAuthenticationProvider.java
@@ -1,12 +1,23 @@
 package it.infn.mw.iam.authn.saml;
 
+import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.providers.ExpiringUsernameAuthenticationToken;
 import org.springframework.security.saml.SAMLAuthenticationProvider;
+import org.springframework.security.saml.SAMLCredential;
+
+import it.infn.mw.iam.authn.saml.util.SamlUserIdentifierResolver;
+import it.infn.mw.iam.persistence.model.IamSamlId;
 
 public class IamSamlAuthenticationProvider extends SAMLAuthenticationProvider {
+
+  final SamlUserIdentifierResolver userIdResolver;
+
+  public IamSamlAuthenticationProvider(SamlUserIdentifierResolver resolver) {
+    this.userIdResolver = resolver;
+  }
 
   @Override
   public Authentication authenticate(Authentication authentication) throws AuthenticationException {
@@ -20,8 +31,14 @@ public class IamSamlAuthenticationProvider extends SAMLAuthenticationProvider {
 
     User user = (User) token.getDetails();
 
+    SAMLCredential samlCredentials = (SAMLCredential) token.getCredentials();
+
+    IamSamlId samlId = userIdResolver.getSamlUserIdentifier(samlCredentials)
+      .orElseThrow(() -> new AuthenticationServiceException(
+          "Could not resolve user identifier from SAML assertion"));
+
     SamlExternalAuthenticationToken extAuthnToken =
-        new SamlExternalAuthenticationToken(token, token.getTokenExpiration(), user.getUsername(),
+        new SamlExternalAuthenticationToken(samlId, token, token.getTokenExpiration(), user.getUsername(),
             token.getCredentials(), token.getAuthorities());
 
     return extAuthnToken;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/AbstractSamlUserIdentifierResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/AbstractSamlUserIdentifierResolver.java
@@ -1,0 +1,17 @@
+package it.infn.mw.iam.authn.saml.util;
+
+public abstract class AbstractSamlUserIdentifierResolver
+    implements NamedSamlUserIdentifierResolver {
+
+  private final String name;
+  
+  public AbstractSamlUserIdentifierResolver(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/AttributeUserIdentifierResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/AttributeUserIdentifierResolver.java
@@ -4,6 +4,8 @@ import java.util.Optional;
 
 import org.springframework.security.saml.SAMLCredential;
 
+import it.infn.mw.iam.persistence.model.IamSamlId;
+
 public class AttributeUserIdentifierResolver extends AbstractSamlUserIdentifierResolver {
 
   Saml2Attribute attribute;
@@ -14,9 +16,21 @@ public class AttributeUserIdentifierResolver extends AbstractSamlUserIdentifierR
   }
 
   @Override
-  public Optional<String> getUserIdentifier(SAMLCredential samlCredential) {
+  public Optional<IamSamlId> getSamlUserIdentifier(SAMLCredential samlCredential) {
 
-    return Optional.ofNullable(samlCredential.getAttributeAsString(attribute.getAttributeName()));
+    String attributeValue = samlCredential.getAttributeAsString(attribute.getAttributeName());
+
+    if (attributeValue == null) {
+      return Optional.empty();
+    }
+
+    IamSamlId samlId = new IamSamlId();
+    samlId.setIdpId(samlCredential.getRemoteEntityID());
+    samlId.setAttributeId(attribute.getAttributeName());
+    samlId.setUserId(attributeValue);
+
+    return Optional.of(samlId);
+
   }
 
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/AttributeUserIdentifierResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/AttributeUserIdentifierResolver.java
@@ -4,19 +4,19 @@ import java.util.Optional;
 
 import org.springframework.security.saml.SAMLCredential;
 
-public class AttributeUserIdentifierResolver implements SamlUserIdentifierResolver {
+public class AttributeUserIdentifierResolver extends AbstractSamlUserIdentifierResolver {
 
-  private final String attributeName;
+  Saml2Attribute attribute;
 
-  public AttributeUserIdentifierResolver(String attributeName) {
-    this.attributeName = attributeName;
+  public AttributeUserIdentifierResolver(Saml2Attribute attribute) {
+    super(attribute.name());
+    this.attribute = attribute;
   }
 
   @Override
   public Optional<String> getUserIdentifier(SAMLCredential samlCredential) {
-    
-    return Optional.ofNullable(samlCredential.getAttributeAsString(attributeName));
-    
+
+    return Optional.ofNullable(samlCredential.getAttributeAsString(attribute.getAttributeName()));
   }
 
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/FirstApplicableChainedSamlIdResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/FirstApplicableChainedSamlIdResolver.java
@@ -7,6 +7,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.saml.SAMLCredential;
 
+import it.infn.mw.iam.persistence.model.IamSamlId;
+
 public class FirstApplicableChainedSamlIdResolver implements SamlUserIdentifierResolver {
 
   public static final Logger LOG = LoggerFactory.getLogger(FirstApplicableChainedSamlIdResolver.class);
@@ -18,17 +20,17 @@ public class FirstApplicableChainedSamlIdResolver implements SamlUserIdentifierR
   }
 
   @Override
-  public Optional<String> getUserIdentifier(SAMLCredential samlCredential) {
+  public Optional<IamSamlId> getSamlUserIdentifier(SAMLCredential samlCredential) {
 
     for (SamlUserIdentifierResolver resolver : resolvers) {
       LOG.debug("Attempting SAML user id resolution with resolver {}",
           resolver.getClass().getName());
 
-      Optional<String> userId = resolver.getUserIdentifier(samlCredential);
+      Optional<IamSamlId> userId = resolver.getSamlUserIdentifier(samlCredential);
 
       if (userId.isPresent()) {
 
-        LOG.debug("Resolved user id: {}", userId);
+        LOG.debug("Resolved SAML user id: {}", userId);
         return userId;
       }
     }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/NameIdUserIdentifierResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/NameIdUserIdentifierResolver.java
@@ -7,6 +7,8 @@ import org.springframework.security.saml.SAMLCredential;
 
 import com.google.common.base.Verify;
 
+import it.infn.mw.iam.persistence.model.IamSamlId;
+
 public class NameIdUserIdentifierResolver extends AbstractSamlUserIdentifierResolver{
 
   public static final String NAMEID_RESOLVER = "nameID";
@@ -16,13 +18,19 @@ public class NameIdUserIdentifierResolver extends AbstractSamlUserIdentifierReso
   }
 
   @Override
-  public Optional<String> getUserIdentifier(SAMLCredential samlCredential) {
+  public Optional<IamSamlId> getSamlUserIdentifier(SAMLCredential samlCredential) {
 
     Verify.verifyNotNull(samlCredential);
 
     if (samlCredential.getNameID() != null) {
       NameID nameId = samlCredential.getNameID();
-      return Optional.of(nameId.getValue());
+      
+      IamSamlId samlId = new IamSamlId();
+      samlId.setAttributeId(nameId.getFormat());
+      samlId.setUserId(nameId.getValue());
+      samlId.setIdpId(samlCredential.getRemoteEntityID());
+      
+      return Optional.of(samlId);
 
     }
     

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/NameIdUserIdentifierResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/NameIdUserIdentifierResolver.java
@@ -7,7 +7,13 @@ import org.springframework.security.saml.SAMLCredential;
 
 import com.google.common.base.Verify;
 
-public class NameIdUserIdentifierResolver implements SamlUserIdentifierResolver {
+public class NameIdUserIdentifierResolver extends AbstractSamlUserIdentifierResolver{
+
+  public static final String NAMEID_RESOLVER = "nameID";
+  
+  public NameIdUserIdentifierResolver() {
+    super(NAMEID_RESOLVER);
+  }
 
   @Override
   public Optional<String> getUserIdentifier(SAMLCredential samlCredential) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/NamedSamlUserIdentifierResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/NamedSamlUserIdentifierResolver.java
@@ -1,0 +1,7 @@
+package it.infn.mw.iam.authn.saml.util;
+
+public interface NamedSamlUserIdentifierResolver extends SamlUserIdentifierResolver {
+
+  public String getName();
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/Saml2Attribute.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/Saml2Attribute.java
@@ -4,6 +4,7 @@ public enum Saml2Attribute {
 
   epuid("eduPersonUniqueId", "urn:oid:1.3.6.1.4.1.5923.1.1.1.13"),
   eppn("eduPersonPrincipalName", "urn:oid:1.3.6.1.4.1.5923.1.1.1.6"),
+  eduPersonOrcid("eduPersonOrcid", "urn:oid:1.3.6.1.4.1.5923.1.1.1.16"),
   mail("mail", "urn:oid:0.9.2342.19200300.100.1.3"),
   givenName("givenName", "urn:oid:2.5.4.42"),
   sn("sn", "urn:oid:2.5.4.4"),

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/Saml2Attribute.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/Saml2Attribute.java
@@ -1,0 +1,29 @@
+package it.infn.mw.iam.authn.saml.util;
+
+public enum Saml2Attribute {
+
+  epuid("eduPersonUniqueId", "urn:oid:1.3.6.1.4.1.5923.1.1.1.13"),
+  eppn("eduPersonPrincipalName", "urn:oid:1.3.6.1.4.1.5923.1.1.1.6"),
+  mail("mail", "urn:oid:0.9.2342.19200300.100.1.3"),
+  givenName("givenName", "urn:oid:2.5.4.42"),
+  sn("sn", "urn:oid:2.5.4.4"),
+  employeeNumber("employeeNumber", "urn:oid:2.16.840.1.113730.3.1.3"),
+  spidCode("spidCode", "spidCode");
+
+  private Saml2Attribute(String alias, String attributeName) {
+    this.alias = alias;
+    this.attributeName = attributeName;
+  }
+
+  private String alias;
+  private String attributeName;
+
+  public String getAlias() {
+    return alias;
+  }
+
+  public String getAttributeName() {
+    return attributeName;
+  }
+  
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/Saml2Attribute.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/Saml2Attribute.java
@@ -7,6 +7,7 @@ public enum Saml2Attribute {
   mail("mail", "urn:oid:0.9.2342.19200300.100.1.3"),
   givenName("givenName", "urn:oid:2.5.4.42"),
   sn("sn", "urn:oid:2.5.4.4"),
+  cn("cn", "urn:oid:2.5.4.3"),
   employeeNumber("employeeNumber", "urn:oid:2.16.840.1.113730.3.1.3"),
   spidCode("spidCode", "spidCode");
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/SamlIdResolvers.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/SamlIdResolvers.java
@@ -1,26 +1,33 @@
 package it.infn.mw.iam.authn.saml.util;
 
+import com.google.common.collect.ImmutableMap;
+
 public class SamlIdResolvers {
 
-  public static final String EPUID_NAME = "urn:oid:1.3.6.1.4.1.5923.1.1.1.13";
-  public static final String EPPN_NAME = "urn:oid:1.3.6.1.4.1.5923.1.1.1.6";
-  public static final String MAIL_NAME = "urn:oid:0.9.2342.19200300.100.1.3";
+  public static final String NAME_ID_NAME = "nameID";
+  
+  private ImmutableMap<String, SamlUserIdentifierResolver> registeredResolvers;
 
-  private SamlIdResolvers() {}
+  public SamlIdResolvers() {
+    ImmutableMap.Builder<String, SamlUserIdentifierResolver> builder =
+        ImmutableMap.<String, SamlUserIdentifierResolver>builder();
 
-  public static SamlUserIdentifierResolver epuid() {
-    return new AttributeUserIdentifierResolver(EPUID_NAME);
+    for (Saml2Attribute a : Saml2Attribute.values()) {
+      builder.put(a.name(), new AttributeUserIdentifierResolver(a));
+    }
+
+    builder.put(NAME_ID_NAME, new NameIdUserIdentifierResolver());
+
+    registeredResolvers = builder.build();
   }
 
-  public static SamlUserIdentifierResolver eppn() {
-    return new AttributeUserIdentifierResolver(EPPN_NAME);
+  public SamlUserIdentifierResolver byAttribute(Saml2Attribute attribute) {
+    return registeredResolvers.get(attribute.name());
+  }
+  
+  public SamlUserIdentifierResolver byName(String name) {
+    return registeredResolvers.get(name);
   }
 
-  public static SamlUserIdentifierResolver mail() {
-    return new AttributeUserIdentifierResolver(MAIL_NAME);
-  }
 
-  public static SamlUserIdentifierResolver nameid() {
-    return new NameIdUserIdentifierResolver();
-  }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/SamlUserIdentifierResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/SamlUserIdentifierResolver.java
@@ -5,7 +5,5 @@ import java.util.Optional;
 import org.springframework.security.saml.SAMLCredential;
 
 public interface SamlUserIdentifierResolver {
-
   public Optional<String> getUserIdentifier(SAMLCredential samlCredential);
-
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/SamlUserIdentifierResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/SamlUserIdentifierResolver.java
@@ -4,6 +4,8 @@ import java.util.Optional;
 
 import org.springframework.security.saml.SAMLCredential;
 
+import it.infn.mw.iam.persistence.model.IamSamlId;
+
 public interface SamlUserIdentifierResolver {
-  public Optional<String> getUserIdentifier(SAMLCredential samlCredential);
+  public Optional<IamSamlId> getSamlUserIdentifier(SAMLCredential samlCredential);
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/JpaConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/JpaConfig.java
@@ -43,9 +43,9 @@ public class JpaConfig extends JpaBaseConfiguration {
     map.put("eclipselink.logging.level.sql", "OFF");
     map.put("eclipselink.cache.shared.default", "false");
 
-    // map.put("eclipselink.ddl-generation.output-mode", "sql-script");
-    // map.put("eclipselink.ddl-generation", "create-tables");
-    // map.put("eclipselink.create-ddl-jdbc-file-name", "ddl.sql");
+    map.put("eclipselink.ddl-generation.output-mode", "sql-script");
+    map.put("eclipselink.ddl-generation", "create-tables");
+    map.put("eclipselink.create-ddl-jdbc-file-name", "ddl.sql");
 
     return map;
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/JpaConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/JpaConfig.java
@@ -43,9 +43,9 @@ public class JpaConfig extends JpaBaseConfiguration {
     map.put("eclipselink.logging.level.sql", "OFF");
     map.put("eclipselink.cache.shared.default", "false");
 
-    map.put("eclipselink.ddl-generation.output-mode", "sql-script");
-    map.put("eclipselink.ddl-generation", "create-tables");
-    map.put("eclipselink.create-ddl-jdbc-file-name", "ddl.sql");
+//    map.put("eclipselink.ddl-generation.output-mode", "sql-script");
+//    map.put("eclipselink.ddl-generation", "create-tables");
+//    map.put("eclipselink.create-ddl-jdbc-file-name", "ddl.sql");
 
     return map;
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/MitreConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/MitreConfig.java
@@ -38,7 +38,13 @@ public class MitreConfig {
     }
 
     config.setIssuer(issuer);
-    config.setRegTokenLifeTime(tokenLifeTime);
+    
+    if (tokenLifeTime <= 0L){
+      config.setRegTokenLifeTime(null);
+    } else {
+      config.setRegTokenLifeTime(tokenLifeTime);
+    }
+    
     config.setForceHttps(false);
     config.setLocale(Locale.ENGLISH);
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/saml/IamSamlProperties.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/saml/IamSamlProperties.java
@@ -11,6 +11,7 @@ public class IamSamlProperties {
   private String keystorePassword;
   private String keyId;
   private String keyPassword;
+  private String idResolvers;
 
   private int maxAssertionTimeSec;
 
@@ -80,6 +81,14 @@ public class IamSamlProperties {
 
   public void setMaxAuthenticationAgeSec(int maxAuthenticationAgeSec) {
     this.maxAuthenticationAgeSec = maxAuthenticationAgeSec;
+  }
+
+  public String getIdResolvers() {
+    return idResolvers;
+  }
+
+  public void setIdResolvers(String idResolvers) {
+    this.idResolvers = idResolvers;
   }
 
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/saml/SamlConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/saml/SamlConfig.java
@@ -261,7 +261,7 @@ public class SamlConfig extends WebSecurityConfigurerAdapter {
   public SAMLAuthenticationProvider samlAuthenticationProvider(SamlUserIdentifierResolver resolver,
       IamAccountRepository accountRepo, InactiveAccountAuthenticationHander handler) {
 
-    IamSamlAuthenticationProvider samlAuthenticationProvider = new IamSamlAuthenticationProvider();
+    IamSamlAuthenticationProvider samlAuthenticationProvider = new IamSamlAuthenticationProvider(resolver);
     samlAuthenticationProvider
       .setUserDetails(samlUserDetailsService(resolver, accountRepo, handler));
     samlAuthenticationProvider.setForcePrincipalAsString(false);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/registration/DefaultRegistrationRequestService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/registration/DefaultRegistrationRequestService.java
@@ -98,6 +98,7 @@ public class DefaultRegistrationRequestService
     } else if (ExternalAuthenticationType.SAML.equals(extAuthnInfo.getType())) {
       ScimSamlId samlId = new ScimSamlId.Builder().idpId(extAuthnInfo.getIssuer())
         .userId(extAuthnInfo.getSubject())
+        .attributeId(extAuthnInfo.getSubjectAttribute())
         .build();
       user.addSamlId(samlId);
     }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/registration/RegistrationController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/registration/RegistrationController.java
@@ -43,7 +43,7 @@ public class RegistrationController {
     if (authn instanceof AbstractExternalAuthenticationToken<?>) {
 
       return Optional
-        .of(((AbstractExternalAuthenticationToken<?>) authn).toExernalAuthenticationInfo());
+        .of(((AbstractExternalAuthenticationToken<?>) authn).toExernalAuthenticationRegistrationInfo());
     }
 
     return Optional.empty();

--- a/iam-login-service/src/main/resources/application-saml.yml
+++ b/iam-login-service/src/main/resources/application-saml.yml
@@ -7,3 +7,4 @@ saml:
   idp-metadata: ${IAM_SAML_IDP_METADATA:classpath:/saml/idp-metadata.xml}
   max-assertion-time-sec: ${IAM_SAML_MAX_ASSERTION_TIME:3000}
   max-authentication-age-sec: ${IAM_SAML_MAX_AUTHENTICATION_AGE:86400}
+  id-resolvers: ${IAM_SAML_ID_RESOLVERS:epuid,eppn}

--- a/iam-login-service/src/main/webapp/resources/iam/js/dashboard-app/components/user/saml/user.saml.component.html
+++ b/iam-login-service/src/main/webapp/resources/iam/js/dashboard-app/components/user/saml/user.saml.component.html
@@ -13,14 +13,17 @@
             <table class="table no-margin" id="saml_account_list">
                 <thead>
                     <tr>
-                        <th>Identity Provider ID</th>
-                        <th>User ID</th>
+                        <th>IdP Entity ID</th>
+                        <th>Attribute</th>
+                        <th>Attribute Value</th>
+
                         <th class="text-right"></th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr ng-repeat="samlId in $ctrl.getSamlIds()">
                         <td>{{ samlId.idpId }}</td>
+                        <td>{{ samlId.attributeId }}</td>
                         <td>{{ samlId.userId }}</td>
                         <td class="text-right">
                             <div class="btn-group">

--- a/iam-login-service/src/main/webapp/resources/iam/js/dashboard-app/components/user/saml/user.saml.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/js/dashboard-app/components/user/saml/user.saml.component.js
@@ -106,7 +106,7 @@
     };
 
     self.openRemoveSamlAccountDialog = function(samlId) {
-      var account = `${samlId.idpId} : ${samlId.userId}`;
+      var account = `${samlId.idpId} ${samlId.attributeId} = ${samlId.userId}`;
 
       var modalOptions = {
         closeButtonText: 'Cancel',

--- a/iam-login-service/src/main/webapp/resources/iam/js/dashboard-app/controllers/add-user-saml-account.controller.js
+++ b/iam-login-service/src/main/webapp/resources/iam/js/dashboard-app/controllers/add-user-saml-account.controller.js
@@ -19,13 +19,15 @@ function AddSamlAccountController($scope, $uibModalInstance, scimFactory, Utils,
 
 		addSamlAccountCtrl.idpId = "";
 		addSamlAccountCtrl.userId = "";
+		addSamlAccountCtrl.attributeId = "";
 		addSamlAccountCtrl.enabled = true;
 	};
 	
 	function addSamlAccount() {
 
 		addSamlAccountCtrl.enabled = false;
-		scimFactory.addSamlId(addSamlAccountCtrl.user.id, addSamlAccountCtrl.idpId, addSamlAccountCtrl.userId).then(function(response) {
+		scimFactory.addSamlId(addSamlAccountCtrl.user.id, addSamlAccountCtrl.idpId,		
+			addSamlAccountCtrl.attributeId, addSamlAccountCtrl.userId).then(function(response) {
 			$uibModalInstance.close(response.data);
 			addSamlAccountCtrl.enabled = true;
 		},function(error) {

--- a/iam-login-service/src/main/webapp/resources/iam/js/dashboard-app/dashboard-app.module.js
+++ b/iam-login-service/src/main/webapp/resources/iam/js/dashboard-app/dashboard-app.module.js
@@ -16,7 +16,7 @@ angular.module('dashboardApp')
       $rootScope.iamVersion = getIamVersion();
       $rootScope.iamCommitId = getIamGitCommitId();
       
-      LoadTemplatesService.loadTemplates();
+      // LoadTemplatesService.loadTemplates();
 
       $trace.enable('TRANSITION');
 

--- a/iam-login-service/src/main/webapp/resources/iam/js/dashboard-app/dashboard-app.module.js
+++ b/iam-login-service/src/main/webapp/resources/iam/js/dashboard-app/dashboard-app.module.js
@@ -16,7 +16,7 @@ angular.module('dashboardApp')
       $rootScope.iamVersion = getIamVersion();
       $rootScope.iamCommitId = getIamGitCommitId();
       
-      // LoadTemplatesService.loadTemplates();
+      LoadTemplatesService.loadTemplates();
 
       $trace.enable('TRANSITION');
 

--- a/iam-login-service/src/main/webapp/resources/iam/js/dashboard-app/services/scim-factory.service.js
+++ b/iam-login-service/src/main/webapp/resources/iam/js/dashboard-app/services/scim-factory.service.js
@@ -332,9 +332,9 @@ angular.module('dashboardApp').factory("scimFactory", [ '$http', '$httpParamSeri
 		return $http.patch(url, data, config);
 	};
 	
-	function addSamlId(userId, samlIdpId, samlUserId) {
+	function addSamlId(userId, samlIdpId, samlAttributeId, samlUserId) {
 		
-		console.info("Patch user-id, add saml-account ", userId, samlIdpId, samlUserId);
+		console.info("Patch user-id, add saml-account ", userId, samlIdpId, samlAttributeId, samlUserId);
 		
 		var config = {
 				headers: { 'Content-Type': 'application/scim+json' }
@@ -347,6 +347,7 @@ angular.module('dashboardApp').factory("scimFactory", [ '$http', '$httpParamSeri
 						"urn:indigo-dc:scim:schemas:IndigoUser": {
 							samlIds: [{
 								"idpId": samlIdpId,
+								"attributeId": samlAttributeId,
 								"userId": samlUserId
 								}
 							]
@@ -374,6 +375,7 @@ angular.module('dashboardApp').factory("scimFactory", [ '$http', '$httpParamSeri
 						"urn:indigo-dc:scim:schemas:IndigoUser": {
 							samlIds: [{
 								"idpId": samlId.idpId,
+								"attributeId": samlId.attributeId,
 								"userId": samlId.userId
 								}
 							]

--- a/iam-login-service/src/main/webapp/resources/iam/template/dashboard/user/addsamlaccount.html
+++ b/iam-login-service/src/main/webapp/resources/iam/template/dashboard/user/addsamlaccount.html
@@ -4,12 +4,25 @@
 <div class="modal-body">
 
     <div class="form-group">
-        <label>Identity Provider</label>
+        <label>Idp Entity Id</label>
         <input id="idp" class="form-control" type="text" placeholder="Saml ID Identity Provider ..." ng-model="addSamlAccountCtrl.idpId">
     </div>
+
     <div class="form-group">
-        <label>User ID</label>
-        <input id="userid" class="form-control" type="text" placeholder="Saml ID User id ..." ng-model="addSamlAccountCtrl.userId">
+        <label>Attribute Id</label>
+        <select id="attributeId" name="attributeId" class="form-control" 
+            ng-model="addSamlAccountCtrl.attributeId">
+            <option value="urn:oid:1.3.6.1.4.1.5923.1.1.1.13">eduPersonUniqueId</option>
+            <option value="urn:oid:1.3.6.1.4.1.5923.1.1.1.6">eduPersonPrincipalName</option>
+            <option value="urn:oid:2.16.840.1.113730.3.1.3">employeeNumber</option>
+            <option value="urn:oid:1.3.6.1.4.1.5923.1.1.1.16">eduPersonOrcid</option>
+            <option value="spidCode">spidCode</option>
+        </select>
+    </div>
+
+    <div class="form-group">
+        <label>Attribute Value</label>
+        <input id="userid" class="form-control" type="text" placeholder="Saml attribute value ..." ng-model="addSamlAccountCtrl.userId">
     </div>
 
     <div class="row">
@@ -21,7 +34,7 @@
 </div>
 <div class="modal-footer">
 	<button class="btn btn-primary" type="button" id="modal-btn-confirm"
-	   ng-disabled="!addSamlAccountCtrl.idpId ||  !addSamlAccountCtrl.userId || !addSamlAccountCtrl.enabled"
+	   ng-disabled="!addSamlAccountCtrl.idpId ||  !addSamlAccountCtrl.userId || !addSamlAccountCtrl.attributeId || !addSamlAccountCtrl.enabled"
 	   ng-click="addSamlAccountCtrl.addSamlAccount()">Add Account</button>
 	<button class="btn btn-danger" type="button" id="modal-btn-cancel"
 		ng-click="addSamlAccountCtrl.cancel()">Cancel</button>

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/ExternalAuthenticationBuilderTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/ExternalAuthenticationBuilderTests.java
@@ -3,6 +3,8 @@ package it.infn.mw.iam.test.ext_authn;
 import static it.infn.mw.iam.authn.DefaultExternalAuthenticationInfoBuilder.OIDC_TYPE;
 import static it.infn.mw.iam.authn.DefaultExternalAuthenticationInfoBuilder.SAML_TYPE;
 import static it.infn.mw.iam.authn.DefaultExternalAuthenticationInfoBuilder.TYPE_ATTR;
+import static it.infn.mw.iam.authn.saml.util.Saml2Attribute.eppn;
+import static it.infn.mw.iam.authn.saml.util.Saml2Attribute.epuid;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -18,7 +20,6 @@ import org.springframework.security.saml.SAMLCredential;
 import it.infn.mw.iam.authn.DefaultExternalAuthenticationInfoBuilder;
 import it.infn.mw.iam.authn.oidc.OidcExternalAuthenticationToken;
 import it.infn.mw.iam.authn.saml.SamlExternalAuthenticationToken;
-import it.infn.mw.iam.authn.saml.util.SamlIdResolvers;
 
 public class ExternalAuthenticationBuilderTests {
 
@@ -53,8 +54,8 @@ public class ExternalAuthenticationBuilderTests {
     when(mockToken.getExternalAuthentication()).thenReturn(token);
     when(token.getCredentials()).thenReturn(cred);
     when(cred.getRemoteEntityID()).thenReturn("idpId");
-    when(cred.getAttributeAsString(SamlIdResolvers.EPUID_NAME)).thenReturn("epuid");
-    when(cred.getAttributeAsString(SamlIdResolvers.EPPN_NAME)).thenReturn("eppn");
+    when(cred.getAttributeAsString(epuid.getAttributeName())).thenReturn("epuid");
+    when(cred.getAttributeAsString(eppn.getAttributeName())).thenReturn("eppn");
 
     Map<String, String> infoMap = builder.buildInfoMap(mockToken);
     assertThat(infoMap.get(TYPE_ATTR), Matchers.equalTo(SAML_TYPE));

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/account_linking/AccountUnlinkTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/account_linking/AccountUnlinkTests.java
@@ -1,5 +1,6 @@
 package it.infn.mw.iam.test.ext_authn.account_linking;
 
+import static it.infn.mw.iam.authn.saml.util.Saml2Attribute.epuid;
 import static it.infn.mw.iam.test.ext_authn.saml.SamlExternalAuthenticationTestSupport.DEFAULT_IDP_ID;
 import static it.infn.mw.iam.test.ext_authn.saml.SamlExternalAuthenticationTestSupport.T2_EPUID;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -50,6 +51,8 @@ public class AccountUnlinkTests {
   private IamAccountRepository iamAccountRepo;
 
   private MockMvc mvc;
+  
+  public static final String SAML_ATTRIBUTE_ID = epuid.getAttributeName();
 
   public static final String UNLINKED_ISSUER = UUID.randomUUID().toString();
   public static final String UNLINKED_SUBJECT = UUID.randomUUID().toString();
@@ -60,11 +63,14 @@ public class AccountUnlinkTests {
   public static final String SAML_LINKED_ISSUER = DEFAULT_IDP_ID;
   public static final String SAML_LINKED_SUBJECT = T2_EPUID;
 
-  public static final IamSamlId UNLINKED_SAML_ID = new IamSamlId(UNLINKED_ISSUER, UNLINKED_SUBJECT);
-  public static final IamOidcId UNLINKED_OIDC_ID = new IamOidcId(UNLINKED_ISSUER, UNLINKED_SUBJECT);
+  public static final IamSamlId UNLINKED_SAML_ID = new IamSamlId(UNLINKED_ISSUER, 
+      SAML_ATTRIBUTE_ID, UNLINKED_SUBJECT);
+  
+  public static final IamOidcId UNLINKED_OIDC_ID = new IamOidcId(UNLINKED_ISSUER, 
+      UNLINKED_SUBJECT);
 
   public static final IamSamlId LINKED_SAML_ID =
-      new IamSamlId(SAML_LINKED_ISSUER, SAML_LINKED_SUBJECT);
+      new IamSamlId(SAML_LINKED_ISSUER, SAML_ATTRIBUTE_ID, SAML_LINKED_SUBJECT);
 
   public static final IamOidcId LINKED_OIDC_ID =
       new IamOidcId(OIDC_LINKED_ISSUER, OIDC_LINKED_SUBJECT);
@@ -186,6 +192,7 @@ public class AccountUnlinkTests {
     mvc
       .perform(delete(accountLinkingResourceSaml()).param("iss", SAML_LINKED_ISSUER)
         .param("sub", SAML_LINKED_SUBJECT)
+        .param("attr", LINKED_SAML_ID.getAttributeId())
         .with(csrf().asHeader()))
       .andDo(print()).andExpect(status().isNoContent());
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/account_linking/SamlAccountLinkingTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/account_linking/SamlAccountLinkingTests.java
@@ -5,6 +5,7 @@ import static it.infn.mw.iam.authn.ExternalAuthenticationHandlerSupport.ACCOUNT_
 import static it.infn.mw.iam.authn.ExternalAuthenticationHandlerSupport.ACCOUNT_LINKING_SESSION_KEY;
 import static it.infn.mw.iam.authn.ExternalAuthenticationHandlerSupport.ACCOUNT_LINKING_SESSION_SAVED_AUTHENTICATION;
 import static it.infn.mw.iam.authn.ExternalAuthenticationHandlerSupport.EXT_AUTH_ERROR_KEY;
+import static it.infn.mw.iam.authn.saml.util.Saml2Attribute.epuid;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -38,6 +39,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 import it.infn.mw.iam.IamLoginService;
 import it.infn.mw.iam.persistence.model.IamAccount;
+import it.infn.mw.iam.persistence.model.IamSamlId;
 import it.infn.mw.iam.persistence.repository.IamAccountRepository;
 import it.infn.mw.iam.test.ext_authn.saml.SamlExternalAuthenticationTestSupport;
 import it.infn.mw.iam.test.ext_authn.saml.SamlTestConfig;
@@ -108,7 +110,10 @@ public class SamlAccountLinkingTests extends SamlExternalAuthenticationTestSuppo
           request().sessionAttribute(ACCOUNT_LINKING_SESSION_SAVED_AUTHENTICATION, nullValue()))
       .andExpect(request().sessionAttribute(ACCOUNT_LINKING_SESSION_KEY, nullValue()));
 
-    IamAccount account = iamAccountRepo.findBySamlId(DEFAULT_IDP_ID, T1_EPUID)
+    IamSamlId samlId  = new IamSamlId(DEFAULT_IDP_ID, epuid.getAttributeName(),
+        T1_EPUID);
+    
+    IamAccount account = iamAccountRepo.findBySamlId(samlId)
       .orElseThrow(() -> new AssertionError("User not found linked to expected SAML id"));
 
     Assert.assertThat(account.getUsername(), equalTo(TEST_100_USER));
@@ -164,7 +169,9 @@ public class SamlAccountLinkingTests extends SamlExternalAuthenticationTestSuppo
       .getSession();
 
     String expectedErrorMessage = String
-      .format("SAML account '[%s] %s' is already linked to another user", DEFAULT_IDP_ID, T2_EPUID);
+      .format("SAML account '[%s] (%s = %s)' is already linked to another user", DEFAULT_IDP_ID, 
+          epuid.getAttributeName(),
+          T2_EPUID);
 
     mvc.perform(get("/iam/account-linking/SAML/done").session(session))
       .andExpect(status().isFound())
@@ -226,7 +233,9 @@ public class SamlAccountLinkingTests extends SamlExternalAuthenticationTestSuppo
 
 
     String expectedErrorMessage = String
-      .format("SAML account '[%s] %s' is already linked to user 'test'", DEFAULT_IDP_ID, T2_EPUID);
+      .format("SAML account '[%s] (%s = %s)' is already linked to user 'test'", DEFAULT_IDP_ID, 
+          epuid.getAttributeName(),
+          T2_EPUID);
 
     mvc.perform(get("/iam/account-linking/SAML/done").session(session))
       .andExpect(status().isFound())

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/ResolverTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/ResolverTests.java
@@ -9,6 +9,8 @@ import org.mockito.Mockito;
 import org.opensaml.saml2.core.NameID;
 import org.springframework.security.saml.SAMLCredential;
 
+import it.infn.mw.iam.authn.saml.util.NameIdUserIdentifierResolver;
+import it.infn.mw.iam.authn.saml.util.Saml2Attribute;
 import it.infn.mw.iam.authn.saml.util.SamlAttributeNames;
 import it.infn.mw.iam.authn.saml.util.SamlIdResolvers;
 import it.infn.mw.iam.authn.saml.util.SamlUserIdentifierResolver;
@@ -22,7 +24,7 @@ public class ResolverTests {
     SAMLCredential cred = Mockito.mock(SAMLCredential.class);
     Mockito.when(cred.getNameID()).thenReturn(null);
 
-    SamlUserIdentifierResolver resolver = SamlIdResolvers.nameid();
+    SamlUserIdentifierResolver resolver = new NameIdUserIdentifierResolver();
 
     Optional<String> resolvedId = resolver.getUserIdentifier(cred);
 
@@ -38,7 +40,7 @@ public class ResolverTests {
     SAMLCredential cred = Mockito.mock(SAMLCredential.class);
     Mockito.when(cred.getNameID()).thenReturn(nameId);
 
-    SamlUserIdentifierResolver resolver = SamlIdResolvers.nameid();
+    SamlUserIdentifierResolver resolver = new NameIdUserIdentifierResolver();
 
     Optional<String> resolvedId = resolver.getUserIdentifier(cred);
 
@@ -48,7 +50,10 @@ public class ResolverTests {
 
   @Test
   public void mailIdResolverTest() {
-    SamlUserIdentifierResolver resolver = SamlIdResolvers.mail();
+    SamlIdResolvers resolvers = new SamlIdResolvers();
+    
+    SamlUserIdentifierResolver resolver = resolvers.byAttribute(Saml2Attribute.mail);
+    
     SAMLCredential cred = Mockito.mock(SAMLCredential.class);
     Mockito.when(cred.getAttributeAsString(SamlAttributeNames.mail)).thenReturn("test@test.org");
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/ResolverTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/ResolverTests.java
@@ -11,9 +11,9 @@ import org.springframework.security.saml.SAMLCredential;
 
 import it.infn.mw.iam.authn.saml.util.NameIdUserIdentifierResolver;
 import it.infn.mw.iam.authn.saml.util.Saml2Attribute;
-import it.infn.mw.iam.authn.saml.util.SamlAttributeNames;
 import it.infn.mw.iam.authn.saml.util.SamlIdResolvers;
 import it.infn.mw.iam.authn.saml.util.SamlUserIdentifierResolver;
+import it.infn.mw.iam.persistence.model.IamSamlId;
 
 public class ResolverTests {
 
@@ -26,7 +26,7 @@ public class ResolverTests {
 
     SamlUserIdentifierResolver resolver = new NameIdUserIdentifierResolver();
 
-    Optional<String> resolvedId = resolver.getUserIdentifier(cred);
+    Optional<IamSamlId> resolvedId = resolver.getSamlUserIdentifier(cred);
 
     Assert.assertFalse(resolvedId.isPresent());
 
@@ -36,29 +36,42 @@ public class ResolverTests {
   public void nameIdResolverTest() {
     NameID nameId = Mockito.mock(NameID.class);
     Mockito.when(nameId.getValue()).thenReturn("nameid");
+    Mockito.when(nameId.getFormat()).thenReturn("format");
 
     SAMLCredential cred = Mockito.mock(SAMLCredential.class);
     Mockito.when(cred.getNameID()).thenReturn(nameId);
+    Mockito.when(cred.getRemoteEntityID()).thenReturn("entityId");
+
 
     SamlUserIdentifierResolver resolver = new NameIdUserIdentifierResolver();
 
-    Optional<String> resolvedId = resolver.getUserIdentifier(cred);
+    IamSamlId resolvedId = resolver.getSamlUserIdentifier(cred)
+      .orElseThrow(() -> new AssertionError("Could not resolve nameid SAML ID"));
 
-    Assert.assertThat(resolvedId.get(), Matchers.equalTo("nameid"));
-
+    Assert.assertThat(resolvedId.getUserId(), Matchers.equalTo("nameid"));
+    Assert.assertThat(resolvedId.getIdpId(), Matchers.equalTo("entityId"));
+    Assert.assertThat(resolvedId.getAttributeId(), Matchers.equalTo("format"));
   }
 
   @Test
   public void mailIdResolverTest() {
     SamlIdResolvers resolvers = new SamlIdResolvers();
-    
+
     SamlUserIdentifierResolver resolver = resolvers.byAttribute(Saml2Attribute.mail);
-    
+
     SAMLCredential cred = Mockito.mock(SAMLCredential.class);
-    Mockito.when(cred.getAttributeAsString(SamlAttributeNames.mail)).thenReturn("test@test.org");
+    Mockito.when(cred.getAttributeAsString(Saml2Attribute.mail.getAttributeName()))
+      .thenReturn("test@test.org");
+    Mockito.when(cred.getRemoteEntityID()).thenReturn("entityId");
 
-    Optional<String> resolvedId = resolver.getUserIdentifier(cred);
+    IamSamlId resolvedId = resolver.getSamlUserIdentifier(cred)
+      .orElseThrow(() -> new AssertionError("Could not resolve email address SAML ID"));
 
-    Assert.assertThat(resolvedId.get(), Matchers.equalTo("test@test.org"));
+    Assert.assertThat(resolvedId.getUserId(), Matchers.equalTo("test@test.org"));
+    Assert.assertThat(resolvedId.getAttributeId(),
+        Matchers.equalTo(Saml2Attribute.mail.getAttributeName()));
+
+    Assert.assertThat(resolvedId.getIdpId(), Matchers.equalTo("entityId"));
+
   }
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/login/LoginTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/login/LoginTests.java
@@ -1,0 +1,87 @@
+package it.infn.mw.iam.test.login;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import javax.transaction.Transactional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import it.infn.mw.iam.IamLoginService;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = {IamLoginService.class})
+@WebAppConfiguration
+@Transactional
+public class LoginTests {
+
+  public static final String LOGIN_URL = "/login";
+  public static final String ADMIN_USERNAME = "admin";
+  public static final String ADMIN_PASSWORD = "password";
+  
+  @Autowired
+  private WebApplicationContext context;
+  
+  
+  private MockMvc mvc;
+  
+  @Before
+  public void setup() {
+    mvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+  }
+  
+  
+  
+  @Test
+  public void loginForAdminUserWorks() throws Exception{
+    MockHttpSession session =  (MockHttpSession) mvc.perform(
+        post(LOGIN_URL)
+        .param("username", ADMIN_USERNAME)
+        .param("password", ADMIN_PASSWORD)
+        .param("submit", "Login"))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(MockMvcResultMatchers.redirectedUrl("/dashboard"))
+        .andReturn()
+        .getRequest()
+        .getSession();
+    
+     MvcResult result = mvc.perform(get("/dashboard").session(session))
+        .andExpect(status().isOk())
+        .andExpect(MockMvcResultMatchers.view().name("iam/dashboard"))
+        .andReturn();
+  }
+  
+  @Test
+  public void loginWithInvalidCredentialsIsBlocked() throws Exception{
+    mvc.perform(
+        post(LOGIN_URL)
+        .param("username", ADMIN_USERNAME)
+        .param("password", "whatever")
+        .param("submit", "Login"))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(MockMvcResultMatchers.redirectedUrl("/login?error=failure"));
+    
+    mvc.perform(
+        post(LOGIN_URL)
+        .param("username", "whatever")
+        .param("password", "whatever")
+        .param("submit", "Login"))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(MockMvcResultMatchers.redirectedUrl("/login?error=failure"));
+    
+  }
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/SamlExtAuthRegistrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/SamlExtAuthRegistrationTests.java
@@ -26,7 +26,9 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import it.infn.mw.iam.IamLoginService;
+import it.infn.mw.iam.authn.saml.util.Saml2Attribute;
 import it.infn.mw.iam.persistence.model.IamAccount;
+import it.infn.mw.iam.persistence.model.IamSamlId;
 import it.infn.mw.iam.persistence.repository.IamAccountRepository;
 import it.infn.mw.iam.registration.PersistentUUIDTokenGenerator;
 import it.infn.mw.iam.registration.RegistrationRequestDto;
@@ -129,7 +131,9 @@ public class SamlExtAuthRegistrationTests extends SamlExternalAuthenticationTest
     assertThat(err.getMessage(), startsWith(
         "Your registration request to indigo-dc was submitted and confirmed successfully"));
 
-    IamAccount account = iamAccountRepo.findBySamlId(DEFAULT_IDP_ID, T1_EPUID)
+    IamSamlId id = new IamSamlId(DEFAULT_IDP_ID, Saml2Attribute.epuid.getAttributeName(), T1_EPUID);
+
+    IamAccount account = iamAccountRepo.findBySamlId(id)
       .orElseThrow(() -> new AssertionError("Expected account not found"));
 
     iamAccountRepo.delete(account);

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/repository/IamAccountRepositoryTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/repository/IamAccountRepositoryTests.java
@@ -1,0 +1,42 @@
+package it.infn.mw.iam.test.repository;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import javax.persistence.EntityManager;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import it.infn.mw.iam.IamLoginService;
+import it.infn.mw.iam.authn.saml.util.Saml2Attribute;
+import it.infn.mw.iam.persistence.model.IamAccount;
+import it.infn.mw.iam.persistence.model.IamSamlId;
+import it.infn.mw.iam.persistence.repository.IamAccountRepository;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = {IamLoginService.class})
+public class IamAccountRepositoryTests {
+
+  static final IamSamlId TEST_USER_ID = new IamSamlId("https://idptestbed/idp/shibboleth",
+      Saml2Attribute.epuid.getAttributeName(), "78901@idptestbed");
+
+  @Autowired
+  IamAccountRepository repo;
+
+  @Autowired
+  EntityManager em;
+
+  @Test
+  public void testSamlIdResolutionWorksAsExpected() {
+
+    IamAccount testUserAccount = repo.findBySamlId(TEST_USER_ID)
+      .orElseThrow(() -> new AssertionError("Could not lookup test user by SAML id"));
+
+    Assert.assertThat(testUserAccount.getUsername(), equalTo("test"));
+  }
+
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/core/provisioning/user/ScimUserProvisioningTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/core/provisioning/user/ScimUserProvisioningTests.java
@@ -41,7 +41,9 @@ public class ScimUserProvisioningTests {
   final ScimPhoto TESTUSER_PHOTO = ScimPhoto.builder().value("http://site.org/user.png").build();
   final ScimOidcId TESTUSER_OIDCID =
       ScimOidcId.builder().issuer("urn:oidc:test:issuer").subject("1234").build();
-  final ScimSamlId TESTUSER_SAMLID = ScimSamlId.builder().idpId("idpID").userId("userId").build();
+  final ScimSamlId TESTUSER_SAMLID = ScimSamlId.builder().idpId("idpID")
+      .userId("userId")
+      .build();
   final ScimSshKey TESTUSER_SSHKEY = ScimSshKey.builder()
     .primary(true)
     .display("Personal Key")

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/updater/AccountUpdatersTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/updater/AccountUpdatersTests.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 
 import java.util.Optional;
@@ -32,6 +33,7 @@ import it.infn.mw.iam.api.scim.updater.builders.Adders;
 import it.infn.mw.iam.api.scim.updater.builders.Removers;
 import it.infn.mw.iam.api.scim.updater.builders.Replacers;
 import it.infn.mw.iam.api.scim.updater.util.CollectionHelpers;
+import it.infn.mw.iam.authn.saml.util.Saml2Attribute;
 import it.infn.mw.iam.persistence.model.IamAccount;
 import it.infn.mw.iam.persistence.model.IamGroup;
 import it.infn.mw.iam.persistence.model.IamOidcId;
@@ -50,8 +52,11 @@ public class AccountUpdatersTests {
   public static final IamOidcId OLD_OIDC_ID = new IamOidcId(OLD, OLD);
   public static final IamOidcId NEW_OIDC_ID = new IamOidcId(NEW, NEW);
 
-  public static final IamSamlId OLD_SAML_ID = new IamSamlId(OLD, OLD);
-  public static final IamSamlId NEW_SAML_ID = new IamSamlId(NEW, NEW);
+  public static final IamSamlId OLD_SAML_ID =
+      new IamSamlId(OLD, Saml2Attribute.epuid.getAttributeName(), OLD);
+
+  public static final IamSamlId NEW_SAML_ID =
+      new IamSamlId(NEW, Saml2Attribute.epuid.getAttributeName(), NEW);
 
   public static final IamSshKey OLD_SSHKEY = new IamSshKey(OLD);
   public static final IamSshKey NEW_SSHKEY = new IamSshKey(NEW);
@@ -104,7 +109,7 @@ public class AccountUpdatersTests {
 
     Mockito.when(repo.findByOidcId(anyString(), anyString())).thenReturn(Optional.empty());
 
-    Mockito.when(repo.findBySamlId(anyString(), anyString())).thenReturn(Optional.empty());
+    Mockito.when(repo.findBySamlId(anyObject())).thenReturn(Optional.empty());
 
     Mockito.when(repo.findByEmail(anyString())).thenReturn(Optional.empty());
 
@@ -120,7 +125,7 @@ public class AccountUpdatersTests {
 
   private void repoBindSamlIdToAccount(IamSamlId id, IamAccount a) {
 
-    Mockito.when(repo.findBySamlId(id.getIdpId(), id.getUserId())).thenReturn(Optional.of(a));
+    Mockito.when(repo.findBySamlId(id)).thenReturn(Optional.of(a));
   }
 
   private void repoBindEmailToAccount(String email, IamAccount a) {

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/user/ScimUserProvisioningPatchTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/user/ScimUserProvisioningPatchTests.java
@@ -4,6 +4,7 @@ import static it.infn.mw.iam.test.TestUtils.passwordTokenGetter;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.startsWith;
 
 import java.util.Base64;
 
@@ -157,6 +158,25 @@ public class ScimUserProvisioningPatchTests {
         "urn:indigo-dc:scim:schemas:IndigoUser", equalTo(null));
 
   }
+
+  @Test
+  public void testAddSamlIdAttributeIdFailsIfAttributeIdIsEmpty() {
+
+    ScimIndigoUser indigoUser = ScimIndigoUser.builder()
+      .addSamlId(
+          ScimSamlId.builder().idpId("test_idp").userId("test_user").attributeId(null).build())
+      .build();
+
+
+    ScimUser user = ScimUser.builder().indigoUserInfo(indigoUser).build();
+    ScimUserPatchRequest req = getPatchAddRequest(user);
+
+    restUtils.doPatch(lennon.getMeta().getLocation(), req, HttpStatus.BAD_REQUEST)
+      .and()
+      .body("detail", startsWith("attributeId cannot be null"));
+
+  }
+
 
   @Test
   public void testAddReassignAndRemoveSamlId() {

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/util/saml/SamlSecurityContextBuilder.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/util/saml/SamlSecurityContextBuilder.java
@@ -12,6 +12,7 @@ import com.google.common.base.Strings;
 
 import it.infn.mw.iam.authn.saml.SamlExternalAuthenticationToken;
 import it.infn.mw.iam.authn.saml.util.SamlAttributeNames;
+import it.infn.mw.iam.persistence.model.IamSamlId;
 import it.infn.mw.iam.test.ext_authn.saml.SamlExternalAuthenticationTestSupport;
 import it.infn.mw.iam.test.util.SecurityContextBuilderSupport;
 
@@ -60,7 +61,9 @@ public class SamlSecurityContextBuilder extends SecurityContextBuilderSupport {
     ExpiringUsernameAuthenticationToken samlToken = new ExpiringUsernameAuthenticationToken(
         expirationTime, subject, samlCredential, authorities);
 
-    SamlExternalAuthenticationToken token = new SamlExternalAuthenticationToken(samlToken,
+    IamSamlId samlId = new IamSamlId(issuer, subjectAttribute, subject);
+    
+    SamlExternalAuthenticationToken token = new SamlExternalAuthenticationToken(samlId, samlToken,
         samlToken.getTokenExpiration(), subject, samlToken.getCredentials(), authorities);
 
     context.setAuthentication(token);

--- a/iam-persistence/pom.xml
+++ b/iam-persistence/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>it.infn.mw</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>0.6.0</version>
+    <version>1.0.0.rc0-SNAPSHOT</version>
   </parent>
 
   <artifactId>iam-persistence</artifactId>

--- a/iam-persistence/src/main/java/it/infn/mw/iam/persistence/model/IamSamlId.java
+++ b/iam-persistence/src/main/java/it/infn/mw/iam/persistence/model/IamSamlId.java
@@ -5,12 +5,14 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 @Entity
-@Table(name = "iam_saml_id")
+@Table(name = "iam_saml_id", 
+indexes = {@Index(columnList="idpId,attribute_id,userId", name="IDX_IAM_SAML_ID_1")})
 public class IamSamlId implements IamAccountRef {
 
   @Id
@@ -24,7 +26,7 @@ public class IamSamlId implements IamAccountRef {
   @Column(nullable = false, length = 256)
   String idpId;
 
-  @Column(name = "attribute_id", length = 64)
+  @Column(name = "attribute_id", nullable=false, length = 256)
   String attributeId;
 
   @Column(nullable = false, length = 256)

--- a/iam-persistence/src/main/java/it/infn/mw/iam/persistence/model/IamSamlId.java
+++ b/iam-persistence/src/main/java/it/infn/mw/iam/persistence/model/IamSamlId.java
@@ -24,11 +24,16 @@ public class IamSamlId implements IamAccountRef {
   @Column(nullable = false, length = 256)
   String idpId;
 
+  @Column(name = "attribute_id", length = 64)
+  String attributeId;
+
   @Column(nullable = false, length = 256)
   String userId;
 
-  public IamSamlId(String idpId, String userId) {
+
+  public IamSamlId(String idpId, String attributeId, String userId) {
     setIdpId(idpId);
+    setAttributeId(attributeId);
     setUserId(userId);
   }
 
@@ -76,11 +81,20 @@ public class IamSamlId implements IamAccountRef {
     this.userId = userId;
   }
 
+
+  public String getAttributeId() {
+    return attributeId;
+  }
+
+  public void setAttributeId(String attributeId) {
+    this.attributeId = attributeId;
+  }
+
   @Override
   public int hashCode() {
-
     final int prime = 31;
     int result = 1;
+    result = prime * result + ((attributeId == null) ? 0 : attributeId.hashCode());
     result = prime * result + ((idpId == null) ? 0 : idpId.hashCode());
     result = prime * result + ((userId == null) ? 0 : userId.hashCode());
     return result;
@@ -88,7 +102,6 @@ public class IamSamlId implements IamAccountRef {
 
   @Override
   public boolean equals(Object obj) {
-
     if (this == obj)
       return true;
     if (obj == null)
@@ -96,6 +109,11 @@ public class IamSamlId implements IamAccountRef {
     if (getClass() != obj.getClass())
       return false;
     IamSamlId other = (IamSamlId) obj;
+    if (attributeId == null) {
+      if (other.attributeId != null)
+        return false;
+    } else if (!attributeId.equals(other.attributeId))
+      return false;
     if (idpId == null) {
       if (other.idpId != null)
         return false;
@@ -111,8 +129,8 @@ public class IamSamlId implements IamAccountRef {
 
   @Override
   public String toString() {
-
-    return "IamSamlId [id=" + id + ", idpId=" + idpId + ", userId=" + userId + "]";
+    return "IamSamlId [idpId=" + idpId + ", attributeId=" + attributeId + ", userId=" + userId
+        + "]";
   }
 
 }

--- a/iam-persistence/src/main/java/it/infn/mw/iam/persistence/repository/IamAccountRepository.java
+++ b/iam-persistence/src/main/java/it/infn/mw/iam/persistence/repository/IamAccountRepository.java
@@ -9,7 +9,8 @@ import org.springframework.data.repository.query.Param;
 
 import it.infn.mw.iam.persistence.model.IamAccount;
 
-public interface IamAccountRepository extends PagingAndSortingRepository<IamAccount, Long> {
+public interface IamAccountRepository extends PagingAndSortingRepository<IamAccount, Long>, 
+  IamAccountRepositoryCustom {
 
   @Query("select count(a) from IamAccount a")
   int countAllUsers();
@@ -18,8 +19,10 @@ public interface IamAccountRepository extends PagingAndSortingRepository<IamAcco
 
   Optional<IamAccount> findByUsername(@Param("username") String username);
 
-  @Query("select a from IamAccount a join a.samlIds si where si.idpId = :idpId and si.userId = :subject")
-  Optional<IamAccount> findBySamlId(@Param("idpId") String idpId, @Param("subject") String subject);
+  @Query("select a from IamAccount a join a.samlIds si where si.idpId = :idpId "
+      + "and si.attributeId = :attributeId and si.userId = :userId")
+  Optional<IamAccount> findBySamlId(@Param("idpId") String idpId,
+      @Param("attributeId") String attributeId, @Param("userId") String userId);
 
   @Query("select a from IamAccount a join a.oidcIds oi where oi.issuer = :issuer and oi.subject = :subject")
   Optional<IamAccount> findByOidcId(@Param("issuer") String issuer,

--- a/iam-persistence/src/main/java/it/infn/mw/iam/persistence/repository/IamAccountRepositoryCustom.java
+++ b/iam-persistence/src/main/java/it/infn/mw/iam/persistence/repository/IamAccountRepositoryCustom.java
@@ -1,0 +1,12 @@
+package it.infn.mw.iam.persistence.repository;
+
+import java.util.Optional;
+
+import it.infn.mw.iam.persistence.model.IamAccount;
+import it.infn.mw.iam.persistence.model.IamSamlId;
+
+public interface IamAccountRepositoryCustom {
+  
+  Optional<IamAccount> findBySamlId(IamSamlId samlId);
+
+}

--- a/iam-persistence/src/main/java/it/infn/mw/iam/persistence/repository/IamAccountRepositoryImpl.java
+++ b/iam-persistence/src/main/java/it/infn/mw/iam/persistence/repository/IamAccountRepositoryImpl.java
@@ -1,0 +1,22 @@
+package it.infn.mw.iam.persistence.repository;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import it.infn.mw.iam.persistence.model.IamAccount;
+import it.infn.mw.iam.persistence.model.IamSamlId;
+
+@Component
+public class IamAccountRepositoryImpl implements IamAccountRepositoryCustom {
+
+  @Autowired
+  IamAccountRepository repo;
+
+  @Override
+  public Optional<IamAccount> findBySamlId(IamSamlId samlId) {
+    return repo.findBySamlId(samlId.getIdpId(), samlId.getAttributeId(), 
+        samlId.getUserId());
+  }
+}

--- a/iam-persistence/src/main/resources/db/migration/h2/V13__add_attribute_id_to_saml_id_table.sql
+++ b/iam-persistence/src/main/resources/db/migration/h2/V13__add_attribute_id_to_saml_id_table.sql
@@ -3,6 +3,6 @@ ALTER TABLE iam_saml_id ADD COLUMN (attribute_id varchar(256));
 -- Create index
 CREATE INDEX IDX_IAM_SAML_ID_1 ON iam_saml_id(IDPID, attribute_id, USERID);
 -- Update existing records, so that epuid is the default attribute id
-update iam_saml_id set attribute_id = 'urn:oid:1.3.6.1.4.1.5923.1.1.1.13' where attribute_id = NULL;
+update iam_saml_id set attribute_id = 'urn:oid:1.3.6.1.4.1.5923.1.1.1.13' where attribute_id is NULL;
 -- Add not null constraint on attribute id
 ALTER TABLE iam_saml_id ALTER COLUMN attribute_id varchar(256) NOT NULL; 

--- a/iam-persistence/src/main/resources/db/migration/h2/V13__add_attribute_id_to_saml_id_table.sql
+++ b/iam-persistence/src/main/resources/db/migration/h2/V13__add_attribute_id_to_saml_id_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE iam_saml_id ADD COLUMN (attribute_id varchar(64))

--- a/iam-persistence/src/main/resources/db/migration/mysql/V13__add_attribute_id_to_saml_id_table.sql
+++ b/iam-persistence/src/main/resources/db/migration/mysql/V13__add_attribute_id_to_saml_id_table.sql
@@ -3,6 +3,6 @@ ALTER TABLE iam_saml_id ADD COLUMN (attribute_id varchar(256));
 -- Create index
 CREATE INDEX IDX_IAM_SAML_ID_1 ON iam_saml_id(IDPID, attribute_id, USERID);
 -- Update existing records, so that epuid is the default attribute id
-update iam_saml_id set attribute_id = 'urn:oid:1.3.6.1.4.1.5923.1.1.1.13' where attribute_id = NULL;
+update iam_saml_id set attribute_id = 'urn:oid:1.3.6.1.4.1.5923.1.1.1.13' where attribute_id is NULL;
 -- Add not null constraint on attribute id
 ALTER TABLE iam_saml_id MODIFY attribute_id varchar(256) NOT NULL; 

--- a/iam-persistence/src/main/resources/db/migration/mysql/V13__add_attribute_id_to_saml_id_table.sql
+++ b/iam-persistence/src/main/resources/db/migration/mysql/V13__add_attribute_id_to_saml_id_table.sql
@@ -5,4 +5,4 @@ CREATE INDEX IDX_IAM_SAML_ID_1 ON iam_saml_id(IDPID, attribute_id, USERID);
 -- Update existing records, so that epuid is the default attribute id
 update iam_saml_id set attribute_id = 'urn:oid:1.3.6.1.4.1.5923.1.1.1.13' where attribute_id = NULL;
 -- Add not null constraint on attribute id
-ALTER TABLE iam_saml_id ALTER COLUMN attribute_id varchar(256) NOT NULL; 
+ALTER TABLE iam_saml_id MODIFY attribute_id varchar(256) NOT NULL; 

--- a/iam-persistence/src/main/resources/db/migration/test/V100000___test_data.sql
+++ b/iam-persistence/src/main/resources/db/migration/test/V100000___test_data.sql
@@ -126,9 +126,9 @@ INSERT INTO iam_oidc_id(issuer, subject, account_id) VALUES
 ('https://accounts.google.com', '105440632287425289613', 2),
 ('urn:test-oidc-issuer', 'test-user', 2);
 
-INSERT INTO iam_saml_id(idpid, userid, account_id) VALUES
-('https://idptestbed/idp/shibboleth', 'andrea.ceccanti@example.org',2),
-('https://idptestbed/idp/shibboleth', '78901@idptestbed',2);
+INSERT INTO iam_saml_id(idpid, attribute_id, userid, account_id) VALUES
+('https://idptestbed/idp/shibboleth', 'urn:oid:0.9.2342.19200300.100.1.3', 'andrea.ceccanti@example.org',2),
+('https://idptestbed/idp/shibboleth', 'urn:oid:1.3.6.1.4.1.5923.1.1.1.13', '78901@idptestbed',2);
 
 INSERT INTO iam_group(id, name, uuid, description, creationtime, lastupdatetime) VALUES
 (1, 'Production', 'c617d586-54e6-411d-8e38-64967798fa8a', 'The production group', CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP()),

--- a/iam-persistence/src/main/resources/db/migration/test/V11_1__no_attr_id_saml_account_for_admin_user.sql
+++ b/iam-persistence/src/main/resources/db/migration/test/V11_1__no_attr_id_saml_account_for_admin_user.sql
@@ -1,0 +1,5 @@
+-- Insert SAML account id for admin user to check that
+-- the database migration logic in v12 updates the record as 
+-- expected
+INSERT INTO iam_saml_id(idpid, userid, account_id) VALUES
+('https://idptestbed/idp/shibboleth', 'admin@example.org',1);

--- a/iam-test-client/pom.xml
+++ b/iam-test-client/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>it.infn.mw</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>0.6.0</version>
+    <version>1.0.0.rc0-SNAPSHOT</version>
   </parent>
 
   <artifactId>iam-test-client</artifactId>

--- a/iam-test-protected-resource/pom.xml
+++ b/iam-test-protected-resource/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>it.infn.mw</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>0.6.0</version>
+    <version>1.0.0.rc0-SNAPSHOT</version>
   </parent>
 
   <artifactId>iam-test-protected-resource</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>it.infn.mw</groupId>
   <artifactId>iam-parent</artifactId>
-  <version>0.6.0</version>
+  <version>1.0.0.rc0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>IAM Parent POM</name>
 


### PR DESCRIPTION
This PR provides a fix for issue #116, introducing 

- a new attributeId column in the IAM_SAML_ID table which holdes the name of the SAML attribute used for the linking
- tests to check that linking works as expected
- changes to the dashboard to include the new attribute id

