### PR TITLE
Improved SAML resolution and testing

### DIFF
--- a/docker/trust-anchors/Dockerfile
+++ b/docker/trust-anchors/Dockerfile
@@ -7,6 +7,6 @@ RUN yum -y install epel-release && yum -y update
 RUN yum -y install rsync igi-test-ca ca-policy-egi-core fetch-crl && fetch-crl || true
 RUN chmod +x /update-trust-anchors.sh 
 
-ENTRYPOINT ["/update-trust-anchors.sh"]
+RUN FORCE_TRUST_ANCHORS_UPDATE=1 /update-trust-anchors.sh
 
-VOLUME /etc/grid-security/certificates
+ENTRYPOINT ["/update-trust-anchors.sh"]

--- a/docker/trust-anchors/build-image.sh
+++ b/docker/trust-anchors/build-image.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-docker build --no-cache=true --rm=true -t indigoiam/trustanchors .
+docker build --rm=true -t indigoiam/trustanchors .
 

--- a/docker/trust-anchors/igi-test-ca.repo
+++ b/docker/trust-anchors/igi-test-ca.repo
@@ -1,6 +1,6 @@
 [Test-CA]
 name=Test-CA
-baseurl=https://jenkins.cloud.ba.infn.it/job/repo_test_ca//lastSuccessfulBuild/artifact/yum/
+baseurl=https://ci.cloud.cnaf.infn.it/job/repo_test_ca/lastSuccessfulBuild/artifact/yum/
 protect=1
 enabled=1
 priority=1

--- a/docker/trust-anchors/update-trust-anchors.sh
+++ b/docker/trust-anchors/update-trust-anchors.sh
@@ -1,15 +1,22 @@
 #!/bin/bash
 set -ex
 
-if [ -n "${SKIP_UPDATE_TRUST_ANCHORS}" ]; then
-  echo "Skipping trust anchors update as requested."
+if [[ -z "${FORCE_TRUST_ANCHORS_UPDATE}" ]]; then
+  echo "Skipping trust anchors update (default behaviour)."
   exit 0
 fi
 
 fetch-crl --verbose || true
 
-echo "Args: $@"
+# Update centos ca-trust
+
+for c in /etc/grid-security/certificates/*.pem; do
+  cp $c /etc/pki/ca-trust/source/anchors/
+done
+
+update-ca-trust extract
 
 if [ $# -gt 0 ]; then
+  echo "Certificate copy requested to $1"
   rsync -avu --no-owner --no-group /etc/grid-security/certificates/ $1
 fi

--- a/iam-login-service/docker/push-prod-image.sh
+++ b/iam-login-service/docker/push-prod-image.sh
@@ -47,6 +47,7 @@ if [[ -n ${DOCKER_REGISTRY_HOST} ]]; then
   docker push ${DOCKER_REGISTRY_HOST}/${POM_VERSION_TAG}
   docker push ${DOCKER_REGISTRY_HOST}/${POM_VERSION_LATEST_TAG}
   if [ "${GIT_BRANCH_NAME}" != "HEAD" ]; then
+    docker tag ${BRANCH_LATEST_TAG} ${DOCKER_REGISTRY_HOST}/${BRANCH_LATEST_TAG}
     docker push ${DOCKER_REGISTRY_HOST}/${BRANCH_LATEST_TAG}
   fi
 else

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/AttributeUserIdentifierResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/AttributeUserIdentifierResolver.java
@@ -15,6 +15,8 @@
  */
 package it.infn.mw.iam.authn.saml.util;
 
+import static java.lang.String.format;
+
 import org.springframework.security.saml.SAMLCredential;
 
 import it.infn.mw.iam.persistence.model.IamSamlId;
@@ -36,7 +38,7 @@ public class AttributeUserIdentifierResolver extends AbstractSamlUserIdentifierR
 
     if (attributeValue == null) {
       return SamlUserIdentifierResolutionResult
-        .resolutionFailure(String.format("Attribute '%s:%s' not found in assertion", attribute.getAlias(),
+        .resolutionFailure(format("Attribute '%s:%s' not found in assertion", attribute.getAlias(),
             attribute.getAttributeName()));
     }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/AttributeUserIdentifierResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/AttributeUserIdentifierResolver.java
@@ -50,5 +50,4 @@ public class AttributeUserIdentifierResolver extends AbstractSamlUserIdentifierR
     return SamlUserIdentifierResolutionResult.resolutionSuccess(samlId);
 
   }
-
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/EPTIDUserIdentifierResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/EPTIDUserIdentifierResolver.java
@@ -26,6 +26,8 @@ import org.opensaml.xml.XMLObject;
 import org.opensaml.xml.schema.XSAny;
 import org.springframework.security.saml.SAMLCredential;
 
+import com.google.common.base.Strings;
+
 import it.infn.mw.iam.persistence.model.IamSamlId;
 
 public class EPTIDUserIdentifierResolver extends AttributeUserIdentifierResolver {
@@ -38,6 +40,12 @@ public class EPTIDUserIdentifierResolver extends AttributeUserIdentifierResolver
   public SamlUserIdentifierResolutionResult resolveSamlUserIdentifier(
       SAMLCredential samlCredential) {
 
+    if (Strings.isNullOrEmpty(samlCredential.getRemoteEntityID())) {
+      return SamlUserIdentifierResolutionResult
+          .resolutionFailure(format("Malformed assertion while looking for attribute '%s:%s': remoteEntityID null or empty", attribute.getAlias(),
+              attribute.getAttributeName()));
+    }
+    
     Attribute eptidAttr = samlCredential.getAttribute(attribute.getAttributeName());
 
     if (eptidAttr == null) {
@@ -95,8 +103,8 @@ public class EPTIDUserIdentifierResolver extends AttributeUserIdentifierResolver
     }
 
     IamSamlId samlId = new IamSamlId();
+    
     samlId.setIdpId(samlCredential.getRemoteEntityID());
-    samlId.setIdpId(nameId.getNameQualifier());
     samlId.setAttributeId(attribute.getAttributeName());
     samlId.setUserId(nameId.getValue());
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/EPTIDUserIdentifierResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/EPTIDUserIdentifierResolver.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package it.infn.mw.iam.authn.saml.util;
 
 import static it.infn.mw.iam.authn.saml.util.SamlUserIdentifierResolutionResult.resolutionFailure;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/EPTIDUserIdentifierResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/EPTIDUserIdentifierResolver.java
@@ -1,0 +1,74 @@
+package it.infn.mw.iam.authn.saml.util;
+
+import static it.infn.mw.iam.authn.saml.util.SamlUserIdentifierResolutionResult.resolutionFailure;
+import static java.lang.String.format;
+import static java.util.Objects.isNull;
+
+import org.opensaml.saml2.core.Attribute;
+import org.opensaml.saml2.core.NameID;
+import org.opensaml.saml2.core.NameIDType;
+import org.opensaml.xml.XMLObject;
+import org.springframework.security.saml.SAMLCredential;
+
+import it.infn.mw.iam.persistence.model.IamSamlId;
+
+public class EPTIDUserIdentifierResolver extends AttributeUserIdentifierResolver {
+
+  public EPTIDUserIdentifierResolver() {
+    super(Saml2Attribute.EPTID);
+  }
+
+  @Override
+  public SamlUserIdentifierResolutionResult resolveSamlUserIdentifier(
+      SAMLCredential samlCredential) {
+
+    Attribute eptidAttr = samlCredential.getAttribute(attribute.getAttributeName());
+
+    if (eptidAttr == null) {
+      return SamlUserIdentifierResolutionResult
+        .resolutionFailure(format("Attribute '%s:%s' not found in assertion", attribute.getAlias(),
+            attribute.getAttributeName()));
+    }
+
+    if (isNull(eptidAttr.getAttributeValues()) ) {
+      return SamlUserIdentifierResolutionResult
+          .resolutionFailure(format("Attribute '%s:%s' is malformed: null or empty list of values",
+              attribute.getAlias(), attribute.getAttributeName()));
+    }
+    
+    if (eptidAttr.getAttributeValues().isEmpty()) {
+      return SamlUserIdentifierResolutionResult
+        .resolutionFailure(format("Attribute '%s:%s' is malformed: null or empty list of values",
+            attribute.getAlias(), attribute.getAttributeName()));
+    }
+
+    if (eptidAttr.getAttributeValues().size() > 1) {
+      return SamlUserIdentifierResolutionResult
+        .resolutionFailure(format("Attribute '%s:%s' is malformed: more than one value found",
+            attribute.getAlias(), attribute.getAttributeName()));
+    }
+
+    XMLObject maybeNameId = eptidAttr.getAttributeValues().get(0);
+
+    if (!(maybeNameId instanceof NameID)) {
+      return SamlUserIdentifierResolutionResult
+        .resolutionFailure(format("Attribute '%s:%s' is malformed: value is not a NameID",
+            attribute.getAlias(), attribute.getAttributeName()));
+    }
+
+    NameID nameId = (NameID) maybeNameId;
+    if (!nameId.getFormat().equals(NameIDType.PERSISTENT)) {
+      return resolutionFailure(
+          format("Attribute '%s:%s' is malformed: resolved NameID is not persistent: %s",
+              attribute.getAlias(), attribute.getAttributeName(), nameId.getFormat()));
+    }
+
+    IamSamlId samlId = new IamSamlId();
+    samlId.setIdpId(samlCredential.getRemoteEntityID());
+    samlId.setIdpId(nameId.getNameQualifier());
+    samlId.setAttributeId(attribute.getAttributeName());
+    samlId.setUserId(nameId.getValue());
+
+    return SamlUserIdentifierResolutionResult.resolutionSuccess(samlId);
+  }
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/FirstApplicableChainedSamlIdResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/FirstApplicableChainedSamlIdResolver.java
@@ -49,7 +49,14 @@ public class FirstApplicableChainedSamlIdResolver implements SamlUserIdentifierR
         return result;
       }
       
-      result.getErrorMessages().ifPresent(errorMessages::addAll);
+      result.getErrorMessages().ifPresent(messages -> {
+        errorMessages.addAll(messages);
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("SAML user id resolution with resolver {} failed with the following errors",
+              resolver.getClass().getName());
+          messages.forEach(LOG::debug);
+        }
+      });
     }
 
     LOG.debug(

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/NameIdUserIdentifierResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/NameIdUserIdentifierResolver.java
@@ -15,10 +15,12 @@
  */
 package it.infn.mw.iam.authn.saml.util;
 
+import static com.google.common.base.Verify.verifyNotNull;
+import static it.infn.mw.iam.authn.saml.util.SamlUserIdentifierResolutionResult.resolutionFailure;
+import static it.infn.mw.iam.authn.saml.util.SamlUserIdentifierResolutionResult.resolutionSuccess;
+
 import org.opensaml.saml2.core.NameID;
 import org.springframework.security.saml.SAMLCredential;
-
-import com.google.common.base.Verify;
 
 import it.infn.mw.iam.persistence.model.IamSamlId;
 
@@ -34,7 +36,7 @@ public class NameIdUserIdentifierResolver extends AbstractSamlUserIdentifierReso
   public SamlUserIdentifierResolutionResult resolveSamlUserIdentifier(
       SAMLCredential samlCredential) {
    
-    Verify.verifyNotNull(samlCredential);
+    verifyNotNull(samlCredential);
     
     if (samlCredential.getNameID() != null) {
       NameID nameId = samlCredential.getNameID();
@@ -44,11 +46,11 @@ public class NameIdUserIdentifierResolver extends AbstractSamlUserIdentifierReso
       samlId.setUserId(nameId.getValue());
       samlId.setIdpId(samlCredential.getRemoteEntityID());
 
-      return SamlUserIdentifierResolutionResult.resolutionSuccess(samlId);
+      return resolutionSuccess(samlId);
 
     }
     
-    return SamlUserIdentifierResolutionResult.resolutionFailure("NameID resolution failure");
+    return resolutionFailure("NameID resolution failure");
   }
 
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/PersistentNameIdUserIdentifierResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/PersistentNameIdUserIdentifierResolver.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package it.infn.mw.iam.authn.saml.util;
 
 import static it.infn.mw.iam.authn.saml.util.SamlUserIdentifierResolutionResult.resolutionFailure;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/PersistentNameIdUserIdentifierResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/PersistentNameIdUserIdentifierResolver.java
@@ -1,0 +1,44 @@
+package it.infn.mw.iam.authn.saml.util;
+
+import static it.infn.mw.iam.authn.saml.util.SamlUserIdentifierResolutionResult.resolutionFailure;
+import static it.infn.mw.iam.authn.saml.util.SamlUserIdentifierResolutionResult.resolutionSuccess;
+import static java.util.Objects.isNull;
+
+import org.opensaml.saml2.core.NameID;
+import org.opensaml.saml2.core.NameIDType;
+import org.springframework.security.saml.SAMLCredential;
+
+import it.infn.mw.iam.persistence.model.IamSamlId;
+
+public class PersistentNameIdUserIdentifierResolver extends AbstractSamlUserIdentifierResolver {
+
+  public static final String PERSISTENT_NAMEID_RESOLVER = "persistentNameID";
+
+  public PersistentNameIdUserIdentifierResolver() {
+    super(PERSISTENT_NAMEID_RESOLVER);
+  }
+
+  @Override
+  public SamlUserIdentifierResolutionResult resolveSamlUserIdentifier(
+      SAMLCredential samlCredential) {
+
+    if (isNull(samlCredential.getNameID())) {
+      return resolutionFailure(
+          "PersistentNameID resolution failure: NameID element not found in samlAssertion");
+    }
+
+    NameID nameId = samlCredential.getNameID();
+
+    if (!nameId.getFormat().equals(NameIDType.PERSISTENT)) {
+      return resolutionFailure(
+          "PersistentNameID resolution failure: resolved NameID is not persistent: "+nameId.getFormat());
+    }
+    
+    IamSamlId samlId = new IamSamlId();
+    samlId.setAttributeId(nameId.getFormat());
+    samlId.setUserId(nameId.getValue());
+    samlId.setIdpId(samlCredential.getRemoteEntityID());
+
+    return resolutionSuccess(samlId);
+  }
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/Saml2Attribute.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/Saml2Attribute.java
@@ -26,7 +26,9 @@ public enum Saml2Attribute {
   SN("sn", "urn:oid:2.5.4.4"),
   CN("cn", "urn:oid:2.5.4.3"),
   EMPLOYEE_NUMBER("employeeNumber", "urn:oid:2.16.840.1.113730.3.1.3"),
-  SPID_CODE("spidCode", "spidCode");
+  SPID_CODE("spidCode", "spidCode"),
+  SUBJECT_ID("subjectId", "urn:oasis:names:tc:SAML:profile:subject-id"),
+  PAIRWISE_ID("pairwiseId", "urn:oasis:names:tc:SAML:profile:pairwise-id");
 
   private String alias;
   private String attributeName;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/SamlIdResolvers.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/SamlIdResolvers.java
@@ -15,32 +15,34 @@
  */
 package it.infn.mw.iam.authn.saml.util;
 
+import static it.infn.mw.iam.authn.saml.util.NameIdUserIdentifierResolver.NAMEID_RESOLVER;
+import static it.infn.mw.iam.authn.saml.util.PersistentNameIdUserIdentifierResolver.PERSISTENT_NAMEID_RESOLVER;
+
 import com.google.common.collect.ImmutableMap;
 
 public class SamlIdResolvers {
-
-  public static final String NAME_ID_NAME = "nameID";
   
-  private ImmutableMap<String, SamlUserIdentifierResolver> registeredResolvers;
+  private ImmutableMap<String, NamedSamlUserIdentifierResolver> registeredResolvers;
 
   public SamlIdResolvers() {
-    ImmutableMap.Builder<String, SamlUserIdentifierResolver> builder =
-        ImmutableMap.<String, SamlUserIdentifierResolver>builder();
+    ImmutableMap.Builder<String, NamedSamlUserIdentifierResolver> builder =
+        ImmutableMap.<String, NamedSamlUserIdentifierResolver>builder();
 
     for (Saml2Attribute a : Saml2Attribute.values()) {
       builder.put(a.getAlias(), new AttributeUserIdentifierResolver(a));
     }
 
-    builder.put(NAME_ID_NAME, new NameIdUserIdentifierResolver());
+    builder.put(PERSISTENT_NAMEID_RESOLVER, new PersistentNameIdUserIdentifierResolver());
+    builder.put(NAMEID_RESOLVER, new NameIdUserIdentifierResolver());
 
     registeredResolvers = builder.build();
   }
 
-  public SamlUserIdentifierResolver byAttribute(Saml2Attribute attribute) {
+  public NamedSamlUserIdentifierResolver byAttribute(Saml2Attribute attribute) {
     return registeredResolvers.get(attribute.getAlias());
   }
   
-  public SamlUserIdentifierResolver byName(String name) {
+  public NamedSamlUserIdentifierResolver byName(String name) {
     return registeredResolvers.get(name);
   }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/SamlIdResolvers.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/SamlIdResolvers.java
@@ -20,21 +20,19 @@ import static it.infn.mw.iam.authn.saml.util.PersistentNameIdUserIdentifierResol
 import static it.infn.mw.iam.authn.saml.util.Saml2Attribute.EPTID;
 
 import java.util.EnumSet;
+import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
 
 public class SamlIdResolvers {
 
-  private ImmutableMap<String, NamedSamlUserIdentifierResolver> registeredResolvers;
-
-  public static final EnumSet<Saml2Attribute> STRING_VALUE_ATTRIBUTE_RESOLVERS =
-      EnumSet.complementOf(EnumSet.of(EPTID));
+  private Map<String, NamedSamlUserIdentifierResolver> registeredResolvers;
 
   public SamlIdResolvers() {
     ImmutableMap.Builder<String, NamedSamlUserIdentifierResolver> builder =
         ImmutableMap.<String, NamedSamlUserIdentifierResolver>builder();
 
-    for (Saml2Attribute a: STRING_VALUE_ATTRIBUTE_RESOLVERS) {
+    for (Saml2Attribute a: EnumSet.complementOf(EnumSet.of(EPTID))) {
       builder.put(a.getAlias(), new AttributeUserIdentifierResolver(a));
     }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/SamlIdResolvers.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/SamlIdResolvers.java
@@ -1,15 +1,17 @@
 /**
  * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2018
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package it.infn.mw.iam.authn.saml.util;
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/SamlIdResolvers.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/SamlIdResolvers.java
@@ -1,37 +1,43 @@
 /**
  * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2018
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package it.infn.mw.iam.authn.saml.util;
 
 import static it.infn.mw.iam.authn.saml.util.NameIdUserIdentifierResolver.NAMEID_RESOLVER;
 import static it.infn.mw.iam.authn.saml.util.PersistentNameIdUserIdentifierResolver.PERSISTENT_NAMEID_RESOLVER;
+import static it.infn.mw.iam.authn.saml.util.Saml2Attribute.EPTID;
+
+import java.util.EnumSet;
 
 import com.google.common.collect.ImmutableMap;
 
 public class SamlIdResolvers {
-  
+
   private ImmutableMap<String, NamedSamlUserIdentifierResolver> registeredResolvers;
+
+  public static final EnumSet<Saml2Attribute> STRING_VALUE_ATTRIBUTE_RESOLVERS =
+      EnumSet.complementOf(EnumSet.of(EPTID));
 
   public SamlIdResolvers() {
     ImmutableMap.Builder<String, NamedSamlUserIdentifierResolver> builder =
         ImmutableMap.<String, NamedSamlUserIdentifierResolver>builder();
 
-    for (Saml2Attribute a : Saml2Attribute.values()) {
+    for (Saml2Attribute a: STRING_VALUE_ATTRIBUTE_RESOLVERS) {
       builder.put(a.getAlias(), new AttributeUserIdentifierResolver(a));
     }
 
+    // EPTID has its own resolver 
+    builder.put(EPTID.getAlias(), new EPTIDUserIdentifierResolver());
     builder.put(PERSISTENT_NAMEID_RESOLVER, new PersistentNameIdUserIdentifierResolver());
     builder.put(NAMEID_RESOLVER, new NameIdUserIdentifierResolver());
 
@@ -41,7 +47,7 @@ public class SamlIdResolvers {
   public NamedSamlUserIdentifierResolver byAttribute(Saml2Attribute attribute) {
     return registeredResolvers.get(attribute.getAlias());
   }
-  
+
   public NamedSamlUserIdentifierResolver byName(String name) {
     return registeredResolvers.get(name);
   }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/ResolverTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/ResolverTests.java
@@ -304,7 +304,7 @@ public class ResolverTests {
     XSAny attributeValue = mock(XSAny.class);
     NameID nameid = mock(NameID.class);
     XMLObject object = mock(XMLObject.class);
-    when(cred.getRemoteEntityID()).thenReturn("entityId");
+    
 
     when(cred.getAttribute(Saml2Attribute.EPTID.getAttributeName())).thenReturn(attribute);
 
@@ -312,6 +312,15 @@ public class ResolverTests {
     SamlUserIdentifierResolver resolver = new EPTIDUserIdentifierResolver();
 
     SamlUserIdentifierResolutionResult result = resolver.resolveSamlUserIdentifier(cred);
+    assertThat(result.getResolvedId().isPresent(), is(false));
+    assertThat(result.getErrorMessages().isPresent(), is(true));
+    assertThat(result.getErrorMessages().get().get(0),
+        is("Malformed assertion while looking for attribute 'eduPersonTargetedId:urn:oid:1.3.6.1.4.1.5923.1.1.1.10': "
+            + "remoteEntityID null or empty"));
+    
+    when(cred.getRemoteEntityID()).thenReturn("entityId");
+    
+    result = resolver.resolveSamlUserIdentifier(cred);
     assertThat(result.getResolvedId().isPresent(), is(false));
     assertThat(result.getErrorMessages().isPresent(), is(true));
     assertThat(result.getErrorMessages().get().get(0),
@@ -398,6 +407,7 @@ public class ResolverTests {
     assertThat(result.getResolvedId().isPresent(), is(true));
     assertThat(result.getErrorMessages().isPresent(), is(false));
     assertThat(result.getResolvedId().get().getUserId(), is("nameid"));
+    assertThat(result.getResolvedId().get().getIdpId(), is("entityId"));
   }
 
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/ResolverTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/ResolverTests.java
@@ -1,15 +1,17 @@
 /**
  * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2018
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package it.infn.mw.iam.test.ext_authn.saml;
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/ResolverTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/ResolverTests.java
@@ -1,25 +1,27 @@
 /**
  * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2018
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package it.infn.mw.iam.test.ext_authn.saml;
 
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 
@@ -28,11 +30,16 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.opensaml.saml2.core.NameID;
+import org.opensaml.saml2.core.NameIDType;
 import org.springframework.security.saml.SAMLCredential;
 
+import it.infn.mw.iam.authn.saml.util.FirstApplicableChainedSamlIdResolver;
 import it.infn.mw.iam.authn.saml.util.NameIdUserIdentifierResolver;
+import it.infn.mw.iam.authn.saml.util.NamedSamlUserIdentifierResolver;
+import it.infn.mw.iam.authn.saml.util.PersistentNameIdUserIdentifierResolver;
 import it.infn.mw.iam.authn.saml.util.Saml2Attribute;
 import it.infn.mw.iam.authn.saml.util.SamlIdResolvers;
+import it.infn.mw.iam.authn.saml.util.SamlUserIdentifierResolutionResult;
 import it.infn.mw.iam.authn.saml.util.SamlUserIdentifierResolver;
 import it.infn.mw.iam.persistence.model.IamSamlId;
 
@@ -40,15 +47,15 @@ public class ResolverTests {
 
 
   @Test
-  public void testSamlIdResolverAttributeResolution(){
+  public void testSamlIdResolverAttributeResolution() {
     SamlIdResolvers resolvers = new SamlIdResolvers();
-    
-    for (Saml2Attribute a: Saml2Attribute.values()){
+
+    for (Saml2Attribute a : Saml2Attribute.values()) {
       Assert.assertNotNull(resolvers.byName(a.getAlias()));
     }
-    
+
   }
-  
+
   @Test
   public void emptyNameIdResolverTest() {
 
@@ -76,12 +83,65 @@ public class ResolverTests {
 
     SamlUserIdentifierResolver resolver = new NameIdUserIdentifierResolver();
 
-    IamSamlId resolvedId = resolver.resolveSamlUserIdentifier(cred).getResolvedId()
-      .orElseThrow(() -> new AssertionError("Could not resolve nameid SAML ID"));
+    IamSamlId resolvedId = resolver.resolveSamlUserIdentifier(cred).getResolvedId().orElseThrow(
+        () -> new AssertionError("Could not resolve nameid SAML ID"));
 
     Assert.assertThat(resolvedId.getUserId(), Matchers.equalTo("nameid"));
     Assert.assertThat(resolvedId.getIdpId(), Matchers.equalTo("entityId"));
     Assert.assertThat(resolvedId.getAttributeId(), Matchers.equalTo("format"));
+  }
+
+  @Test
+  public void persistentNameIdResolverTest() {
+    NameID nameId = Mockito.mock(NameID.class);
+    Mockito.when(nameId.getValue()).thenReturn("nameid");
+    Mockito.when(nameId.getFormat()).thenReturn("format");
+
+    SAMLCredential cred = Mockito.mock(SAMLCredential.class);
+    Mockito.when(cred.getNameID()).thenReturn(nameId);
+    Mockito.when(cred.getRemoteEntityID()).thenReturn("entityId");
+
+    SamlUserIdentifierResolver resolver = new PersistentNameIdUserIdentifierResolver();
+
+    SamlUserIdentifierResolutionResult result = resolver.resolveSamlUserIdentifier(cred);
+    assertThat(result.getResolvedId().isPresent(), is(false));
+    assertThat(result.getErrorMessages().isPresent(), is(true));
+    assertThat(result.getErrorMessages().get().get(0),
+        containsString("resolved NameID is not persistent"));
+  }
+
+  @Test
+  public void persistentNameIdResolverTestNoNameId() {
+
+    SAMLCredential cred = Mockito.mock(SAMLCredential.class);
+    Mockito.when(cred.getRemoteEntityID()).thenReturn("entityId");
+
+    SamlUserIdentifierResolver resolver = new PersistentNameIdUserIdentifierResolver();
+
+    SamlUserIdentifierResolutionResult result = resolver.resolveSamlUserIdentifier(cred);
+    assertThat(result.getResolvedId().isPresent(), is(false));
+    assertThat(result.getErrorMessages().isPresent(), is(true));
+    assertThat(result.getErrorMessages().get().get(0),
+        containsString("NameID element not found in samlAssertion"));
+  }
+
+  @Test
+  public void persistentNameIdResolverTestResolutionSuccess() {
+    NameID nameId = Mockito.mock(NameID.class);
+    Mockito.when(nameId.getValue()).thenReturn("nameid");
+    Mockito.when(nameId.getFormat()).thenReturn(NameIDType.PERSISTENT);
+
+    SAMLCredential cred = Mockito.mock(SAMLCredential.class);
+    Mockito.when(cred.getNameID()).thenReturn(nameId);
+    Mockito.when(cred.getRemoteEntityID()).thenReturn("entityId");
+
+    SamlUserIdentifierResolver resolver = new PersistentNameIdUserIdentifierResolver();
+
+    SamlUserIdentifierResolutionResult result = resolver.resolveSamlUserIdentifier(cred);
+    assertThat(result.getResolvedId().isPresent(), is(true));
+    assertThat(result.getErrorMessages().isPresent(), is(false));
+    assertThat(result.getResolvedId().get().getUserId(), is("nameid"));
+
   }
 
   @Test
@@ -91,20 +151,112 @@ public class ResolverTests {
     SamlUserIdentifierResolver resolver = resolvers.byAttribute(Saml2Attribute.MAIL);
 
     assertThat(resolver, is(not(nullValue())));
-    
+
     SAMLCredential cred = Mockito.mock(SAMLCredential.class);
     Mockito.when(cred.getAttributeAsString(Saml2Attribute.MAIL.getAttributeName()))
       .thenReturn("test@test.org");
     Mockito.when(cred.getRemoteEntityID()).thenReturn("entityId");
 
-    IamSamlId resolvedId = resolver.resolveSamlUserIdentifier(cred).getResolvedId()
-      .orElseThrow(() -> new AssertionError("Could not resolve email address SAML ID"));
+    IamSamlId resolvedId = resolver.resolveSamlUserIdentifier(cred).getResolvedId().orElseThrow(
+        () -> new AssertionError("Could not resolve email address SAML ID"));
 
     assertThat(resolvedId.getUserId(), equalTo("test@test.org"));
-    assertThat(resolvedId.getAttributeId(),
-        equalTo(Saml2Attribute.MAIL.getAttributeName()));
+    assertThat(resolvedId.getAttributeId(), equalTo(Saml2Attribute.MAIL.getAttributeName()));
 
     Assert.assertThat(resolvedId.getIdpId(), equalTo("entityId"));
+  }
+
+  @Test
+  public void attributeNotFoundResolverTest() {
+
+    SamlIdResolvers resolvers = new SamlIdResolvers();
+    SamlUserIdentifierResolver resolver = resolvers.byAttribute(Saml2Attribute.SUBJECT_ID);
+    assertThat(resolver, is(not(nullValue())));
+
+    SAMLCredential cred = Mockito.mock(SAMLCredential.class);
+    Mockito.when(cred.getAttributeAsString(Saml2Attribute.MAIL.getAttributeName()))
+      .thenReturn("test@test.org");
+    Mockito.when(cred.getRemoteEntityID()).thenReturn("entityId");
+
+    SamlUserIdentifierResolutionResult result = resolver.resolveSamlUserIdentifier(cred);
+    assertThat(result.getResolvedId().isPresent(), is(false));
+    assertThat(result.getErrorMessages().isPresent(), is(true));
+
+    assertThat(result.getErrorMessages().get().get(0),
+        containsString(format("Attribute '%s:%s' not found in assertion",
+            Saml2Attribute.SUBJECT_ID.getAlias(), Saml2Attribute.SUBJECT_ID.getAttributeName())));
+
+  }
+
+  @Test
+  public void firstApplicableChainedResolverTest() {
+
+    SamlIdResolvers resolvers = new SamlIdResolvers();
+
+    SamlUserIdentifierResolver subjectIdResolver = resolvers.byAttribute(Saml2Attribute.SUBJECT_ID);
+
+    SamlUserIdentifierResolver uniqueIdResolver = resolvers.byAttribute(Saml2Attribute.EPUID);
+
+    SamlUserIdentifierResolver persistentNameIdResolver =
+        new PersistentNameIdUserIdentifierResolver();
+
+    SAMLCredential cred = Mockito.mock(SAMLCredential.class);
+    when(cred.getAttributeAsString(Saml2Attribute.MAIL.getAttributeName()))
+      .thenReturn("test@test.org");
+    when(cred.getRemoteEntityID()).thenReturn("entityId");
+
+    SamlUserIdentifierResolver resolver = new FirstApplicableChainedSamlIdResolver(
+        asList(subjectIdResolver, uniqueIdResolver, persistentNameIdResolver));
+
+    SamlUserIdentifierResolutionResult result = resolver.resolveSamlUserIdentifier(cred);
+    assertThat(result.getResolvedId().isPresent(), is(false));
+    assertThat(result.getErrorMessages().isPresent(), is(true));
+    assertThat(result.getErrorMessages().get().size(), is(3));
+    assertThat(result.getErrorMessages().get().get(0),
+        containsString(format("Attribute '%s:%s' not found in assertion",
+            Saml2Attribute.SUBJECT_ID.getAlias(), Saml2Attribute.SUBJECT_ID.getAttributeName())));
+
+    assertThat(result.getErrorMessages().get().get(1),
+        containsString(format("Attribute '%s:%s' not found in assertion",
+            Saml2Attribute.EPUID.getAlias(), Saml2Attribute.EPUID.getAttributeName())));
+
+    assertThat(result.getErrorMessages().get().get(2),
+        containsString("NameID element not found in samlAssertion"));
+  }
+
+  @Test
+  public void firstApplicableChainedResolverTestSuccess() {
+
+    SamlIdResolvers resolvers = new SamlIdResolvers();
+
+    SamlUserIdentifierResolver subjectIdResolver = resolvers.byAttribute(Saml2Attribute.SUBJECT_ID);
+
+    SamlUserIdentifierResolver uniqueIdResolver = resolvers.byAttribute(Saml2Attribute.EPUID);
+
+    SamlUserIdentifierResolver persistentNameIdResolver =
+        new PersistentNameIdUserIdentifierResolver();
+
+    SAMLCredential cred = Mockito.mock(SAMLCredential.class);
+    when(cred.getAttributeAsString(Saml2Attribute.EPUID.getAttributeName()))
+      .thenReturn("123456789@test.org");
+    when(cred.getRemoteEntityID()).thenReturn("entityId");
+
+    SamlUserIdentifierResolver resolver = new FirstApplicableChainedSamlIdResolver(
+        asList(subjectIdResolver, uniqueIdResolver, persistentNameIdResolver));
+
+    SamlUserIdentifierResolutionResult result = resolver.resolveSamlUserIdentifier(cred);
+    assertThat(result.getResolvedId().isPresent(), is(true));
+    assertThat(result.getResolvedId().get().getUserId(), is("123456789@test.org"));
+
+  }
+
+  @Test
+  public void getNameTest() {
+
+    SamlIdResolvers resolvers = new SamlIdResolvers();
+    NamedSamlUserIdentifierResolver subjectIdResolver =
+        resolvers.byAttribute(Saml2Attribute.SUBJECT_ID);
+    assertThat(subjectIdResolver.getName(), is(Saml2Attribute.SUBJECT_ID.name()));
 
   }
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/saml/AssertionBuilderTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/saml/AssertionBuilderTests.java
@@ -93,6 +93,7 @@ public class AssertionBuilderTests {
       .givenName("Illo")
       .sn("Camughe")
       .mail("sub@mail.test")
+      .eptid()
       .build();
 
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/util/saml/SamlAssertionBuilder.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/util/saml/SamlAssertionBuilder.java
@@ -46,7 +46,9 @@ import org.opensaml.saml2.core.impl.AuthnContextClassRefBuilder;
 import org.opensaml.saml2.core.impl.AuthnStatementBuilder;
 import org.opensaml.xml.XMLObjectBuilderFactory;
 import org.opensaml.xml.io.MarshallingException;
+import org.opensaml.xml.schema.XSAny;
 import org.opensaml.xml.schema.XSString;
+import org.opensaml.xml.schema.impl.XSAnyBuilder;
 import org.opensaml.xml.schema.impl.XSStringBuilder;
 import org.opensaml.xml.security.SecurityException;
 import org.opensaml.xml.security.credential.Credential;
@@ -60,6 +62,7 @@ import org.opensaml.xml.signature.impl.SignatureBuilder;
 
 import com.google.common.collect.Lists;
 
+import it.infn.mw.iam.authn.saml.util.Saml2Attribute;
 import it.infn.mw.iam.authn.saml.util.SamlAttributeNames;
 
 public class SamlAssertionBuilder {
@@ -184,6 +187,32 @@ public class SamlAssertionBuilder {
     return as;
   }
 
+  private Attribute buildEPTIDAttribute() {
+    Attribute attr = attributeBuilder.buildObject();
+    attr.setName(Saml2Attribute.EPTID.getAttributeName());
+    attr.setNameFormat(Attribute.URI_REFERENCE);
+    
+    @SuppressWarnings("unchecked")
+    SAMLObjectBuilder<NameID> niBuilder =
+    (SAMLObjectBuilder<NameID>) builderFactory.getBuilder(NameID.DEFAULT_ELEMENT_NAME);
+    
+    
+    NameID nid = niBuilder.buildObject();
+    nid.setValue(nameId);
+    nid.setFormat(nameIdFormat);
+    
+    XMLObjectBuilderFactory bf = Configuration.getBuilderFactory();
+    XSAnyBuilder builder = (XSAnyBuilder) bf.getBuilder(XSAny.TYPE_NAME);
+    XSAny attrVal = builder.buildObject(AttributeValue.DEFAULT_ELEMENT_NAME);
+    
+    
+    attrVal.getUnknownXMLObjects().add(nid);
+    attr.getAttributeValues().add(attrVal);
+    
+    return attr;
+  }
+  
+  
   private Attribute buildStringAttribute(String name, String value) {
     Attribute attr = attributeBuilder.buildObject();
     attr.setName(name);
@@ -199,6 +228,11 @@ public class SamlAssertionBuilder {
 
     attr.getAttributeValues().add(xsString);
     return attr;
+  }
+  
+  public SamlAssertionBuilder eptid() {
+    attributes.add(buildEPTIDAttribute());
+    return this;
   }
 
   public SamlAssertionBuilder eppn(String eppn) {
@@ -294,24 +328,27 @@ public class SamlAssertionBuilder {
 
   }
 
-  private Subject buildSubject() {
-
+  private NameID buildNameID() {
     @SuppressWarnings("unchecked")
     SAMLObjectBuilder<NameID> niBuilder =
-	(SAMLObjectBuilder<NameID>) builderFactory.getBuilder(NameID.DEFAULT_ELEMENT_NAME);
+    (SAMLObjectBuilder<NameID>) builderFactory.getBuilder(NameID.DEFAULT_ELEMENT_NAME);
 
     NameID nid = niBuilder.buildObject();
     nid.setValue(nameId);
     nid.setFormat(nameIdFormat);
+    
+    return nid;
+  }
+  
+  private Subject buildSubject() {
 
     @SuppressWarnings("unchecked")
     SAMLObjectBuilder<Subject> builder =
 	(SAMLObjectBuilder<Subject>) builderFactory.getBuilder(Subject.DEFAULT_ELEMENT_NAME);
 
-
     Subject sub = builder.buildObject();
 
-    sub.setNameID(nid);
+    sub.setNameID(buildNameID());
 
     sub.getSubjectConfirmations().add(buildSubjectConfirmation());
 


### PR DESCRIPTION
This PR introduces:

- proper support for parsing EPTID SAML attribute ( fixes #253)
- support for the SAML persistent nameId resolver and the Subject ID attribute