### PR TITLE
Allow inclusion of the scope claim in access tokens

### DIFF
--- a/iam-login-service/src/main/resources/application.yml
+++ b/iam-login-service/src/main/resources/application.yml
@@ -77,7 +77,8 @@ iam:
 
   access_token:
     include_authn_info: ${IAM_ACCESS_TOKEN_INCLUDE_AUTHN_INFO:false}
-    
+    include_scope: ${IAM_ACCESS_TOKEN_INCLUDE_SCOPE:false}
+
   superuser:
     username: ${IAM_SUPERUSER_USERNAME:superuser}
     password: ${IAM_SUPERUSER_PASSWORD:superpassword}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/AccessTokenIncludeScopeTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/AccessTokenIncludeScopeTests.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.oauth;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTParser;
+
+import it.infn.mw.iam.IamLoginService;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = {IamLoginService.class})
+@WebAppConfiguration
+@Transactional
+@TestPropertySource(properties = {"iam.access_token.include_scope=true"})
+public class AccessTokenIncludeScopeTests extends EndpointsTestUtils {
+  private static final String CLIENT_CREDENTIALS_CLIENT_ID = "client-cred";
+  private static final String CLIENT_CREDENTIALS_CLIENT_SECRET = "secret";
+  
+  private static final String SCOPES = "read-tasks";
+  private static final String SCOPE_CLAIM = "scope";
+  
+  private static final String USERNAME = "test";
+  private static final String PASSWORD = "password";
+
+  @Before
+  public void setup() throws Exception {
+    buildMockMvc();
+  }
+
+  @Test
+  public void testScopeIncludedInAccessTokenClientCred() throws Exception {
+
+    String accessToken = new AccessTokenGetter().grantType("client_credentials")
+      .clientId(CLIENT_CREDENTIALS_CLIENT_ID)
+      .clientSecret(CLIENT_CREDENTIALS_CLIENT_SECRET)
+      .scope(SCOPES)
+      .getAccessTokenValue();
+
+    JWT token = JWTParser.parse(accessToken);
+    String scopeClaim = (String) token.getJWTClaimsSet().getClaim(SCOPE_CLAIM); 
+    assertThat(scopeClaim, notNullValue());
+    assertThat(scopeClaim, is(SCOPES));
+  }
+  
+  @Test
+  public void testScopeIncludedInPasswordFlow()  throws Exception {
+    String accessToken = new AccessTokenGetter().grantType("password")
+        .clientId(CLIENT_CREDENTIALS_CLIENT_ID)
+        .clientSecret(CLIENT_CREDENTIALS_CLIENT_SECRET)
+        .username(USERNAME)
+        .password(PASSWORD)
+        .scope(SCOPES)
+        .getAccessTokenValue();
+    
+    JWT token = JWTParser.parse(accessToken);
+    String scopeClaim = (String) token.getJWTClaimsSet().getClaim(SCOPE_CLAIM); 
+    assertThat(scopeClaim, notNullValue());
+    assertThat(scopeClaim, is(SCOPES));
+  }
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/EndpointsTestUtils.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/EndpointsTestUtils.java
@@ -15,6 +15,7 @@
  */
 package it.infn.mw.iam.test.oauth;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
@@ -118,9 +119,12 @@ public class EndpointsTestUtils {
     public String performTokenRequest() throws Exception {
       MockHttpServletRequestBuilder req = post("/token").param("grant_type", grantType)
         .param("client_id", clientId)
-        .param("client_secret", clientSecret)
-        .param("scope", scope);
-
+        .param("client_secret", clientSecret);
+      
+      if (!isNullOrEmpty(scope)) {
+        req.param("scope", scope);
+      }
+        
       if ("password".equals(grantType)) {
         req.param("username", username).param("password", password);
       }


### PR DESCRIPTION
This commit introduces the ability to include the scope claim in access
tokens issued by IAM.

The inclusion of the scope claim in access token is activated by setting
the `iam.access_token.include_scope` property to `true`. The default
value is `false`, i.e. issued scopes are not included in access tokens
by default.

Issue: https://github.com/indigo-iam/iam/issues/289