### PR TITLE
Add grant types to dynamic client registration page

### DIFF
--- a/iam-login-service/src/main/webapp/resources/js/dynreg.js
+++ b/iam-login-service/src/main/webapp/resources/js/dynreg.js
@@ -369,7 +369,9 @@ var DynRegEditView = Backbone.View.extend({
 		'implicit': 'implicit',
 		'client_credentials': 'client_credentials',
 		'redelegate': 'urn:ietf:params:oauth:grant_type:redelegate',
-		'refresh_token': 'refresh_token'
+		'refresh_token': 'refresh_token',
+		'device': 'urn:ietf:params:oauth:grant-type:device_code',
+		'token-exchange': 'urn:ietf:params:oauth:grant-type:token-exchange'
 	},
 
 	// maps from a form-friendly name to the real response type

--- a/iam-login-service/src/main/webapp/resources/template/dynreg.html
+++ b/iam-login-service/src/main/webapp/resources/template/dynreg.html
@@ -267,6 +267,18 @@
                             <%-($.inArray("refresh_token", client.grant_types) > -1 ? 'checked' : '')%>> 
                         <label for="grantTypes-refresh_token" class="checkbox" data-i18n="client.client-form.refresh">refresh</label>
                     </div>
+
+					<div>
+                        <input id="grantTypes-device" type="checkbox" name="grantTypes"
+                            <%-($.inArray("urn:ietf:params:oauth:grant-type:device_code", client.grant_types) > -1 ? 'checked' : '')%>> 
+                        <label for="grantTypes-device" class="checkbox" data-i18n="client.client-form.device">device</label>
+                    </div>
+
+                    <div>
+                        <input id="grantTypes-token-exchange" type="checkbox" name="grantTypes"
+                            <%-($.inArray("urn:ietf:params:oauth:grant-type:token-exchange", client.grant_types) > -1 ? 'checked' : '')%>> 
+                        <label for="grantTypes-token-exchange" class="checkbox" data-i18n="client.client-form.token-exchange">token exchange</label>
+                    </div>
                 </div>
             </div>
 

--- a/iam-login-service/src/main/webapp/resources/template/dynreg.html
+++ b/iam-login-service/src/main/webapp/resources/template/dynreg.html
@@ -256,6 +256,12 @@
                         <label for="grantTypes-implicit" class="radio" data-i18n="client.client-form.implicit">implicit</label>
                     </div>
 
+                    <div style="color: gray; pointer-events: none;">
+                        <input id="grantTypes-password" type="checkbox" name="grantTypes" readonly
+                            <%-($.inArray("password", client.grant_types) > -1 ? 'checked' : '')%>>
+                        <label for="grantTypes-password" class="checkbox" data-i18n="client.client-form.password">password</label>
+                    </div>
+
                     <div>
                         <input id="grantTypes-redelegate" type="checkbox" name="grantTypes"
                             <%-($.inArray("urn:ietf:params:oauth:grant_type:redelegate", client.grant_types) > -1 ? 'checked' : '')%>> 
@@ -268,14 +274,14 @@
                         <label for="grantTypes-refresh_token" class="checkbox" data-i18n="client.client-form.refresh">refresh</label>
                     </div>
 
-					<div>
+                    <div>
                         <input id="grantTypes-device" type="checkbox" name="grantTypes"
                             <%-($.inArray("urn:ietf:params:oauth:grant-type:device_code", client.grant_types) > -1 ? 'checked' : '')%>> 
                         <label for="grantTypes-device" class="checkbox" data-i18n="client.client-form.device">device</label>
                     </div>
 
-                    <div>
-                        <input id="grantTypes-token-exchange" type="checkbox" name="grantTypes"
+                    <div style="color: gray; pointer-events: none;">
+                        <input id="grantTypes-token-exchange" type="checkbox" name="grantTypes" readonly"
                             <%-($.inArray("urn:ietf:params:oauth:grant-type:token-exchange", client.grant_types) > -1 ? 'checked' : '')%>> 
                         <label for="grantTypes-token-exchange" class="checkbox" data-i18n="client.client-form.token-exchange">token exchange</label>
                     </div>


### PR DESCRIPTION
This PR resolves issue #223.
Basically, now both the admin client management page and the self-service client registration page have the same grant type options.