### PR TITLE
Include notes in admin-targeted request email

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/notification/DefaultNotificationService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/notification/DefaultNotificationService.java
@@ -118,6 +118,7 @@ public class DefaultNotificationService implements NotificationService {
     model.put("email", email);
     model.put("indigoDashboardUrl", dashboardUrl);
     model.put("organisationName", organisationName);
+    model.put("notes", request.getNotes());
 
     return createMessage("adminHandleRequest.vm", model, IamNotificationType.CONFIRMATION,
         properties.getSubject().get("adminHandleRequest"), properties.getAdminAddress());

--- a/iam-login-service/src/main/resources/templates/adminHandleRequest.vm
+++ b/iam-login-service/src/main/resources/templates/adminHandleRequest.vm
@@ -1,8 +1,11 @@
-The following user has submitted his membership request:
+The following user has submitted a membership request:
 
 Name: $name
 Username: $username
 Email: $email
+
+Notes:
+$notes
 	
 You can approve or reject this request by following the link below:
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/notification/NotificationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/notification/NotificationTests.java
@@ -390,6 +390,27 @@ public class NotificationTests {
 
     deleteUser(reg.getAccountId());
   }
+  
+  @Test
+  public void testAdminNotificationMailShouldContainNotes()
+      throws MessagingException, IOException {
+
+    String username = "test_user";
+
+    RegistrationRequestDto reg = createRegistrationRequest(username);
+    String confirmationKey = generator.getLastToken();
+    confirmRegistrationRequest(confirmationKey);
+
+    notificationService.sendPendingNotifications();
+
+    WiserMessage message = wiser.getMessages().get(1);
+
+    assertThat(message.getMimeMessage().isMimeType("text/plain"), is(true));
+    String content = message.getMimeMessage().getContent().toString();
+    assertThat(content, containsString("Some short notes..."));
+
+    deleteUser(reg.getAccountId());
+  }
 
   @Test
   public void testPasswordResetMailContainsUsername() throws MessagingException, IOException {


### PR DESCRIPTION
Since the notes field is now mandatory it makes sense to include it by
default in admin-targeted membership requests notifications.

Issue: #190