### PR TITLE
Fix security config for token revocation endpoint

### DIFF
--- a/iam-common/pom.xml
+++ b/iam-common/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>it.infn.mw</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>1.0.0.rc1-SNAPSHOT</version>
+    <version>1.0.0.rc2-SNAPSHOT</version>
   </parent>
 
   <artifactId>iam-common</artifactId>

--- a/iam-login-service/pom.xml
+++ b/iam-login-service/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>it.infn.mw</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>1.0.0.rc1-SNAPSHOT</version>
+    <version>1.0.0.rc2-SNAPSHOT</version>
   </parent>
 
   <artifactId>iam-login-service</artifactId>

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/SecurityConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/SecurityConfig.java
@@ -454,7 +454,9 @@ public class SecurityConfig {
       http.antMatcher("/revoke**").httpBasic().authenticationEntryPoint(authenticationEntryPoint)
           .and().addFilterBefore(corsFilter, SecurityContextPersistenceFilter.class)
           .addFilterBefore(clientCredentialsEndpointFilter(), BasicAuthenticationFilter.class)
-          .exceptionHandling().authenticationEntryPoint(authenticationEntryPoint).and()
+          .exceptionHandling().authenticationEntryPoint(authenticationEntryPoint)
+          .and()
+            .csrf().disable()
           .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
       // @formatter:on
     }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/RevocationEndpointTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/RevocationEndpointTests.java
@@ -1,0 +1,177 @@
+package it.infn.mw.iam.test.oauth;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Set;
+
+import javax.transaction.Transactional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mitre.oauth2.model.OAuth2AccessTokenEntity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import it.infn.mw.iam.IamLoginService;
+import it.infn.mw.iam.core.IamTokenService;
+import it.infn.mw.iam.persistence.repository.IamAccountRepository;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = IamLoginService.class)
+@WebAppConfiguration
+@Transactional
+public class RevocationEndpointTests extends EndpointsTestUtils {
+
+  public static final String REVOKE_ENDPOINT = "/revoke";
+
+  public static final String PASSWORD_GRANT_CLIENT_ID = "password-grant";
+  public static final String PASSWORD_GRANT_CLIENT_SECRET = "secret";
+
+  @Autowired
+  IamTokenService iamTokenService;
+
+  @Autowired
+  IamAccountRepository accountRepo;
+
+  @Before
+  public void setup() throws Exception {
+    buildMockMvc();
+  }
+  
+  
+  @Test
+  public void testRevocationEnpointRequiresClientAuth() throws Exception {
+    mvc
+    .perform(post(REVOKE_ENDPOINT)
+      .contentType(APPLICATION_FORM_URLENCODED)
+      .param("token", "whatever"))
+    .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  public void testRevokeInvalidTokenReturns200() throws Exception {
+    mvc
+      .perform(post(REVOKE_ENDPOINT)
+        .with(httpBasic(PASSWORD_GRANT_CLIENT_ID, PASSWORD_GRANT_CLIENT_SECRET))
+        .contentType(APPLICATION_FORM_URLENCODED)
+        .param("token", "whatever"))
+      .andExpect(status().isOk());
+  }
+
+  @Test
+  public void accessTokenRevocationWorks() throws Exception {
+
+    Set<OAuth2AccessTokenEntity> accessTokens = iamTokenService.getAllAccessTokensForUser("test");
+
+    // Start clean
+    accessTokens.forEach(iamTokenService::revokeAccessToken);
+
+    String accessToken = getPasswordAccessToken();
+
+    accessTokens = iamTokenService.getAllAccessTokensForUser("test");
+
+    assertThat(accessTokens, hasSize(2)); // access token + id token -> size 2
+
+    mvc
+      .perform(post(REVOKE_ENDPOINT)
+        .with(httpBasic(PASSWORD_GRANT_CLIENT_ID, PASSWORD_GRANT_CLIENT_SECRET))
+        .contentType(APPLICATION_FORM_URLENCODED)
+        .param("token", accessToken))
+      .andExpect(status().isOk());
+
+    accessTokens = iamTokenService.getAllAccessTokensForUser("test");
+
+    assertThat(accessTokens, hasSize(0)); // revoking the access token revokes the linked id token
+
+  }
+
+  @Test
+  public void accessTokenRevocationRevokesTheRightToken() throws Exception {
+    Set<OAuth2AccessTokenEntity> accessTokens = iamTokenService.getAllAccessTokensForUser("test");
+
+    // Start clean
+    accessTokens.forEach(iamTokenService::revokeAccessToken);
+
+    String tokenOne = getPasswordAccessToken();
+    String tokenTwo = getPasswordAccessToken();
+
+    accessTokens = iamTokenService.getAllAccessTokensForUser("test");
+    assertThat(accessTokens, hasSize(4));
+
+    mvc
+      .perform(post(REVOKE_ENDPOINT)
+        .with(httpBasic(PASSWORD_GRANT_CLIENT_ID, PASSWORD_GRANT_CLIENT_SECRET))
+        .contentType(APPLICATION_FORM_URLENCODED)
+        .param("token", tokenOne))
+      .andExpect(status().isOk());
+
+    accessTokens = iamTokenService.getAllAccessTokensForUser("test");
+    assertThat(accessTokens, hasSize(2));
+    accessTokens.stream().filter(t -> t.getValue().equals(tokenTwo)).findAny().orElseThrow(
+        () -> new AssertionError("Expected access token not found"));
+  }
+
+  @Test
+  public void refreshTokenRevocationWorks() throws Exception {
+
+    // Start clean
+    iamTokenService.getAllAccessTokensForUser("test").forEach(iamTokenService::revokeAccessToken);
+    iamTokenService.getAllRefreshTokensForUser("test").forEach(iamTokenService::revokeRefreshToken);
+
+    AccessTokenGetter tg = buildAccessTokenGetter();
+    tg.scope("openid profile offline_access");
+    DefaultOAuth2AccessToken tokenResponseObject = tg.getTokenResponseObject();
+    String refreshTokenValue = tokenResponseObject.getRefreshToken().getValue();
+
+    assertThat(iamTokenService.getAllRefreshTokensForUser("test"), hasSize(1));
+
+    mvc
+      .perform(post(REVOKE_ENDPOINT)
+        .with(httpBasic(PASSWORD_GRANT_CLIENT_ID, PASSWORD_GRANT_CLIENT_SECRET))
+        .contentType(APPLICATION_FORM_URLENCODED)
+        .param("token", refreshTokenValue))
+      .andExpect(status().isOk());
+
+    assertThat(iamTokenService.getAllRefreshTokensForUser("test"), hasSize(0));
+  }
+
+  @Test
+  public void refreshTokenRevocationRevokesTheRightToken() throws Exception {
+    // Start clean
+    iamTokenService.getAllAccessTokensForUser("test").forEach(iamTokenService::revokeAccessToken);
+    iamTokenService.getAllRefreshTokensForUser("test").forEach(iamTokenService::revokeRefreshToken);
+
+    AccessTokenGetter tg = buildAccessTokenGetter();
+    tg.scope("openid profile offline_access");
+
+    String rt1 = tg.getTokenResponseObject().getRefreshToken().getValue();
+    String rt2 = tg.getTokenResponseObject().getRefreshToken().getValue();
+
+    assertThat(iamTokenService.getAllRefreshTokensForUser("test"), hasSize(2));
+
+    mvc
+      .perform(post(REVOKE_ENDPOINT)
+        .with(httpBasic(PASSWORD_GRANT_CLIENT_ID, PASSWORD_GRANT_CLIENT_SECRET))
+        .contentType(APPLICATION_FORM_URLENCODED)
+        .param("token", rt1))
+      .andExpect(status().isOk());
+
+
+    assertThat(iamTokenService.getAllRefreshTokensForUser("test"), hasSize(1));
+    
+    iamTokenService.getAllRefreshTokensForUser("test")
+      .stream()
+      .filter(t -> t.getValue().equals(rt2))
+      .findAny()
+      .orElseThrow(() -> new AssertionError("Expected refresh token not found"));
+  }
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/TokenExchangeTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/TokenExchangeTests.java
@@ -85,7 +85,7 @@ public class TokenExchangeTests extends EndpointsTestUtils {
       .username(USERNAME)
       .password(PASSWORD)
       .scope("openid profile")
-      .getAccessToken();
+      .getAccessTokenValue();
 
     // @formatter:off
     String response = mvc.perform(post(TOKEN_ENDPOINT)
@@ -160,7 +160,7 @@ public class TokenExchangeTests extends EndpointsTestUtils {
       .username(USERNAME)
       .password(PASSWORD)
       .scope("openid profile")
-      .getAccessToken();
+      .getAccessTokenValue();
 
     // @formatter:off
     String response = mvc.perform(post(TOKEN_ENDPOINT)
@@ -232,7 +232,7 @@ public class TokenExchangeTests extends EndpointsTestUtils {
       .username(USERNAME)
       .password(PASSWORD)
       .scope("openid profile")
-      .getAccessToken();
+      .getAccessTokenValue();
 
     // @formatter:off
     mvc.perform(post(TOKEN_ENDPOINT)
@@ -265,7 +265,7 @@ public class TokenExchangeTests extends EndpointsTestUtils {
       .username(USERNAME)
       .password(PASSWORD)
       .scope("openid profile offline_access")
-      .getAccessToken();
+      .getAccessTokenValue();
 
     // @formatter:off
     String response = mvc.perform(post(TOKEN_ENDPOINT)
@@ -320,7 +320,7 @@ public class TokenExchangeTests extends EndpointsTestUtils {
       .username(USERNAME)
       .password(PASSWORD)
       .scope("openid")
-      .getAccessToken();
+      .getAccessTokenValue();
 
     // @formatter:off
     mvc.perform(post(TOKEN_ENDPOINT)
@@ -352,7 +352,7 @@ public class TokenExchangeTests extends EndpointsTestUtils {
       .username(USERNAME)
       .password(PASSWORD)
       .scope("openid")
-      .getAccessToken();
+      .getAccessTokenValue();
 
     String actorToken = new AccessTokenGetter().grantType("password")
       .clientId(clientId)
@@ -360,7 +360,7 @@ public class TokenExchangeTests extends EndpointsTestUtils {
       .username(USERNAME)
       .password(PASSWORD)
       .scope("openid")
-      .getAccessToken();
+      .getAccessTokenValue();
 
     // @formatter:off
     mvc.perform(post(TOKEN_ENDPOINT)
@@ -406,7 +406,7 @@ public class TokenExchangeTests extends EndpointsTestUtils {
       .clientId("client-cred")
       .clientSecret("secret")
       .scope("read-tasks write-tasks")
-      .getAccessToken();
+      .getAccessTokenValue();
 
     String actorClientId = "token-exchange-actor";
     String actorClientSecret = "secret";

--- a/iam-persistence/pom.xml
+++ b/iam-persistence/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>it.infn.mw</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>1.0.0.rc1-SNAPSHOT</version>
+    <version>1.0.0.rc2-SNAPSHOT</version>
   </parent>
 
   <artifactId>iam-persistence</artifactId>

--- a/iam-persistence/src/main/resources/db/migration/test/V100000___test_data.sql
+++ b/iam-persistence/src/main/resources/db/migration/test/V100000___test_data.sql
@@ -101,6 +101,7 @@ INSERT INTO client_grant_type (owner_id, grant_type) VALUES
   (4, 'password'),
   (4, 'client_credentials'),
   (5, 'password'),
+  (5, 'refresh_token'),
   (6, 'client_credentials'),
   (7, 'client_credentials'),
   (8, 'urn:ietf:params:oauth:grant-type:token-exchange'),

--- a/iam-test-client/pom.xml
+++ b/iam-test-client/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>it.infn.mw</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>1.0.0.rc1-SNAPSHOT</version>
+    <version>1.0.0.rc2-SNAPSHOT</version>
   </parent>
 
   <artifactId>iam-test-client</artifactId>

--- a/iam-test-protected-resource/pom.xml
+++ b/iam-test-protected-resource/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>it.infn.mw</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>1.0.0.rc1-SNAPSHOT</version>
+    <version>1.0.0.rc2-SNAPSHOT</version>
   </parent>
 
   <artifactId>iam-test-protected-resource</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>it.infn.mw</groupId>
   <artifactId>iam-parent</artifactId>
-  <version>1.0.0.rc1-SNAPSHOT</version>
+  <version>1.0.0.rc2-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>INDIGO Identity and Access Manager (IAM)</name>
 


### PR DESCRIPTION
The token revocation endpoint was incorrectly configured with CSRF
checks enabled.

This commit fixes that and adds some tests to verify that the revocation
endpoint works as expected.

Issue: #159