### PR TITLE
Changes to AUP page design

### DIFF
--- a/iam-login-service/src/main/webapp/WEB-INF/views/iam/signAup.jsp
+++ b/iam-login-service/src/main/webapp/WEB-INF/views/iam/signAup.jsp
@@ -19,7 +19,7 @@
 <t:page title="Sign Acceptable Usage Policy">
   <h2 class="text-center">Sign Acceptable Usage Policy</h2>
   <form id="sign-aup-form" class="sign-aup-form form" action="/iam/aup/sign" method="post">
-    <p>In order to proceed, you need to sign the Acceptable Usage Policy (AUP) for this organization:</p>
+    <p id="sign-aup-subtitle">In order to proceed, you need to sign the Acceptable Usage Policy (AUP) for this organization:</p>
     <div class="form-group">
       <div class="aup-text">${aup.text}</div>
     </div>

--- a/iam-login-service/src/main/webapp/resources/iam/css/iam.css
+++ b/iam-login-service/src/main/webapp/resources/iam/css/iam.css
@@ -100,6 +100,10 @@
     text-align: center;
 }
 
+#sign-aup-form #sign-aup-subtitle {
+  text-align: center;
+}
+
 
 #login-error {
   margin: 0 auto;

--- a/iam-login-service/src/main/webapp/resources/iam/css/iam.css
+++ b/iam-login-service/src/main/webapp/resources/iam/css/iam.css
@@ -81,7 +81,7 @@
 #sign-aup-form {
   padding-top: 2em;
   margin: 0 auto;
-  max-width: 400px;
+  width: 90%;
 }
 
 #sign-aup-form p {


### PR DESCRIPTION
These changes make the AUP field scale to the browser size, rather than having it at a fixed 400px width. This means that longer AUPs are more readable when viewed in a desktop browser.