### PR TITLE
Open modal to prevent double click

### DIFF
--- a/iam-login-service/src/main/webapp/resources/iam/js/dashboard-app/controllers/registration.controller.js
+++ b/iam-login-service/src/main/webapp/resources/iam/js/dashboard-app/controllers/registration.controller.js
@@ -80,6 +80,7 @@ function RequestManagementController($scope, $rootScope, $state, $filter, filter
 		requests.loadingModal = $uibModal
 		.open({
 			animation: false,
+			backdrop: 'static',
 			templateUrl : '/resources/iam/template/dashboard/loading-modal.html'
 		});
 
@@ -104,15 +105,33 @@ function RequestManagementController($scope, $rootScope, $state, $filter, filter
 	}
 
 	function approveRequest(request) {
-		RegistrationRequestService.updateRequest(request.uuid, 'APPROVED').then(
-			function() {
-				var msg = request.givenname + " " + request.familyname + " request APPROVED successfully";
-				$scope.operationResult = Utils.buildSuccessOperationResult(msg);
-				requests.loadData();
-			},
-			function(error) {
-				$scope.operationResult = Utils.buildErrorOperationResult(error);
-			})
+		$scope.buttonDisabled = true;
+		
+		$rootScope.pageLoadingProgress = 50;
+		requests.approvingModal = $uibModal
+		.open({
+			animation: false,
+			backdrop: 'static',
+			templateUrl : '/resources/iam/template/dashboard/loading-modal.html'
+		});
+		
+		requests.approvingModal.opened.then(function(){
+			RegistrationRequestService.updateRequest(request.uuid, 'APPROVED').then(
+				function() {
+					$rootScope.pageLoadingProgress = 100;
+					requests.approvingModal.dismiss("Cancel");
+					var msg = request.givenname + " " + request.familyname + " request APPROVED successfully";
+					$scope.operationResult = Utils.buildSuccessOperationResult(msg);
+					requests.loadData();
+					$scope.buttonDisabled = false;
+				},
+				function(error) {
+					$rootScope.pageLoadingProgress = 100;
+					requests.approvingModal.dismiss("Cancel");
+					$scope.operationResult = Util.buildErrorOperationResult(error);
+					$scope.buttonDisabled = false;
+				})
+		});
 	};
 
 	function rejectRequest(request) {
@@ -126,15 +145,29 @@ function RequestManagementController($scope, $rootScope, $state, $filter, filter
 		
 		ModalService.showModal({}, modalOptions).then(
 				function (){
-					RegistrationRequestService.updateRequest(request.uuid, 'REJECTED').then(
+					$rootScope.pageLoadingProgress = 50;
+					requests.rejectingModal = $uibModal
+					.open({
+						animation: false,
+						backdrop: 'static',
+						templateUrl : '/resources/iam/template/dashboard/loading-modal.html'
+					});
+					
+					requests.rejectingModal.opened.then(function(){
+						RegistrationRequestService.updateRequest(request.uuid, 'REJECTED').then(
 							function() {
+								$rootScope.pageLoadingProgress = 100;
+								requests.rejectingModal.dismiss("Cancel");
 								var msg = request.givenname + " " + request.familyname + " request REJECTED successfully";
 								$scope.operationResult = Utils.buildSuccessOperationResult(msg);
 								requests.loadData();
 							},
 							function(error) {
+								$rootScope.pageLoadingProgress = 100;
+								requests.rejectingModal.dismiss("Cancel");
 								$scope.operationResult = Utils.buildErrorOperationResult(error);
 							})
+					});
 				});
 	};
 };

--- a/iam-login-service/src/main/webapp/resources/iam/template/dashboard/requests/management.html
+++ b/iam-login-service/src/main/webapp/resources/iam/template/dashboard/requests/management.html
@@ -79,11 +79,13 @@
 									<td class="text-right">
 										<button class="btn btn-success btn-xs"
 											ng-click="requests.approveRequest(r)" name="btn_approve"
+											ng-disabled="buttonDisabled"
 											title="Approve request">
 											<i class="fa fa-check"></i> Approve
 										</button>
 										<button class="btn btn-danger btn-xs"
 											ng-click="requests.rejectRequest(r)" name="btn_reject"
+											ng-disabled="buttonDisabled"
 											title="Reject request">
 											<i class="fa fa-times"></i> Reject
 										</button>


### PR DESCRIPTION
This PR resolve issue #222.
Basically, the loading modal window is opened until the approve or reject operation is completed.
This behavior prevent the double click.