### PR TITLE
Fine-grained external authentication validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.5.0 (???)
+## 1.5.0 (2019-10-03)
 
 ### Added
 
@@ -9,6 +9,10 @@
 
 - IAM now supports group managers (#231). Group managers can approve group
   membership requests.
+
+- It is now possible to define validation rules on external SAML and OpenID
+  Connect authentications, e.g., to limit access to IAM based on entitlements
+  (#277)
 
 - Real support for login hint on authorization requests: this feature allows a
   relying party to specify a preference on which external SAML IdP should be
@@ -37,13 +41,13 @@
 
 - The token management API now supports sorting (#255)
 
-- Orphaned tokens are now cleanup up from the database (#263)
+- Orphaned tokens are now cleaned up from the database (#263)
 
 - A bug that prevented the deployment of the IAM DB on MySQL 5.7 has been
   resolved (#265)
 
-- Support for the OAuth Device Code flow is now advertised in the IAM OpenID
-  Connect discovery document (#268)
+- Support for the OAuth Device Code flow is now correctly advertised in the IAM
+  OpenID Connect discovery document (#268)
 
 - The device code default expiration is correctly set for dynamically
   registered clients (#267)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,13 +92,16 @@ pipeline {
           }
 
           post {
-            success {
-              junit '**/target/surefire-reports/TEST-*.xml'
-              step( [ $class: 'JacocoPublisher' ] )
+            always {
+              script {
+                def hasJunitReports = fileExists 'iam-login-service/target/surefire-reports'
+                if (hasJunitReports) {
+                  junit '**/target/surefire-reports/TEST-*.xml'
+                  step( [ $class: 'JacocoPublisher' ] )
+                }
+              }
             }
             unsuccessful {
-              junit '**/target/surefire-reports/TEST-*.xml'
-              step( [ $class: 'JacocoPublisher' ] )
               archiveArtifacts artifacts:'**/**/*.dump'
               archiveArtifacts artifacts:'**/**/*.dumpstream'
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,11 +92,13 @@ pipeline {
           }
 
           post {
-            always {
+            success {
               junit '**/target/surefire-reports/TEST-*.xml'
               step( [ $class: 'JacocoPublisher' ] )
             }
             unsuccessful {
+              junit '**/target/surefire-reports/TEST-*.xml'
+              step( [ $class: 'JacocoPublisher' ] )
               archiveArtifacts artifacts:'**/**/*.dump'
               archiveArtifacts artifacts:'**/**/*.dumpstream'
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,7 +103,7 @@ pipeline {
           post {
             always {
               script {
-                maybeArchiveJUnitReports
+                maybeArchiveJUnitReports()
               }
             }
             unsuccessful {
@@ -151,7 +151,7 @@ pipeline {
           post {
             always {
               script {
-                maybeArchiveJUnitReports
+                maybeArchiveJUnitReports()
               }
             }
             unsuccessful {
@@ -193,7 +193,7 @@ pipeline {
           post {
             always {
               script {
-                maybeArchiveJUnitReports
+                maybeArchiveJUnitReports()
               }
             }
             unsuccessful {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,10 @@ pipeline {
           when{
             allOf {
               not {
-                expression{ return params.SONAR_ANALYSIS }
+                anyOf {
+                  triggeredBy 'TimerTrigger'
+                  expression{ return params.SONAR_ANALYSIS }
+                }
               }
               not {
                 expression{ return params.SKIP_TESTS }
@@ -104,7 +107,10 @@ pipeline {
           when{
             allOf{
               expression{ env.CHANGE_URL != ''}
-              expression{ return params.SONAR_ANALYSIS }
+              anyOf {
+                triggeredBy 'TimerTrigger'
+                expression{ return params.SONAR_ANALYSIS }
+              }
             }
           }
           steps {
@@ -149,7 +155,10 @@ pipeline {
           when{
             allOf{
               expression{ env.CHANGE_URL == ''}
-              expression{ return params.SONAR_ANALYSIS }
+              anyOf {
+                triggeredBy 'TimerTrigger'
+                expression{ return params.SONAR_ANALYSIS }
+              }
             }
           }
 
@@ -185,7 +194,10 @@ pipeline {
         stage('quality-gate') {
 
           when{
-            expression{ return params.SONAR_ANALYSIS }
+            anyOf {
+              triggeredBy 'TimerTrigger'
+              expression{ return params.SONAR_ANALYSIS }
+            }
           }
 
           steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,6 +103,7 @@ pipeline {
           post {
             always {
               script {
+                sh 'echo post test'
                 maybeArchiveJUnitReports()
               }
             }
@@ -151,6 +152,7 @@ pipeline {
           post {
             always {
               script {
+                sh 'echo post PR analysis'
                 maybeArchiveJUnitReports()
               }
             }
@@ -193,6 +195,7 @@ pipeline {
           post {
             always {
               script {
+                sh 'echo post analysis'
                 maybeArchiveJUnitReports()
               }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,7 +117,7 @@ pipeline {
         stage('PR analysis'){
           when{
             allOf{
-              expression{ env.CHANGE_URL != ''}
+              expression{ env.CHANGE_URL }
               anyOf {
                 triggeredBy 'TimerTrigger'
                 expression{ return params.SONAR_ANALYSIS }
@@ -152,7 +152,6 @@ pipeline {
           post {
             always {
               script {
-                sh 'echo post PR analysis'
                 maybeArchiveJUnitReports()
               }
             }
@@ -167,7 +166,7 @@ pipeline {
 
           when{
             allOf{
-              expression{ env.CHANGE_URL == ''}
+              expression{ !env.CHANGE_URL }
               anyOf {
                 triggeredBy 'TimerTrigger'
                 expression{ return params.SONAR_ANALYSIS }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,15 @@
 #!/usr/bin/env groovy
 @Library('sd')_
+
 def kubeLabel = getKubeLabel()
+
+def maybeArchiveJUnitReports(){
+  def hasJunitReports = fileExists 'iam-login-service/target/surefire-reports'
+  if (hasJunitReports) {
+    junit '**/target/surefire-reports/TEST-*.xml'
+    step( [ $class: 'JacocoPublisher' ] )
+  }
+}
 
 pipeline {
 
@@ -94,11 +103,7 @@ pipeline {
           post {
             always {
               script {
-                def hasJunitReports = fileExists 'iam-login-service/target/surefire-reports'
-                if (hasJunitReports) {
-                  junit '**/target/surefire-reports/TEST-*.xml'
-                  step( [ $class: 'JacocoPublisher' ] )
-                }
+                maybeArchiveJUnitReports
               }
             }
             unsuccessful {
@@ -145,8 +150,9 @@ pipeline {
 
           post {
             always {
-              junit '**/target/surefire-reports/TEST-*.xml'
-              step( [ $class: 'JacocoPublisher' ] )
+              script {
+                maybeArchiveJUnitReports
+              }
             }
             unsuccessful {
               archiveArtifacts artifacts:'**/**/*.dump'
@@ -186,8 +192,9 @@ pipeline {
           }
           post {
             always {
-              junit '**/target/surefire-reports/TEST-*.xml'
-                step( [ $class: 'JacocoPublisher' ] )
+              script {
+                maybeArchiveJUnitReports
+              }
             }
             unsuccessful {
               archiveArtifacts artifacts:'**/**/*.dump'

--- a/iam-common/pom.xml
+++ b/iam-common/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>it.infn.mw</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>1.5.0.rc6-SNAPSHOT</version>
+    <version>1.5.0.rc7-SNAPSHOT</version>
   </parent>
 
   <artifactId>iam-common</artifactId>

--- a/iam-login-service/pom.xml
+++ b/iam-login-service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>it.infn.mw</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>1.5.0.rc6-SNAPSHOT</version>
+    <version>1.5.0.rc7-SNAPSHOT</version>
   </parent>
 
   <artifactId>iam-login-service</artifactId>

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/BaseValidatorCheck.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/BaseValidatorCheck.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn.common;
+
+import static it.infn.mw.iam.authn.common.ValidatorResult.failure;
+import static java.lang.String.format;
+import static java.util.Objects.nonNull;
+
+public abstract class BaseValidatorCheck<T> implements ValidatorCheck<T> {
+
+  private final String message;
+  
+  protected BaseValidatorCheck(String msg) {
+    this.message = msg;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public boolean hasMessage() {
+    return nonNull(getMessage());
+  }
+
+  protected ValidatorResult handleFailure(ValidatorResult result) {
+    if (result.isError()) {
+      return result;
+    }
+    if (hasMessage()) {
+      return failure(getMessage());
+    } else {
+      return ValidatorResult.failure(format("Validation error: %s", result.getMessage()));
+    }
+  }
+  
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/CompositeValidatorCheck.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/CompositeValidatorCheck.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn.common;
+
+import static it.infn.mw.iam.authn.common.ValidatorResult.failure;
+import static java.lang.String.format;
+import static java.util.Objects.nonNull;
+
+import java.util.List;
+
+public abstract class CompositeValidatorCheck<T> implements ValidatorCheck<T> {
+
+  private final List<ValidatorCheck<T>> checks;
+  private final String message;
+
+  protected CompositeValidatorCheck(List<ValidatorCheck<T>> checks, String message) {
+    this.checks = checks;
+    this.message = message;
+  }
+
+  protected ValidatorResult handleFailure(ValidatorResult result) {
+    if (result.isError()) {
+      return result;
+    }
+    if (hasMessage()) {
+      return failure(message);
+    } else {
+      return ValidatorResult.failure(format("Validation error: %s", result.getMessage()));
+    }
+  }
+
+  public boolean hasMessage() {
+    return nonNull(message);
+  }
+
+  public List<ValidatorCheck<T>> getChecks() {
+    return checks;
+  }
+  
+  public String getMessage() {
+    return message;
+  }
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/CompositeValidatorCheck.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/CompositeValidatorCheck.java
@@ -15,42 +15,18 @@
  */
 package it.infn.mw.iam.authn.common;
 
-import static it.infn.mw.iam.authn.common.ValidatorResult.failure;
-import static java.lang.String.format;
-import static java.util.Objects.nonNull;
-
 import java.util.List;
 
-public abstract class CompositeValidatorCheck<T> implements ValidatorCheck<T> {
+public abstract class CompositeValidatorCheck<T> extends BaseValidatorCheck<T> {
 
   private final List<ValidatorCheck<T>> checks;
-  private final String message;
 
   protected CompositeValidatorCheck(List<ValidatorCheck<T>> checks, String message) {
+    super(message);
     this.checks = checks;
-    this.message = message;
-  }
-
-  protected ValidatorResult handleFailure(ValidatorResult result) {
-    if (result.isError()) {
-      return result;
-    }
-    if (hasMessage()) {
-      return failure(message);
-    } else {
-      return ValidatorResult.failure(format("Validation error: %s", result.getMessage()));
-    }
-  }
-
-  public boolean hasMessage() {
-    return nonNull(message);
   }
 
   public List<ValidatorCheck<T>> getChecks() {
     return checks;
-  }
-  
-  public String getMessage() {
-    return message;
   }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/Conjunction.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/Conjunction.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn.common;
+
+import static it.infn.mw.iam.authn.common.ValidatorResult.success;
+
+import java.util.List;
+
+public class Conjunction<T> extends CompositeValidatorCheck<T> {
+
+  public Conjunction(List<ValidatorCheck<T>> checks, String message) {
+    super(checks, message);
+  }
+
+  @Override
+  public ValidatorResult validate(T credential) {
+    for (ValidatorCheck<T> c : getChecks()) {
+
+      ValidatorResult result = c.validate(credential);
+      if (!result.isSuccess()) {
+        return handleFailure(result);
+      }
+
+    }
+    return success();
+  }
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/Disjunction.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/Disjunction.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn.common;
+
+import static it.infn.mw.iam.authn.common.ValidatorResult.error;
+import static it.infn.mw.iam.authn.common.ValidatorResult.failure;
+
+import java.util.List;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
+
+public class Disjunction<T> extends CompositeValidatorCheck<T> {
+
+  static final Joiner JOINER = Joiner.on(',').skipNulls();
+
+  public Disjunction(List<ValidatorCheck<T>> checks, String message) {
+    super(checks, message);
+  }
+
+  @Override
+  public ValidatorResult validate(T credential) {
+
+    List<String> messages = Lists.newArrayList();
+
+    boolean hadErrors = false;
+    
+    for (ValidatorCheck<T> c : getChecks()) {
+
+      ValidatorResult result = c.validate(credential);
+
+      if (result.isSuccess()) {
+        return result;
+      } else {
+        hadErrors = result.isError() || hadErrors;
+        messages.add(result.getMessage());
+      }
+    }
+
+    final String errorMsg = JOINER.join(messages);
+    return handleFailure(hadErrors ? error(errorMsg) : failure(errorMsg));
+  }
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/Error.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/Error.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn.common;
+
+public class Error<T> implements ValidatorCheck<T> {
+
+  @Override
+  public ValidatorResult validate(T credential) {
+    return ValidatorResult.error("error");
+  }
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/Fail.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/Fail.java
@@ -15,9 +15,12 @@
  */
 package it.infn.mw.iam.authn.common;
 
-public class Fail<T> implements ValidatorCheck<T> {
-  
+public class Fail<T> extends BaseValidatorCheck<T> {
   public static final String FAILURE_MSG = "always fails";
+  
+  public Fail() {
+    super(FAILURE_MSG);
+  }  
 
   @Override
   public ValidatorResult validate(T credential) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/Fail.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/Fail.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn.common;
+
+public class Fail<T> implements ValidatorCheck<T> {
+  
+  public static final String FAILURE_MSG = "always fails";
+
+  @Override
+  public ValidatorResult validate(T credential) {
+    return ValidatorResult.failure(FAILURE_MSG);
+  }
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/Negation.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/Negation.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn.common;
+
+import static it.infn.mw.iam.authn.common.ValidatorResult.failure;
+import static it.infn.mw.iam.authn.common.ValidatorResult.success;
+
+import java.util.List;
+
+public class Negation<T> extends CompositeValidatorCheck<T> {
+
+  public Negation(List<ValidatorCheck<T>> checks, String message) {
+    super(checks, message);
+  }
+
+  @Override
+  public ValidatorResult validate(T credential) {
+
+    // Negation applies only to the first check
+    ValidatorCheck<T> first = getChecks().get(0);
+    ValidatorResult result = first.validate(credential);
+
+    if (result.isFailure()) {
+      return success();
+    } else if (result.isSuccess()) {
+      return failure(getMessage());
+    }
+
+    return result;
+  }
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/Success.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/Success.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn.common;
+
+import static it.infn.mw.iam.authn.common.ValidatorResult.success;
+
+public class Success<T> implements ValidatorCheck<T> {
+
+  @Override
+  public ValidatorResult validate(T credential) {
+    return success();
+  }
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/ValidatorCheck.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/ValidatorCheck.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn.common;
+
+@FunctionalInterface
+public interface ValidatorCheck<T> {
+  ValidatorResult validate(T credential);
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/ValidatorError.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/ValidatorError.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn.common;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class ValidatorError extends AuthenticationException {
+
+  private static final long serialVersionUID = -136000356560140993L;
+
+  public ValidatorError(String msg) {
+    super(msg);
+  }
+
+  public ValidatorError(String msg, Throwable t) {
+    super(msg, t);
+  }
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/ValidatorResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/ValidatorResolver.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn.common;
+
+import java.util.Optional;
+
+@FunctionalInterface
+public interface ValidatorResolver<T> {
+  Optional<ValidatorCheck<T>> resolveChecks(String issuer);
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/ValidatorResult.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/ValidatorResult.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn.common;
+
+import static it.infn.mw.iam.authn.common.ValidatorResult.Status.ERROR;
+import static it.infn.mw.iam.authn.common.ValidatorResult.Status.FAILURE;
+import static it.infn.mw.iam.authn.common.ValidatorResult.Status.SUCCESS;
+import static java.util.Objects.nonNull;
+
+public class ValidatorResult {
+
+  public enum Status {
+    SUCCESS,
+    FAILURE,
+    ERROR
+  }
+
+  private final Status status;
+  private final String message;
+
+  private ValidatorResult(Status s, String message) {
+    this.status = s;
+    this.message = message;
+  }
+
+  private ValidatorResult(Status s) {
+    this(s, null);
+  }
+
+  public boolean hasMessage() {
+    return nonNull(message);
+  }
+
+  public Status getStatus() {
+    return status;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public boolean isSuccess() {
+    return SUCCESS.equals(status);
+  }
+  
+  public boolean isFailure() {
+    return FAILURE.equals(status);
+  }
+  
+  public boolean isError() {
+    return ERROR.equals(status);
+  }
+  
+  public static ValidatorResult success() {
+    return new ValidatorResult(Status.SUCCESS);
+  }
+
+  public static ValidatorResult failure(String message) {
+    return new ValidatorResult(Status.FAILURE, message);
+  }
+
+  public static ValidatorResult error(String message) {
+    return new ValidatorResult(Status.ERROR, message);
+  }
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/config/AuthenticationValidator.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/config/AuthenticationValidator.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn.common.config;
+
+import it.infn.mw.iam.authn.common.ValidatorError;
+
+@FunctionalInterface
+public interface AuthenticationValidator<T> {
+  void validateAuthentication(T authentication) throws ValidatorError;
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/config/DefaultValidatorConfigParser.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/config/DefaultValidatorConfigParser.java
@@ -72,23 +72,26 @@ public class DefaultValidatorConfigParser implements ValidatorConfigParser {
   }
 
   protected ValidatorCheck<?> hasAttr(ValidatorProperties p) {
-    return hasAttribute(p.getRequiredNonEmptyParam("attributeName"));
+    return hasAttribute(p.getRequiredNonEmptyParam("attributeName"), p.getOptionalParam("message"));
   }
-  
+
   protected ValidatorCheck<?> hasClaim(ValidatorProperties p) {
-    return ClaimPresentCheck.hasClaim(p.getRequiredNonEmptyParam("claimName"));
+    return ClaimPresentCheck.hasClaim(p.getRequiredNonEmptyParam("claimName"),
+        p.getOptionalParam("message"));
   }
-  
-  protected ValidatorCheck<?> claimValueMatches(ValidatorProperties p){
-    return ClaimRegexpMatch.claimMatches(p.getRequiredNonEmptyParam("claimName"), 
-        p.getRequiredNonEmptyParam("regexp"));
+
+  protected ValidatorCheck<?> claimValueMatches(ValidatorProperties p) {
+    return ClaimRegexpMatch.claimMatches(p.getRequiredNonEmptyParam("claimName"),
+        p.getRequiredNonEmptyParam("regexp"), p.getOptionalParam("message"));
   }
 
   protected ValidatorCheck<?> attrValueMatches(ValidatorProperties p) {
     return SamlAttributeValueRegexpMatch.attrValueMatches(
-        p.getRequiredNonEmptyParam("attributeName"), p.getRequiredNonEmptyParam("regexp"));
+        p.getRequiredNonEmptyParam("attributeName"), p.getRequiredNonEmptyParam("regexp"),
+        p.getOptionalParam("message"));
   }
-  
+
+  @SuppressWarnings("unchecked")
   @Override
   public ValidatorCheck<?> parseValidatorProperties(ValidatorProperties p) {
     try {
@@ -117,7 +120,7 @@ public class DefaultValidatorConfigParser implements ValidatorConfigParser {
       } else if ("false".equals(p.getKind())) {
         return new Fail<>();
       }
-      
+
       throw new IllegalArgumentException("Known but unsupported kind: " + p.getKind());
 
     } catch (IllegalArgumentException e) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/config/DefaultValidatorConfigParser.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/config/DefaultValidatorConfigParser.java
@@ -40,8 +40,13 @@ import it.infn.mw.iam.authn.saml.validator.check.SamlAttributeValueRegexpMatch;
 
 @Component
 public class DefaultValidatorConfigParser implements ValidatorConfigParser {
+  
+  public static final String MESSAGE_PARAM = "message";
+  public static final String ATTRIBUTE_NAME_PARAM = "attributeName";
+  public static final String CLAIM_NAME_PARAM = "claimName";
+  public static final String REGEXP_PARAM = "regexp";
 
-  private final Set<String> KIND = ImmutableSet.of("or", "and", "not", "hasAttr",
+  private static final Set<String> KIND = ImmutableSet.of("or", "and", "not", "hasAttr",
       "attrValueMatches", "hasClaim", "claimValueMatches", "true", "false");
 
   @SuppressWarnings({"unchecked", "rawtypes"})
@@ -49,7 +54,7 @@ public class DefaultValidatorConfigParser implements ValidatorConfigParser {
     p.requireChildren();
     List<ValidatorCheck<?>> checks =
         p.getChildrens().stream().map(this::parseValidatorProperties).collect(Collectors.toList());
-    return new Disjunction(checks, p.getOptionalParam("message"));
+    return new Disjunction(checks, p.getOptionalParam(MESSAGE_PARAM));
 
   }
 
@@ -59,7 +64,7 @@ public class DefaultValidatorConfigParser implements ValidatorConfigParser {
     List<ValidatorCheck<?>> checks =
         p.getChildrens().stream().map(this::parseValidatorProperties).collect(Collectors.toList());
 
-    return new Conjunction(checks, p.getOptionalParam("message"));
+    return new Conjunction(checks, p.getOptionalParam(MESSAGE_PARAM));
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})
@@ -68,27 +73,27 @@ public class DefaultValidatorConfigParser implements ValidatorConfigParser {
     List<ValidatorCheck<?>> checks =
         p.getChildrens().stream().map(this::parseValidatorProperties).collect(Collectors.toList());
 
-    return new Negation(checks, p.getOptionalParam("message"));
+    return new Negation(checks, p.getOptionalParam(MESSAGE_PARAM));
   }
 
   protected ValidatorCheck<?> hasAttr(ValidatorProperties p) {
-    return hasAttribute(p.getRequiredNonEmptyParam("attributeName"), p.getOptionalParam("message"));
+    return hasAttribute(p.getRequiredNonEmptyParam(ATTRIBUTE_NAME_PARAM), p.getOptionalParam(MESSAGE_PARAM));
   }
 
   protected ValidatorCheck<?> hasClaim(ValidatorProperties p) {
-    return ClaimPresentCheck.hasClaim(p.getRequiredNonEmptyParam("claimName"),
-        p.getOptionalParam("message"));
+    return ClaimPresentCheck.hasClaim(p.getRequiredNonEmptyParam(CLAIM_NAME_PARAM),
+        p.getOptionalParam(MESSAGE_PARAM));
   }
 
   protected ValidatorCheck<?> claimValueMatches(ValidatorProperties p) {
-    return ClaimRegexpMatch.claimMatches(p.getRequiredNonEmptyParam("claimName"),
-        p.getRequiredNonEmptyParam("regexp"), p.getOptionalParam("message"));
+    return ClaimRegexpMatch.claimMatches(p.getRequiredNonEmptyParam(CLAIM_NAME_PARAM),
+        p.getRequiredNonEmptyParam(REGEXP_PARAM), p.getOptionalParam(MESSAGE_PARAM));
   }
 
   protected ValidatorCheck<?> attrValueMatches(ValidatorProperties p) {
     return SamlAttributeValueRegexpMatch.attrValueMatches(
-        p.getRequiredNonEmptyParam("attributeName"), p.getRequiredNonEmptyParam("regexp"),
-        p.getOptionalParam("message"));
+        p.getRequiredNonEmptyParam(ATTRIBUTE_NAME_PARAM), p.getRequiredNonEmptyParam(REGEXP_PARAM),
+        p.getOptionalParam(MESSAGE_PARAM));
   }
 
   @SuppressWarnings("unchecked")

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/config/DefaultValidatorConfigParser.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/config/DefaultValidatorConfigParser.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn.common.config;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static it.infn.mw.iam.authn.saml.validator.check.SamlHasAttributeCheck.hasAttribute;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.google.common.collect.ImmutableSet;
+
+import it.infn.mw.iam.authn.common.Conjunction;
+import it.infn.mw.iam.authn.common.Disjunction;
+import it.infn.mw.iam.authn.common.Fail;
+import it.infn.mw.iam.authn.common.Negation;
+import it.infn.mw.iam.authn.common.Success;
+import it.infn.mw.iam.authn.common.ValidatorCheck;
+import it.infn.mw.iam.authn.oidc.validator.check.ClaimPresentCheck;
+import it.infn.mw.iam.authn.oidc.validator.check.ClaimRegexpMatch;
+import it.infn.mw.iam.authn.saml.validator.check.SamlAttributeValueRegexpMatch;
+
+@Component
+public class DefaultValidatorConfigParser implements ValidatorConfigParser {
+
+  private final Set<String> KIND = ImmutableSet.of("or", "and", "not", "hasAttr",
+      "attrValueMatches", "hasClaim", "claimValueMatches", "true", "false");
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  protected ValidatorCheck<?> disjunction(ValidatorProperties p) {
+    p.requireChildren();
+    List<ValidatorCheck<?>> checks =
+        p.getChildrens().stream().map(this::parseValidatorProperties).collect(Collectors.toList());
+    return new Disjunction(checks, p.getOptionalParam("message"));
+
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  protected ValidatorCheck<?> conjunction(ValidatorProperties p) {
+    p.requireChildren();
+    List<ValidatorCheck<?>> checks =
+        p.getChildrens().stream().map(this::parseValidatorProperties).collect(Collectors.toList());
+
+    return new Conjunction(checks, p.getOptionalParam("message"));
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  protected ValidatorCheck<?> negation(ValidatorProperties p) {
+    p.requireChildren();
+    List<ValidatorCheck<?>> checks =
+        p.getChildrens().stream().map(this::parseValidatorProperties).collect(Collectors.toList());
+
+    return new Negation(checks, p.getOptionalParam("message"));
+  }
+
+  protected ValidatorCheck<?> hasAttr(ValidatorProperties p) {
+    return hasAttribute(p.getRequiredNonEmptyParam("attributeName"));
+  }
+  
+  protected ValidatorCheck<?> hasClaim(ValidatorProperties p) {
+    return ClaimPresentCheck.hasClaim(p.getRequiredNonEmptyParam("claimName"));
+  }
+  
+  protected ValidatorCheck<?> claimValueMatches(ValidatorProperties p){
+    return ClaimRegexpMatch.claimMatches(p.getRequiredNonEmptyParam("claimName"), 
+        p.getRequiredNonEmptyParam("regexp"));
+  }
+
+  protected ValidatorCheck<?> attrValueMatches(ValidatorProperties p) {
+    return SamlAttributeValueRegexpMatch.attrValueMatches(
+        p.getRequiredNonEmptyParam("attributeName"), p.getRequiredNonEmptyParam("regexp"));
+  }
+  
+  @Override
+  public ValidatorCheck<?> parseValidatorProperties(ValidatorProperties p) {
+    try {
+      checkNotNull(p, "p must be non-null");
+      checkArgument(!isNullOrEmpty(p.getKind()), "kind must be non-null and not empty");
+
+      if (!KIND.contains(p.getKind())) {
+        throw new ValidatorConfigError("Unsupported validator kind: " + p.getKind());
+      }
+      if ("or".equals(p.getKind())) {
+        return disjunction(p);
+      } else if ("and".equals(p.getKind())) {
+        return conjunction(p);
+      } else if ("not".equals(p.getKind())) {
+        return negation(p);
+      } else if ("hasAttr".equals(p.getKind())) {
+        return hasAttr(p);
+      } else if ("attrValueMatches".equals(p.getKind())) {
+        return attrValueMatches(p);
+      } else if ("hasClaim".equals(p.getKind())) {
+        return hasClaim(p);
+      } else if ("claimValueMatches".equals(p.getKind())) {
+        return claimValueMatches(p);
+      } else if ("true".equals(p.getKind())) {
+        return new Success<>();
+      } else if ("false".equals(p.getKind())) {
+        return new Fail<>();
+      }
+      
+      throw new IllegalArgumentException("Known but unsupported kind: " + p.getKind());
+
+    } catch (IllegalArgumentException e) {
+      throw new ValidatorConfigError(e);
+    }
+  }
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/config/ValidatorConfigError.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/config/ValidatorConfigError.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn.common.config;
+
+public class ValidatorConfigError extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  public ValidatorConfigError(String message) {
+    super(message);
+  }
+
+  public ValidatorConfigError(Throwable cause) {
+    super(cause);
+  }
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/config/ValidatorConfigParser.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/config/ValidatorConfigParser.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn.common.config;
+
+import it.infn.mw.iam.authn.common.ValidatorCheck;
+
+public interface ValidatorConfigParser {
+
+  <T> ValidatorCheck<T> parseValidatorProperties(ValidatorProperties p);
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/config/ValidatorProperties.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/config/ValidatorProperties.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn.common.config;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.lang.String.format;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.hibernate.validator.constraints.NotBlank;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+public class ValidatorProperties {
+
+  @NotBlank
+  private String kind;
+
+  private Map<String, String> params = Maps.newHashMap();
+
+  private List<ValidatorProperties> childrens = Lists.newArrayList();
+
+  public ValidatorProperties() {}
+
+  public String getKind() {
+    return kind;
+  }
+
+  public void setKind(String kind) {
+    this.kind = kind;
+  }
+
+
+  public Map<String, String> getParams() {
+    return params;
+  }
+
+
+  public void setParams(Map<String, String> params) {
+    this.params = params;
+  }
+
+
+  public List<ValidatorProperties> getChildrens() {
+    return childrens;
+  }
+
+
+  public void setChildrens(List<ValidatorProperties> childrens) {
+    this.childrens = childrens;
+  }
+
+  public String getRequiredNonEmptyParam(String paramName) {
+    checkArgument(nonNull(getParams()), "params required");
+    checkArgument(!isNullOrEmpty(getParams().get(paramName)), format("%s param required", paramName));
+    return getParams().get(paramName);
+  }
+
+  public String getOptionalParam(String paramName) {
+    if (Objects.isNull(getParams())) {
+      return null;
+    }
+    return getParams().get(paramName);
+  }
+  
+  public void requireChildren() {
+    if (isNull(getChildrens()) || getChildrens().isEmpty()) {
+      throw new ValidatorConfigError("children validators required");
+    }
+  }
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/config/ValidatorProperties.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/common/config/ValidatorProperties.java
@@ -39,8 +39,6 @@ public class ValidatorProperties {
 
   private List<ValidatorProperties> childrens = Lists.newArrayList();
 
-  public ValidatorProperties() {}
-
   public String getKind() {
     return kind;
   }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/oidc/OidcAuthenticationProvider.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/oidc/OidcAuthenticationProvider.java
@@ -28,6 +28,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.User;
 
+import it.infn.mw.iam.authn.common.config.AuthenticationValidator;
 import it.infn.mw.iam.authn.oidc.service.OidcUserDetailsService;
 
 public class OidcAuthenticationProvider extends OIDCAuthenticationProvider {
@@ -35,11 +36,14 @@ public class OidcAuthenticationProvider extends OIDCAuthenticationProvider {
   public static final Logger LOG = LoggerFactory.getLogger(OidcAuthenticationProvider.class);
 
   private final OidcUserDetailsService userDetailsService;
+  private final AuthenticationValidator<OIDCAuthenticationToken> tokenValidatorService;
 
   @Autowired
-  public OidcAuthenticationProvider(OidcUserDetailsService userDetailsService) {
+  public OidcAuthenticationProvider(OidcUserDetailsService userDetailsService,
+      AuthenticationValidator<OIDCAuthenticationToken> tokenValidatorService) {
 
     this.userDetailsService = userDetailsService;
+    this.tokenValidatorService = tokenValidatorService;
   }
 
   private Date getExpirationTimeFromOIDCAuthenticationToken(OIDCAuthenticationToken token) {
@@ -59,11 +63,13 @@ public class OidcAuthenticationProvider extends OIDCAuthenticationProvider {
       return null;
     }
 
+    tokenValidatorService.validateAuthentication(token);
+
     User user = (User) userDetailsService.loadUserByOIDC(token);
 
     return new OidcExternalAuthenticationToken(token,
-	getExpirationTimeFromOIDCAuthenticationToken(token), user.getUsername(), null,
-	user.getAuthorities());
+        getExpirationTimeFromOIDCAuthenticationToken(token), user.getUsername(), null,
+        user.getAuthorities());
   }
 
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/oidc/OidcClientFilter.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/oidc/OidcClientFilter.java
@@ -32,7 +32,6 @@ import org.mitre.openid.connect.config.ServerConfiguration;
 import org.mitre.openid.connect.model.PendingOIDCAuthenticationToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.core.Authentication;
 import org.springframework.util.LinkedMultiValueMap;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/oidc/validator/DefaultOidcTokenValidator.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/oidc/validator/DefaultOidcTokenValidator.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn.oidc.validator;
+
+import java.util.Optional;
+
+import org.mitre.openid.connect.model.OIDCAuthenticationToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.nimbusds.jwt.JWT;
+
+import it.infn.mw.iam.authn.common.ValidatorCheck;
+import it.infn.mw.iam.authn.common.ValidatorError;
+import it.infn.mw.iam.authn.common.ValidatorResolver;
+import it.infn.mw.iam.authn.common.ValidatorResult;
+import it.infn.mw.iam.authn.common.config.AuthenticationValidator;
+
+@Service
+public class DefaultOidcTokenValidator
+    implements AuthenticationValidator<OIDCAuthenticationToken> {
+
+  public static final Logger LOG = LoggerFactory.getLogger(DefaultOidcTokenValidator.class);
+
+  private final ValidatorResolver<JWT> resolver;
+
+  @Autowired
+  public DefaultOidcTokenValidator(ValidatorResolver<JWT> validatorResolver) {
+    resolver = validatorResolver;
+  }
+
+
+  @Override
+  public void validateAuthentication(OIDCAuthenticationToken token) throws ValidatorError {
+
+    Optional<ValidatorCheck<JWT>> checks = resolver.resolveChecks(token.getIssuer());
+
+    if (!checks.isPresent()) {
+      LOG.debug("No checks defined for issuer: {}", token.getIssuer());
+    } else {
+      ValidatorResult result = checks.get().validate(token.getIdToken());
+      LOG.debug("{} validation result: {} {}", token.getIdToken(), result.getStatus(),
+          result.getMessage());
+      if (!result.isSuccess()) {
+        throw new ValidatorError(result.getMessage());
+      }
+    }
+  }
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/oidc/validator/DefaultOidcValidatorResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/oidc/validator/DefaultOidcValidatorResolver.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn.oidc.validator;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Objects.nonNull;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.toMap;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.nimbusds.jwt.JWT;
+
+import it.infn.mw.iam.authn.common.ValidatorCheck;
+import it.infn.mw.iam.authn.common.ValidatorResolver;
+import it.infn.mw.iam.authn.common.config.ValidatorConfigError;
+import it.infn.mw.iam.authn.common.config.ValidatorConfigParser;
+import it.infn.mw.iam.config.oidc.OidcProvider;
+import it.infn.mw.iam.config.oidc.OidcProviderProperties;
+
+@Service
+public class DefaultOidcValidatorResolver implements ValidatorResolver<JWT> {
+
+  public static final Logger LOG = LoggerFactory.getLogger(DefaultOidcValidatorResolver.class);
+
+  private final Map<String, ValidatorCheck<JWT>> checksByIssuer;
+
+  @Autowired
+  public DefaultOidcValidatorResolver(ValidatorConfigParser configParser,
+      OidcProviderProperties properties) {
+    Map<String, ValidatorCheck<JWT>> checks = emptyMap();
+
+    try {
+      checks = properties.getProviders()
+        .stream()
+        .filter(p -> nonNull(p.getValidator()))
+        .collect(toMap(OidcProvider::getIssuer,
+            p -> configParser.parseValidatorProperties(p.getValidator())));
+    } catch (ValidatorConfigError e) {
+      LOG.error("Error parsing oidc token validation rules: {}", e.getMessage(), e);
+    } finally {
+      checksByIssuer = checks;
+    }
+  }
+
+
+  @Override
+  public Optional<ValidatorCheck<JWT>> resolveChecks(String issuer) {
+    return ofNullable(checksByIssuer.get(issuer));
+  }
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/oidc/validator/check/ClaimPresentCheck.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/oidc/validator/check/ClaimPresentCheck.java
@@ -27,37 +27,42 @@ import java.text.ParseException;
 
 import com.nimbusds.jwt.JWT;
 
-import it.infn.mw.iam.authn.common.ValidatorCheck;
+import it.infn.mw.iam.authn.common.BaseValidatorCheck;
 import it.infn.mw.iam.authn.common.ValidatorResult;
 
-public class ClaimPresentCheck implements ValidatorCheck<JWT>{
+public class ClaimPresentCheck extends BaseValidatorCheck<JWT> {
 
   final String claimName;
-  
-  private ClaimPresentCheck(String claimName) {
+
+  private ClaimPresentCheck(String claimName, String message) {
+    super(message);
     this.claimName = claimName;
   }
 
   @Override
   public ValidatorResult validate(JWT jwt) {
-    
+
     try {
       Object claimValue = jwt.getJWTClaimsSet().getClaim(claimName);
-      
+
       if (isNull(claimValue)) {
-        return failure(format("Claim '%s' not found", claimName));
+        return handleFailure(failure(format("Claim '%s' not found", claimName)));
       }
-      
+
       return success();
-      
+
     } catch (ParseException e) {
       return error(format("JWT parse error: %s", e.getMessage()));
     }
   }
-  
+
   public static ClaimPresentCheck hasClaim(String claimName) {
+    return hasClaim(claimName, null);
+  }
+
+  public static ClaimPresentCheck hasClaim(String claimName, String message) {
     checkArgument(!isNullOrEmpty(claimName), "claimName must not be null or empty");
-    return new ClaimPresentCheck(claimName);
+    return new ClaimPresentCheck(claimName, message);
   }
 
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/oidc/validator/check/ClaimPresentCheck.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/oidc/validator/check/ClaimPresentCheck.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn.oidc.validator.check;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static it.infn.mw.iam.authn.common.ValidatorResult.error;
+import static it.infn.mw.iam.authn.common.ValidatorResult.failure;
+import static it.infn.mw.iam.authn.common.ValidatorResult.success;
+import static java.lang.String.format;
+import static java.util.Objects.isNull;
+
+import java.text.ParseException;
+
+import com.nimbusds.jwt.JWT;
+
+import it.infn.mw.iam.authn.common.ValidatorCheck;
+import it.infn.mw.iam.authn.common.ValidatorResult;
+
+public class ClaimPresentCheck implements ValidatorCheck<JWT>{
+
+  final String claimName;
+  
+  private ClaimPresentCheck(String claimName) {
+    this.claimName = claimName;
+  }
+
+  @Override
+  public ValidatorResult validate(JWT jwt) {
+    
+    try {
+      Object claimValue = jwt.getJWTClaimsSet().getClaim(claimName);
+      
+      if (isNull(claimValue)) {
+        return failure(format("Claim '%s' not found", claimName));
+      }
+      
+      return success();
+      
+    } catch (ParseException e) {
+      return error(format("JWT parse error: %s", e.getMessage()));
+    }
+  }
+  
+  public static ClaimPresentCheck hasClaim(String claimName) {
+    checkArgument(!isNullOrEmpty(claimName), "claimName must not be null or empty");
+    return new ClaimPresentCheck(claimName);
+  }
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/oidc/validator/check/ClaimRegexpMatch.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/oidc/validator/check/ClaimRegexpMatch.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn.oidc.validator.check;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static it.infn.mw.iam.authn.common.ValidatorResult.error;
+import static it.infn.mw.iam.authn.common.ValidatorResult.failure;
+import static it.infn.mw.iam.authn.common.ValidatorResult.success;
+import static java.lang.String.format;
+import static java.util.Objects.isNull;
+
+import java.text.ParseException;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.nimbusds.jwt.JWT;
+
+import it.infn.mw.iam.authn.common.ValidatorCheck;
+import it.infn.mw.iam.authn.common.ValidatorResult;
+
+public class ClaimRegexpMatch implements ValidatorCheck<JWT> {
+  public static final Logger LOG = LoggerFactory.getLogger(ClaimRegexpMatch.class);
+
+  private final String claimName;
+  private final String regexp;
+  private final Pattern pattern;
+
+  private ClaimRegexpMatch(String claimName, String regexp) {
+    this.claimName = claimName;
+    this.regexp = regexp;
+    this.pattern = Pattern.compile(regexp);
+  }
+
+  protected ValidatorResult handleStringValue(String claimValue) {
+
+    if (pattern.matcher(claimValue).matches()) {
+      return success();
+    } else {
+      final String noMatchMessage =
+          format("Claim '%s' value '%s' does not match regexp: '%s'", claimName, claimValue, regexp);
+      return failure(noMatchMessage);
+    }
+  }
+
+  protected ValidatorResult handleStringArrayValue(String[] claimValue) {
+    for (String v : claimValue) {
+      if (pattern.matcher(v).matches()) {
+        return success();
+      }
+    }
+
+    return failure(format("No claim '%s' value found matching regexp: '%s'", claimName, regexp));
+  }
+
+  @Override
+  public ValidatorResult validate(JWT idToken) {
+
+    try {
+      Object claimValue = idToken.getJWTClaimsSet().getClaim(claimName);
+
+      if (isNull(claimValue)) {
+        return failure(format("Claim '%s' not found", claimName));
+      }
+
+      if (claimValue instanceof String) {
+        return handleStringValue((String) claimValue);
+      } else if (claimValue instanceof String[]) {
+        return handleStringArrayValue((String[]) claimValue);
+      } else {
+        return failure(
+            format("Claim '%s' cannot be extracted as a string or string array", claimName));
+      }
+    } catch (ParseException e) {
+      return error(format("JWT parse error: %s", e.getMessage()));
+    }
+
+  }
+
+  public static ClaimRegexpMatch claimMatches(String claimName, String regexp) {
+    checkArgument(!isNullOrEmpty(claimName), "claimName must not be null or empty");
+    checkArgument(!isNullOrEmpty(regexp), "regexp must not be null or empty");
+    return new ClaimRegexpMatch(claimName, regexp);
+  }
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/IamSamlAuthenticationProvider.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/IamSamlAuthenticationProvider.java
@@ -29,17 +29,21 @@ import org.springframework.security.saml.SAMLCredential;
 
 import com.google.common.base.Joiner;
 
+import it.infn.mw.iam.authn.common.config.AuthenticationValidator;
 import it.infn.mw.iam.authn.saml.util.SamlUserIdentifierResolutionResult;
 import it.infn.mw.iam.authn.saml.util.SamlUserIdentifierResolver;
 import it.infn.mw.iam.persistence.model.IamSamlId;
 
 public class IamSamlAuthenticationProvider extends SAMLAuthenticationProvider {
 
-  final SamlUserIdentifierResolver userIdResolver;
-  final Joiner joiner = Joiner.on(",").skipNulls();
+  private final SamlUserIdentifierResolver userIdResolver;
+  private final AuthenticationValidator<ExpiringUsernameAuthenticationToken> validator;
+  private final Joiner joiner = Joiner.on(",").skipNulls();
 
-  public IamSamlAuthenticationProvider(SamlUserIdentifierResolver resolver) {
+  public IamSamlAuthenticationProvider(SamlUserIdentifierResolver resolver,
+      AuthenticationValidator<ExpiringUsernameAuthenticationToken> validator) {
     this.userIdResolver = resolver;
+    this.validator = validator;
   }
 
   private Supplier<AuthenticationServiceException> handleResolutionFailure(
@@ -69,6 +73,8 @@ public class IamSamlAuthenticationProvider extends SAMLAuthenticationProvider {
 
     IamSamlId samlId = result.getResolvedId().orElseThrow(handleResolutionFailure(result));
 
+    validator.validateAuthentication(token);
+    
     return new SamlExternalAuthenticationToken(samlId, token, token.getTokenExpiration(),
         user.getUsername(), token.getCredentials(), token.getAuthorities());
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/validator/DefaultSamlValidator.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/validator/DefaultSamlValidator.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn.saml.validator;
+
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.providers.ExpiringUsernameAuthenticationToken;
+import org.springframework.security.saml.SAMLCredential;
+import org.springframework.stereotype.Service;
+
+import it.infn.mw.iam.authn.common.ValidatorCheck;
+import it.infn.mw.iam.authn.common.ValidatorError;
+import it.infn.mw.iam.authn.common.ValidatorResolver;
+import it.infn.mw.iam.authn.common.ValidatorResult;
+import it.infn.mw.iam.authn.common.config.AuthenticationValidator;
+
+@Service
+public class DefaultSamlValidator
+    implements AuthenticationValidator<ExpiringUsernameAuthenticationToken> {
+
+  public static final Logger LOG = LoggerFactory.getLogger(DefaultSamlValidator.class);
+
+  private final ValidatorResolver<SAMLCredential> resolver;
+
+  @Autowired
+  public DefaultSamlValidator(ValidatorResolver<SAMLCredential> resolver) {
+    this.resolver = resolver;
+  }
+
+  @Override
+  public void validateAuthentication(ExpiringUsernameAuthenticationToken token)
+      throws ValidatorError {
+
+    SAMLCredential samlCredentials = (SAMLCredential) token.getCredentials();
+
+    Optional<ValidatorCheck<SAMLCredential>> checks =
+        resolver.resolveChecks(samlCredentials.getRemoteEntityID());
+
+    if (checks.isPresent()) {
+      ValidatorResult result = checks.get().validate(samlCredentials);
+      LOG.debug("{} validation result: {} {}", samlCredentials, result.getStatus(),
+          result.getMessage());
+      if (!result.isSuccess()) {
+        throw new ValidatorError(result.getMessage());
+      }
+    } else {
+      LOG.debug("No checks defined for entity: {}", samlCredentials.getRemoteEntityID());
+    }
+  }
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/validator/DefaultSamlValidatorResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/validator/DefaultSamlValidatorResolver.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn.saml.validator;
+
+import static java.util.stream.Collectors.toMap;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.saml.SAMLCredential;
+import org.springframework.stereotype.Service;
+
+import it.infn.mw.iam.authn.common.ValidatorCheck;
+import it.infn.mw.iam.authn.common.ValidatorResolver;
+import it.infn.mw.iam.authn.common.config.ValidatorConfigParser;
+import it.infn.mw.iam.config.saml.IamSamlProperties;
+import it.infn.mw.iam.config.saml.IamSamlProperties.IssuerValidationProperties;
+
+@Service
+public class DefaultSamlValidatorResolver implements ValidatorResolver<SAMLCredential> {
+
+  private final ValidatorCheck<SAMLCredential> defaultValidator;
+  private final Map<String, ValidatorCheck<SAMLCredential>> validators;
+
+
+  @Autowired
+  public DefaultSamlValidatorResolver(ValidatorConfigParser parser, IamSamlProperties props) {
+
+    if (!Objects.isNull(props.getDefaultValidator())) {
+      defaultValidator = parser.parseValidatorProperties(props.getDefaultValidator());
+    } else {
+      defaultValidator = null;
+    }
+
+    validators = props.getValidators()
+      .stream()
+      .collect(toMap(IssuerValidationProperties::getEntityId,
+          p -> parser.parseValidatorProperties(p.getValidator())));
+  }
+
+  @Override
+  public Optional<ValidatorCheck<SAMLCredential>> resolveChecks(String issuer) {
+    return Optional.ofNullable(validators.getOrDefault(issuer, defaultValidator));
+  }
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/validator/check/SamlAttributeValueRegexpMatch.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/validator/check/SamlAttributeValueRegexpMatch.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn.saml.validator.check;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static it.infn.mw.iam.authn.common.ValidatorResult.failure;
+import static java.lang.String.format;
+import static java.util.Objects.isNull;
+import static java.util.regex.Pattern.compile;
+
+import java.util.regex.Pattern;
+
+import org.opensaml.saml2.core.Attribute;
+import org.springframework.security.saml.SAMLCredential;
+
+import it.infn.mw.iam.authn.common.ValidatorCheck;
+import it.infn.mw.iam.authn.common.ValidatorResult;
+
+public class SamlAttributeValueRegexpMatch implements ValidatorCheck<SAMLCredential> {
+
+  private final String attributeName;
+  private final String regexp;
+  private final Pattern pattern;
+
+
+  private SamlAttributeValueRegexpMatch(String attributeName, String regexp) {
+    this.attributeName = attributeName;
+    this.regexp = regexp;
+    this.pattern = compile(regexp);
+  }
+
+  @Override
+  public ValidatorResult validate(SAMLCredential credential) {
+    Attribute attr = credential.getAttribute(attributeName);
+
+    if (isNull(attr)) {
+      return failure(format("Attribute '%s' not found", attributeName));
+    }
+
+    String[] values = credential.getAttributeAsStringArray(attributeName);
+
+    for (String v : values) {
+      if (pattern.matcher(v).matches()) {
+        return ValidatorResult.success();
+      }
+    }
+
+    return failure(
+        format("No attribute '%s' value found matching regexp: '%s'", attributeName, regexp));
+
+  }
+
+  public static ValidatorCheck<SAMLCredential> attrValueMatches(String attributeName,
+      String regexp) {
+    checkArgument(!isNullOrEmpty(attributeName), "attributeName must not be null or empty");
+    checkArgument(!isNullOrEmpty(regexp), "regexp must not be null or empty");
+    return new SamlAttributeValueRegexpMatch(attributeName, regexp);
+  }
+
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/validator/check/SamlAttributeValueRegexpMatch.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/validator/check/SamlAttributeValueRegexpMatch.java
@@ -27,17 +27,19 @@ import java.util.regex.Pattern;
 import org.opensaml.saml2.core.Attribute;
 import org.springframework.security.saml.SAMLCredential;
 
+import it.infn.mw.iam.authn.common.BaseValidatorCheck;
 import it.infn.mw.iam.authn.common.ValidatorCheck;
 import it.infn.mw.iam.authn.common.ValidatorResult;
 
-public class SamlAttributeValueRegexpMatch implements ValidatorCheck<SAMLCredential> {
+public class SamlAttributeValueRegexpMatch extends BaseValidatorCheck<SAMLCredential> {
 
   private final String attributeName;
   private final String regexp;
   private final Pattern pattern;
 
 
-  private SamlAttributeValueRegexpMatch(String attributeName, String regexp) {
+  private SamlAttributeValueRegexpMatch(String attributeName, String regexp, String message) {
+    super(message);
     this.attributeName = attributeName;
     this.regexp = regexp;
     this.pattern = compile(regexp);
@@ -48,7 +50,7 @@ public class SamlAttributeValueRegexpMatch implements ValidatorCheck<SAMLCredent
     Attribute attr = credential.getAttribute(attributeName);
 
     if (isNull(attr)) {
-      return failure(format("Attribute '%s' not found", attributeName));
+      return handleFailure(failure(format("Attribute '%s' not found", attributeName)));
     }
 
     String[] values = credential.getAttributeAsStringArray(attributeName);
@@ -59,16 +61,21 @@ public class SamlAttributeValueRegexpMatch implements ValidatorCheck<SAMLCredent
       }
     }
 
-    return failure(
-        format("No attribute '%s' value found matching regexp: '%s'", attributeName, regexp));
+    return handleFailure(failure(
+        format("No attribute '%s' value found matching regexp: '%s'", attributeName, regexp)));
 
   }
 
   public static ValidatorCheck<SAMLCredential> attrValueMatches(String attributeName,
       String regexp) {
+    return attrValueMatches(attributeName, regexp, null);
+  }
+  
+  public static ValidatorCheck<SAMLCredential> attrValueMatches(String attributeName,
+      String regexp, String message) {
     checkArgument(!isNullOrEmpty(attributeName), "attributeName must not be null or empty");
     checkArgument(!isNullOrEmpty(regexp), "regexp must not be null or empty");
-    return new SamlAttributeValueRegexpMatch(attributeName, regexp);
+    return new SamlAttributeValueRegexpMatch(attributeName, regexp, message);
   }
 
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/validator/check/SamlHasAttributeCheck.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/validator/check/SamlHasAttributeCheck.java
@@ -25,14 +25,16 @@ import static java.util.Objects.isNull;
 import org.opensaml.saml2.core.Attribute;
 import org.springframework.security.saml.SAMLCredential;
 
+import it.infn.mw.iam.authn.common.BaseValidatorCheck;
 import it.infn.mw.iam.authn.common.ValidatorCheck;
 import it.infn.mw.iam.authn.common.ValidatorResult;
 
-public class SamlHasAttributeCheck implements ValidatorCheck<SAMLCredential> {
+public class SamlHasAttributeCheck extends BaseValidatorCheck<SAMLCredential> {
 
   private final String attributeName;
 
-  private SamlHasAttributeCheck(String attributeOid) {
+  private SamlHasAttributeCheck(String attributeOid, String message) {
+    super(message);
     this.attributeName = attributeOid;
   }
 
@@ -40,14 +42,18 @@ public class SamlHasAttributeCheck implements ValidatorCheck<SAMLCredential> {
   public ValidatorResult validate(SAMLCredential credential) {
     Attribute attribute = credential.getAttribute(attributeName);
     if (isNull(attribute)) {
-      return failure(format("Attribute '%s' not found", attributeName));
+      return handleFailure(failure(format("Attribute '%s' not found", attributeName)));
     }
     return success();
   }
 
-  public static ValidatorCheck<SAMLCredential> hasAttribute(String attributeName) {
+  public static ValidatorCheck<SAMLCredential> hasAttribute(String attributeName, String message) {
     checkArgument(!isNullOrEmpty(attributeName), "attributeName must be non-null and not empty");
-    return new SamlHasAttributeCheck(attributeName);
+    return new SamlHasAttributeCheck(attributeName, message);
+  }
+  
+  public static ValidatorCheck<SAMLCredential> hasAttribute(String attributeName) {
+    return hasAttribute(attributeName, null);
   }
 
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/validator/check/SamlHasAttributeCheck.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/validator/check/SamlHasAttributeCheck.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn.saml.validator.check;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static it.infn.mw.iam.authn.common.ValidatorResult.failure;
+import static it.infn.mw.iam.authn.common.ValidatorResult.success;
+import static java.lang.String.format;
+import static java.util.Objects.isNull;
+
+import org.opensaml.saml2.core.Attribute;
+import org.springframework.security.saml.SAMLCredential;
+
+import it.infn.mw.iam.authn.common.ValidatorCheck;
+import it.infn.mw.iam.authn.common.ValidatorResult;
+
+public class SamlHasAttributeCheck implements ValidatorCheck<SAMLCredential> {
+
+  private final String attributeName;
+
+  private SamlHasAttributeCheck(String attributeOid) {
+    this.attributeName = attributeOid;
+  }
+
+  @Override
+  public ValidatorResult validate(SAMLCredential credential) {
+    Attribute attribute = credential.getAttribute(attributeName);
+    if (isNull(attribute)) {
+      return failure(format("Attribute '%s' not found", attributeName));
+    }
+    return success();
+  }
+
+  public static ValidatorCheck<SAMLCredential> hasAttribute(String attributeName) {
+    checkArgument(!isNullOrEmpty(attributeName), "attributeName must be non-null and not empty");
+    return new SamlHasAttributeCheck(attributeName);
+  }
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/oidc/OidcConfiguration.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/oidc/OidcConfiguration.java
@@ -33,6 +33,7 @@ import org.mitre.openid.connect.client.service.impl.DynamicServerConfigurationSe
 import org.mitre.openid.connect.client.service.impl.PlainAuthRequestUrlBuilder;
 import org.mitre.openid.connect.client.service.impl.StaticAuthRequestOptionsService;
 import org.mitre.openid.connect.client.service.impl.StaticClientConfigurationService;
+import org.mitre.openid.connect.model.OIDCAuthenticationToken;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -59,6 +60,7 @@ import it.infn.mw.iam.authn.ExternalAuthenticationFailureHandler;
 import it.infn.mw.iam.authn.ExternalAuthenticationSuccessHandler;
 import it.infn.mw.iam.authn.InactiveAccountAuthenticationHander;
 import it.infn.mw.iam.authn.RootIsDashboardSuccessHandler;
+import it.infn.mw.iam.authn.common.config.AuthenticationValidator;
 import it.infn.mw.iam.authn.oidc.DefaultOidcTokenRequestor;
 import it.infn.mw.iam.authn.oidc.DefaultRestTemplateFactory;
 import it.infn.mw.iam.authn.oidc.OidcAuthenticationProvider;
@@ -163,9 +165,11 @@ public class OidcConfiguration {
 
   @Bean
   public OIDCAuthenticationProvider openIdConnectAuthenticationProvider(
-      OidcUserDetailsService userDetailService, UserInfoFetcher userInfoFetcher) {
+      OidcUserDetailsService userDetailService, UserInfoFetcher userInfoFetcher,
+      AuthenticationValidator<OIDCAuthenticationToken> validator) {
 
-    OidcAuthenticationProvider provider = new OidcAuthenticationProvider(userDetailService);
+    OidcAuthenticationProvider provider =
+        new OidcAuthenticationProvider(userDetailService, validator);
     provider.setUserInfoFetcher(userInfoFetcher);
 
     return provider;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/oidc/OidcProvider.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/oidc/OidcProvider.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
+import it.infn.mw.iam.authn.common.config.ValidatorProperties;
 import it.infn.mw.iam.config.login.LoginButtonProperties;
 
 @JsonInclude(Include.NON_EMPTY)
@@ -42,6 +43,9 @@ public class OidcProvider {
   private LoginButtonProperties loginButton;
 
   private boolean enabled = true;
+  
+  @Valid
+  private ValidatorProperties validator;
   
   public String getName() {
     return name;
@@ -81,6 +85,14 @@ public class OidcProvider {
 
   public void setEnabled(boolean enabled) {
     this.enabled = enabled;
+  }
+
+  public ValidatorProperties getValidator() {
+    return validator;
+  }
+
+  public void setValidator(ValidatorProperties validator) {
+    this.validator = validator;
   }
   
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/oidc/OidcProviderValidatorCheckProperties.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/oidc/OidcProviderValidatorCheckProperties.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.config.oidc;
+
+import java.util.Map;
+
+import org.hibernate.validator.constraints.NotBlank;
+
+import com.google.common.collect.Maps;
+
+public class OidcProviderValidatorCheckProperties {
+
+  @NotBlank
+  String kind;
+  
+  
+  Map<String, String> params = Maps.newHashMap();
+  
+  public OidcProviderValidatorCheckProperties() {
+    
+  }
+
+  public String getKind() {
+    return kind;
+  }
+
+  public void setKind(String kind) {
+    this.kind = kind;
+  }
+
+  public Map<String, String> getParams() {
+    return params;
+  }
+
+  public void setParams(Map<String, String> params) {
+    this.params = params;
+  }
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/oidc/OidcProviderValidatorCheckProperties.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/oidc/OidcProviderValidatorCheckProperties.java
@@ -25,13 +25,8 @@ public class OidcProviderValidatorCheckProperties {
 
   @NotBlank
   String kind;
-  
-  
+
   Map<String, String> params = Maps.newHashMap();
-  
-  public OidcProviderValidatorCheckProperties() {
-    
-  }
 
   public String getKind() {
     return kind;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/oidc/OidcProviderValidatorProperties.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/oidc/OidcProviderValidatorProperties.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.config.oidc;
+
+import java.util.List;
+
+public class OidcProviderValidatorProperties {
+
+  public enum CombinationRule {
+    and,
+    or
+  }
+
+  CombinationRule combinationRule = CombinationRule.and;
+  List<OidcProviderValidatorCheckProperties> checks;
+  String message;
+
+  public OidcProviderValidatorProperties() {}
+
+  public CombinationRule getCombinationRule() {
+    return combinationRule;
+  }
+
+  public void setCombinationRule(CombinationRule combinationRule) {
+    this.combinationRule = combinationRule;
+  }
+
+  public List<OidcProviderValidatorCheckProperties> getChecks() {
+    return checks;
+  }
+
+  public void setChecks(List<OidcProviderValidatorCheckProperties> checks) {
+    this.checks = checks;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+  }
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/saml/IamSamlProperties.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/saml/IamSamlProperties.java
@@ -20,18 +20,45 @@ import java.util.concurrent.TimeUnit;
 
 import javax.validation.Valid;
 
+import org.hibernate.validator.constraints.NotBlank;
 import org.opensaml.saml2.core.NameIDType;
 import org.opensaml.xml.signature.SignatureConstants;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import com.google.common.collect.Lists;
 
+import it.infn.mw.iam.authn.common.config.ValidatorProperties;
 import it.infn.mw.iam.authn.saml.profile.IamSSOProfileOptions;
 import it.infn.mw.iam.config.login.LoginButtonProperties;
 import it.infn.mw.iam.config.saml.IamSamlJITAccountProvisioningProperties.AttributeMappingProperties;
 
 @ConfigurationProperties(prefix = "saml")
 public class IamSamlProperties {
+  
+  public static class IssuerValidationProperties {
+    
+    @NotBlank
+    String entityId;
+    
+    ValidatorProperties validator;
+
+    public String getEntityId() {
+      return entityId;
+    }
+
+    public void setEntityId(String entityId) {
+      this.entityId = entityId;
+    }
+
+    public ValidatorProperties getValidator() {
+      return validator;
+    }
+
+    public void setValidator(ValidatorProperties validator) {
+      this.validator = validator;
+    }
+  }
+  
   
   public static class RegistrationMappingProperties {
     
@@ -206,6 +233,11 @@ public class IamSamlProperties {
  
   private List<RegistrationMappingProperties> customMapping = Lists.newArrayList();
   
+  private ValidatorProperties defaultValidator;
+  
+  private List<IssuerValidationProperties> validators = Lists.newArrayList();
+  
+  
   public List<IamSamlIdpMetadataProperties> getIdpMetadata() {
     return idpMetadata;
   }
@@ -365,5 +397,21 @@ public class IamSamlProperties {
 
   public void setCustomMapping(List<RegistrationMappingProperties> customMapping) {
     this.customMapping = customMapping;
+  }
+
+  public ValidatorProperties getDefaultValidator() {
+    return defaultValidator;
+  }
+
+  public void setDefaultValidator(ValidatorProperties defaultValidator) {
+    this.defaultValidator = defaultValidator;
+  }
+
+  public List<IssuerValidationProperties> getValidators() {
+    return validators;
+  }
+
+  public void setValidators(List<IssuerValidationProperties> validators) {
+    this.validators = validators;
   }
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/oidc/OidcExternalAuthenticationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/oidc/OidcExternalAuthenticationTests.java
@@ -22,8 +22,6 @@ import static org.junit.Assert.assertThat;
 
 import java.io.UnsupportedEncodingException;
 
-import org.springframework.transaction.annotation.Transactional;
-
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,6 +34,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponents;
@@ -56,13 +55,12 @@ import it.infn.mw.iam.test.util.oidc.MockRestTemplateFactory;
 @Transactional
 public class OidcExternalAuthenticationTests extends OidcExternalAuthenticationTestsSupport {
 
-
   @Before
   public void setup() {
     MockRestTemplateFactory tf = (MockRestTemplateFactory) restTemplateFactory;
     tf.resetTemplate();
   }
-
+  
   @Test
   public void testOidcUnregisteredUserRedirectedToRegisterPage() throws JOSEException,
       JsonProcessingException, RestClientException, UnsupportedEncodingException {
@@ -167,9 +165,6 @@ public class OidcExternalAuthenticationTests extends OidcExternalAuthenticationT
     assertThat(response.getStatusCode(), equalTo(HttpStatus.FOUND));
     assertNotNull(response.getHeaders().getLocation());
     assertThat(response.getHeaders().getLocation().toString(), Matchers.startsWith(loginPageURL()));
-
-
-
   }
 
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/oidc/OidcExternalAuthenticationTestsSupport.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/oidc/OidcExternalAuthenticationTestsSupport.java
@@ -52,39 +52,39 @@ import it.infn.mw.iam.test.util.oidc.MockRestTemplateFactory;
 public class OidcExternalAuthenticationTestsSupport {
 
   @Value("${local.server.port}")
-  Integer iamPort;
+  protected Integer iamPort;
 
   @Autowired
-  RestTemplateFactory restTemplateFactory;
+  protected RestTemplateFactory restTemplateFactory;
 
   @Autowired
-  MockOIDCProvider mockOidcProvider;
+  protected MockOIDCProvider mockOidcProvider;
 
   @Autowired
-  UserInfoFetcher mockUserInfoFetcher;
+  protected UserInfoFetcher mockUserInfoFetcher;
 
 
-  String baseIamURL() {
+  protected String baseIamURL() {
     return "http://localhost:" + iamPort;
   }
 
-  String openidConnectLoginURL() {
+  protected String openidConnectLoginURL() {
     return baseIamURL() + "/openid_connect_login";
   }
 
-  String authnInfoURL() {
+  protected String authnInfoURL() {
     return baseIamURL() + "/iam/authn-info";
   }
 
-  String landingPageURL() {
+  protected String landingPageURL() {
     return baseIamURL() + "/dashboard";
   }
 
-  String loginPageURL() {
+  protected String loginPageURL() {
     return baseIamURL() + "/login";
   }
 
-  ClientHttpRequestFactory noRedirectHttpRequestFactory() {
+  protected ClientHttpRequestFactory noRedirectHttpRequestFactory() {
 
     SimpleClientHttpRequestFactory rf = new SimpleClientHttpRequestFactory() {
       protected void prepareConnection(java.net.HttpURLConnection connection, String httpMethod)
@@ -97,11 +97,11 @@ public class OidcExternalAuthenticationTestsSupport {
     return rf;
   }
 
-  RestTemplate noRedirectRestTemplate() {
+  protected RestTemplate noRedirectRestTemplate() {
     return new RestTemplate(noRedirectHttpRequestFactory());
   }
 
-  void checkAuthorizationEndpointRedirect(ResponseEntity<String> response) {
+  protected void checkAuthorizationEndpointRedirect(ResponseEntity<String> response) {
     assertThat(response.getStatusCode(), equalTo(HttpStatus.FOUND));
     assertNotNull(response.getHeaders().getLocation());
 
@@ -117,13 +117,13 @@ public class OidcExternalAuthenticationTestsSupport {
 
   }
 
-  String extractSessionCookie(ResponseEntity<String> response) {
+  protected String extractSessionCookie(ResponseEntity<String> response) {
 
     return response.getHeaders().get("Set-Cookie").get(0);
 
   }
 
-  CodeRequestHolder buildCodeRequest(String sessionCookie, ResponseEntity<String> response) {
+  protected CodeRequestHolder buildCodeRequest(String sessionCookie, ResponseEntity<String> response) {
 
     CodeRequestHolder result = new CodeRequestHolder();
 
@@ -150,7 +150,7 @@ public class OidcExternalAuthenticationTestsSupport {
     return result;
   }
 
-  void prepareSuccessResponse(String tokenResponse) {
+  protected void prepareSuccessResponse(String tokenResponse) {
     MockRestTemplateFactory tf = (MockRestTemplateFactory) restTemplateFactory;
     tf.getMockServer()
       .expect(requestTo(TEST_OIDC_TOKEN_ENDPOINT_URI))
@@ -159,7 +159,7 @@ public class OidcExternalAuthenticationTestsSupport {
       .andRespond(MockRestResponseCreators.withSuccess(tokenResponse, MediaType.APPLICATION_JSON));
   }
 
-  void prepareErrorResponse(String errorResponse) {
+  protected void prepareErrorResponse(String errorResponse) {
     MockRestTemplateFactory tf = (MockRestTemplateFactory) restTemplateFactory;
     tf.getMockServer()
       .expect(requestTo(TEST_OIDC_TOKEN_ENDPOINT_URI))
@@ -170,7 +170,7 @@ public class OidcExternalAuthenticationTestsSupport {
         .body(errorResponse));
   }
 
-  void verifyMockServerCalls() {
+  protected void verifyMockServerCalls() {
     MockRestTemplateFactory tf = (MockRestTemplateFactory) restTemplateFactory;
     tf.getMockServer().verify();
     tf.resetTemplate();

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/oidc/validator/ClaimPresentCheckTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/oidc/validator/ClaimPresentCheckTests.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.ext_authn.oidc.validator;
+
+import static it.infn.mw.iam.authn.oidc.validator.check.ClaimPresentCheck.hasClaim;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.text.ParseException;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.PlainJWT;
+
+public class ClaimPresentCheckTests extends JWTTestSupport{
+
+  @Test
+  public void hasClaimWorkAsExpected() {
+
+    JWT jwt = new PlainJWT(claimSetBuilder().build());
+    assertThat(hasClaim("sub").validate(jwt).isSuccess(), is(true));
+    assertThat(hasClaim("exp").validate(jwt).isFailure(), is(true));
+  }
+  
+  
+  @Test
+  public void claimParseErrorHandled() throws ParseException {
+    JWT jwt = Mockito.mock(JWT.class);
+    
+    when(jwt.getJWTClaimsSet()).thenThrow(new ParseException("parse error",0));
+    assertThat(hasClaim("sub").validate(jwt).isError(), is(true));
+    
+  }
+  
+  @Test(expected = IllegalArgumentException.class)
+  public void nullClaimNotAllowed() {
+    hasClaim(null);
+  }
+  
+  @Test(expected = IllegalArgumentException.class)
+  public void emptyClaimNotAllowed() {
+    hasClaim("");
+  }
+
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/oidc/validator/ClaimRegexpMatchTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/oidc/validator/ClaimRegexpMatchTests.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.ext_authn.oidc.validator;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.text.ParseException;
+import java.time.Instant;
+import java.util.Date;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.PlainJWT;
+
+import it.infn.mw.iam.authn.common.ValidatorCheck;
+import it.infn.mw.iam.authn.common.ValidatorResult;
+import it.infn.mw.iam.authn.oidc.validator.check.ClaimRegexpMatch;
+
+public class ClaimRegexpMatchTests extends JWTTestSupport {
+
+  @Test
+  public void claimNotFound() {
+
+    JWT jwt = new PlainJWT(claimSetBuilder().build());
+
+    ValidatorCheck<JWT> check = ClaimRegexpMatch.claimMatches("entitlement", "admin|user");
+
+    ValidatorResult result = check.validate(jwt);
+    assertThat(result.isFailure(), is(true));
+    assertThat(result.getMessage(), startsWith("Claim 'entitlement' not found"));
+  }
+
+  @Test
+  public void stringClaimMatches() {
+    JWTClaimsSet.Builder builder = claimSetBuilder();
+    builder.claim("entitlement", "sheriff");
+
+    JWT jwt = new PlainJWT(builder.build());
+
+    ValidatorCheck<JWT> check =
+        ClaimRegexpMatch.claimMatches("entitlement", "sheriff|major");
+    ValidatorResult result = check.validate(jwt);
+    assertThat(result.isSuccess(), is(true));
+  }
+
+  @Test
+  public void stringClaimDoesNotMatch() {
+    JWTClaimsSet.Builder builder = claimSetBuilder();
+    builder.claim("entitlement", "sheriff");
+
+    JWT jwt = new PlainJWT(builder.build());
+
+    ValidatorCheck<JWT> check =
+        ClaimRegexpMatch.claimMatches("entitlement", "general|president");
+    ValidatorResult result = check.validate(jwt);
+    assertThat(result.isFailure(), is(true));
+    assertThat(result.getMessage(),
+        is("Claim 'entitlement' value 'sheriff' does not match regexp: 'general|president'"));
+  }
+
+  @Test
+  public void emptyClaimMatchTest() {
+
+    JWTClaimsSet.Builder builder = claimSetBuilder();
+    builder.claim("empty_claim", "");
+
+    JWT jwt = new PlainJWT(builder.build());
+    ValidatorCheck<JWT> check = ClaimRegexpMatch.claimMatches("empty_claim", ".*");
+    ValidatorResult result = check.validate(jwt);
+    assertThat(result.isSuccess(), is(true));
+
+
+  }
+
+  @Test
+  public void stringArrayClaimMatchTest() {
+
+    JWTClaimsSet.Builder builder = claimSetBuilder();
+
+    String[] values = {"one", "two", "three"};
+    builder.claim("array_claim", values);
+
+    JWT jwt = new PlainJWT(builder.build());
+    ValidatorCheck<JWT> check = ClaimRegexpMatch.claimMatches("array_claim", "one|five");
+    ValidatorResult result = check.validate(jwt);
+    assertThat(result.isSuccess(), is(true));
+  }
+
+  @Test
+  public void stringArrayNoFailureMatchTest() {
+
+    JWTClaimsSet.Builder builder = claimSetBuilder();
+
+    String[] values = {"one", "two", "three"};
+    builder.claim("array_claim", values);
+
+    JWT jwt = new PlainJWT(builder.build());
+    ValidatorCheck<JWT> check = ClaimRegexpMatch.claimMatches("array_claim", "ciccio");
+    ValidatorResult result = check.validate(jwt);
+    assertThat(result.isFailure(), is(true));
+    assertThat(result.getMessage(),
+        is("No claim 'array_claim' value found matching regexp: 'ciccio'"));
+
+  }
+  
+  @Test(expected = IllegalArgumentException.class)
+  public void nullRegexpContructionFails() {
+    ClaimRegexpMatch.claimMatches("array_claim", null);
+  }
+  
+  @Test(expected = IllegalArgumentException.class)
+  public void nullClaimContructionFails() {
+    ClaimRegexpMatch.claimMatches(null, ".*");
+  }
+  
+  @Test
+  public void noStringValueTest() {
+    JWTClaimsSet.Builder builder = claimSetBuilder();
+    builder.expirationTime(Date.from(Instant.now()));
+    JWT jwt = new PlainJWT(builder.build());
+    ValidatorCheck<JWT> check = ClaimRegexpMatch.claimMatches("exp", "ciccio");
+    ValidatorResult result = check.validate(jwt);
+    assertThat(result.isFailure(), is(true));
+  }
+  
+  @Test
+  public void jwtParseExceptionHandled() throws Exception {
+    JWT jwt = Mockito.mock(JWT.class);
+    
+    when(jwt.getJWTClaimsSet()).thenThrow(new ParseException("parse error",0));
+    ValidatorCheck<JWT> check = ClaimRegexpMatch.claimMatches("test", ".*");
+    ValidatorResult result = check.validate(jwt);
+    assertThat(result.isError(), is(true));
+    assertThat(result.getMessage(), is("JWT parse error: parse error"));
+    
+  }
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/oidc/validator/ClaimRegexpMatchTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/oidc/validator/ClaimRegexpMatchTests.java
@@ -15,8 +15,8 @@
  */
 package it.infn.mw.iam.test.ext_authn.oidc.validator;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -46,7 +46,7 @@ public class ClaimRegexpMatchTests extends JWTTestSupport {
 
     ValidatorResult result = check.validate(jwt);
     assertThat(result.isFailure(), is(true));
-    assertThat(result.getMessage(), startsWith("Claim 'entitlement' not found"));
+    assertThat(result.getMessage(), containsString("Claim 'entitlement' not found"));
   }
 
   @Test
@@ -74,7 +74,7 @@ public class ClaimRegexpMatchTests extends JWTTestSupport {
     ValidatorResult result = check.validate(jwt);
     assertThat(result.isFailure(), is(true));
     assertThat(result.getMessage(),
-        is("Claim 'entitlement' value 'sheriff' does not match regexp: 'general|president'"));
+        containsString("Claim 'entitlement' value 'sheriff' does not match regexp: 'general|president'"));
   }
 
   @Test
@@ -118,7 +118,7 @@ public class ClaimRegexpMatchTests extends JWTTestSupport {
     ValidatorResult result = check.validate(jwt);
     assertThat(result.isFailure(), is(true));
     assertThat(result.getMessage(),
-        is("No claim 'array_claim' value found matching regexp: 'ciccio'"));
+        containsString("No claim 'array_claim' value found matching regexp: 'ciccio'"));
 
   }
   

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/oidc/validator/JWTTestSupport.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/oidc/validator/JWTTestSupport.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.ext_authn.oidc.validator;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+
+public class JWTTestSupport {
+  
+  public static final String JWT_SUB = "sub";
+  public static final String JWT_ISS = "iss";
+  public static final String JWT_ID = "1";
+  
+  
+  protected JWTClaimsSet.Builder claimSetBuilder(){
+    JWTClaimsSet.Builder builder = new JWTClaimsSet.Builder();
+    builder.jwtID(JWT_ID).subject(JWT_SUB).issuer(JWT_ISS);
+    return builder;
+  }
+
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/oidc/validator/OidcValidatorIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/oidc/validator/OidcValidatorIntegrationTests.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.ext_authn.oidc.validator;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jwt.JWT;
+
+import it.infn.mw.iam.IamLoginService;
+import it.infn.mw.iam.authn.common.Fail;
+import it.infn.mw.iam.authn.common.ValidatorResolver;
+import it.infn.mw.iam.test.ext_authn.oidc.OidcExternalAuthenticationTestsSupport;
+import it.infn.mw.iam.test.ext_authn.oidc.OidcTestConfig;
+import it.infn.mw.iam.test.util.oidc.CodeRequestHolder;
+import it.infn.mw.iam.test.util.oidc.MockRestTemplateFactory;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(
+    classes = {IamLoginService.class, OidcTestConfig.class, OidcValidatorIntegrationTests.Config.class})
+@WebIntegrationTest("server.port:0")
+@Transactional
+public class OidcValidatorIntegrationTests extends OidcExternalAuthenticationTestsSupport {
+  
+  @Configuration
+  public static class Config {
+    @Bean
+    @Primary
+    ValidatorResolver<JWT> validatorResolver(){
+      return r -> Optional.of(new Fail<>());
+    }
+  }
+
+  @Before
+  public void setup() {
+    MockRestTemplateFactory tf = (MockRestTemplateFactory) restTemplateFactory;
+    tf.resetTemplate();
+  }
+  
+  @Test
+  public void testValidatorError() throws JOSEException,
+      JsonProcessingException, RestClientException, UnsupportedEncodingException {
+
+    RestTemplate rt = noRedirectRestTemplate();
+    ResponseEntity<String> response = rt.getForEntity(openidConnectLoginURL(), String.class);
+
+    checkAuthorizationEndpointRedirect(response);
+    HttpHeaders requestHeaders = new HttpHeaders();
+
+    String sessionCookie = extractSessionCookie(response);
+    requestHeaders.add("Cookie", sessionCookie);
+
+    CodeRequestHolder ru = buildCodeRequest(sessionCookie, response);
+
+    String tokenResponse = mockOidcProvider.prepareTokenResponse(OidcTestConfig.TEST_OIDC_CLIENT_ID,
+        "unregistered", ru.nonce);
+
+    prepareSuccessResponse(tokenResponse);
+
+    response = rt.postForEntity(openidConnectLoginURL(), ru.requestEntity, String.class);
+    verifyMockServerCalls();
+
+    assertThat(response.getStatusCode(), equalTo(HttpStatus.FOUND));
+    assertNotNull(response.getHeaders().getLocation());
+
+    UriComponents locationUri =
+        UriComponentsBuilder.fromUri(response.getHeaders().getLocation()).build();
+
+    assertThat(locationUri.getPath(), equalTo("/login"));
+    assertThat(locationUri.getQueryParams().keySet(), hasItem("externalAuthenticationError"));
+    assertThat(locationUri.getQueryParams().getFirst("externalAuthenticationError"), is("always%20fails"));
+  }
+  
+  
+
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/validator/AttributeMatchesTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/validator/AttributeMatchesTests.java
@@ -17,6 +17,7 @@ package it.infn.mw.iam.test.ext_authn.saml.validator;
 
 import static it.infn.mw.iam.authn.saml.validator.check.SamlAttributeValueRegexpMatch.attrValueMatches;
 import static java.lang.String.format;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
@@ -36,7 +37,7 @@ public class AttributeMatchesTests extends SamlValidatorTestSupport {
     ValidatorResult result = attrValueMatches(ENTITLEMENT_ATTR_NAME, ".*").validate(credential);
     assertThat(result.isFailure(), is(true));
     assertThat(result.hasMessage(), is(true));
-    assertThat(result.getMessage(), is(format("Attribute '%s' not found", ENTITLEMENT_ATTR_NAME)));
+    assertThat(result.getMessage(), containsString((format("Attribute '%s' not found", ENTITLEMENT_ATTR_NAME))));
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -91,7 +92,7 @@ public class AttributeMatchesTests extends SamlValidatorTestSupport {
 
     assertThat(result.isFailure(), is(true));
     assertThat(result.hasMessage(), is(true));
-    assertThat(result.getMessage(), is(format("No attribute '%s' value found matching regexp: '%s'",
+    assertThat(result.getMessage(), containsString(format("No attribute '%s' value found matching regexp: '%s'",
         ENTITLEMENT_ATTR_NAME, "wont_match")));
   }
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/validator/AttributeMatchesTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/validator/AttributeMatchesTests.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.ext_authn.saml.validator;
+
+import static it.infn.mw.iam.authn.saml.validator.check.SamlAttributeValueRegexpMatch.attrValueMatches;
+import static java.lang.String.format;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import it.infn.mw.iam.authn.common.ValidatorResult;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AttributeMatchesTests extends SamlValidatorTestSupport {
+
+  @Test
+  public void attributeNotFoundIsFailure() {
+
+    ValidatorResult result = attrValueMatches(ENTITLEMENT_ATTR_NAME, ".*").validate(credential);
+    assertThat(result.isFailure(), is(true));
+    assertThat(result.hasMessage(), is(true));
+    assertThat(result.getMessage(), is(format("Attribute '%s' not found", ENTITLEMENT_ATTR_NAME)));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void nullAttributeNameNotAllowed() {
+    attrValueMatches(null, null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void nullRegexpNotAllowed() {
+    attrValueMatches(ENTITLEMENT_ATTR_NAME, null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void emptyAttributeNameNotAllowed() {
+    attrValueMatches("", ".*");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void emptyRegexpNotAllowed() {
+    attrValueMatches(ENTITLEMENT_ATTR_NAME, "");
+  }
+
+  @Test
+  public void simpleMatch() {
+    when(credential.getAttribute(ENTITLEMENT_ATTR_NAME)).thenReturn(attribute);
+    when(credential.getAttributeAsStringArray(ENTITLEMENT_ATTR_NAME))
+      .thenReturn(new String[] {"example"});
+    ValidatorResult result =
+        attrValueMatches(ENTITLEMENT_ATTR_NAME, "that|example").validate(credential);
+    assertThat(result.isSuccess(), is(true));
+    assertThat(result.hasMessage(), is(false));
+  }
+
+  @Test
+  public void multiMatch() {
+    when(credential.getAttribute(ENTITLEMENT_ATTR_NAME)).thenReturn(attribute);
+    when(credential.getAttributeAsStringArray(ENTITLEMENT_ATTR_NAME))
+      .thenReturn(new String[] {"one", "two", "three", "that"});
+    ValidatorResult result =
+        attrValueMatches(ENTITLEMENT_ATTR_NAME, "that|example").validate(credential);
+    assertThat(result.isSuccess(), is(true));
+    assertThat(result.hasMessage(), is(false));
+  }
+
+  @Test
+  public void noMatch() {
+    when(credential.getAttribute(ENTITLEMENT_ATTR_NAME)).thenReturn(attribute);
+    when(credential.getAttributeAsStringArray(ENTITLEMENT_ATTR_NAME))
+      .thenReturn(new String[] {"example"});
+    ValidatorResult result =
+        attrValueMatches(ENTITLEMENT_ATTR_NAME, "wont_match").validate(credential);
+
+    assertThat(result.isFailure(), is(true));
+    assertThat(result.hasMessage(), is(true));
+    assertThat(result.getMessage(), is(format("No attribute '%s' value found matching regexp: '%s'",
+        ENTITLEMENT_ATTR_NAME, "wont_match")));
+  }
+
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/validator/HasAttributeCheckTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/validator/HasAttributeCheckTests.java
@@ -17,6 +17,7 @@ package it.infn.mw.iam.test.ext_authn.saml.validator;
 
 import static it.infn.mw.iam.authn.saml.validator.check.SamlHasAttributeCheck.hasAttribute;
 import static java.lang.String.format;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
@@ -36,7 +37,7 @@ public class HasAttributeCheckTests extends SamlValidatorTestSupport{
     ValidatorResult result = hasAttribute(ENTITLEMENT_ATTR_NAME).validate(credential); 
     assertThat(result.isFailure(), is(true));
     assertThat(result.hasMessage(), is(true));
-    assertThat(result.getMessage(), is(format("Attribute '%s' not found", ENTITLEMENT_ATTR_NAME)));
+    assertThat(result.getMessage(), containsString(format("Attribute '%s' not found", ENTITLEMENT_ATTR_NAME)));
   }
   
   @Test

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/validator/HasAttributeCheckTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/validator/HasAttributeCheckTests.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.ext_authn.saml.validator;
+
+import static it.infn.mw.iam.authn.saml.validator.check.SamlHasAttributeCheck.hasAttribute;
+import static java.lang.String.format;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import it.infn.mw.iam.authn.common.ValidatorResult;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HasAttributeCheckTests extends SamlValidatorTestSupport{
+  
+  @Test
+  public void attributeNotFoundIsFailure() {
+    
+    ValidatorResult result = hasAttribute(ENTITLEMENT_ATTR_NAME).validate(credential); 
+    assertThat(result.isFailure(), is(true));
+    assertThat(result.hasMessage(), is(true));
+    assertThat(result.getMessage(), is(format("Attribute '%s' not found", ENTITLEMENT_ATTR_NAME)));
+  }
+  
+  @Test
+  public void attributeFoundIsSuccess() {
+   
+    when(credential.getAttribute(ENTITLEMENT_ATTR_NAME)).thenReturn(attribute);
+    ValidatorResult result = hasAttribute(ENTITLEMENT_ATTR_NAME).validate(credential); 
+    assertThat(result.isSuccess(), is(true));
+    assertThat(result.hasMessage(), is(false));    
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void emptyAttributeNameNotAllowed() {
+    hasAttribute("");
+  }
+  
+  @Test(expected = IllegalArgumentException.class)
+  public void nullAttributeNameNotAllowed() {
+    hasAttribute(null);
+  }
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/validator/SamlValidatorIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/validator/SamlValidatorIntegrationTests.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.ext_authn.saml.validator;
+
+import static it.infn.mw.iam.authn.ExternalAuthenticationHandlerSupport.EXT_AUTH_ERROR_KEY;
+import static it.infn.mw.iam.authn.saml.validator.check.SamlHasAttributeCheck.hasAttribute;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Optional;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml2.core.AuthnRequest;
+import org.opensaml.saml2.core.Response;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.saml.SAMLCredential;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import it.infn.mw.iam.IamLoginService;
+import it.infn.mw.iam.authn.common.ValidatorError;
+import it.infn.mw.iam.authn.common.ValidatorResolver;
+import it.infn.mw.iam.test.ext_authn.saml.SamlAuthenticationTestSupport;
+import it.infn.mw.iam.test.ext_authn.saml.SamlTestConfig;
+import it.infn.mw.iam.test.util.saml.SamlUtils;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(
+    classes = {IamLoginService.class, SamlTestConfig.class, SamlValidatorIntegrationTests.class})
+@WebAppConfiguration
+public class SamlValidatorIntegrationTests extends SamlAuthenticationTestSupport {
+
+  @Test
+  public void testValidatorFailure() throws Throwable {
+    MockHttpSession session =
+        (MockHttpSession) mvc.perform(get(samlDefaultIdpLoginUrl()))
+          .andExpect(status().isOk())
+          .andReturn()
+          .getRequest()
+          .getSession();
+
+    AuthnRequest authnRequest = getAuthnRequestFromSession(session);
+
+    assertThat(authnRequest.getAssertionConsumerServiceURL(),
+        Matchers.equalTo("http://localhost:8080/saml/SSO"));
+
+    Response r = buildTest1Response(authnRequest);
+    
+    session = (MockHttpSession) mvc
+        .perform(post(authnRequest.getAssertionConsumerServiceURL())
+          .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+          .param("SAMLResponse", SamlUtils.signAndSerializeToBase64(r))
+          .session(session))
+        .andExpect(redirectedUrlPattern("/login**"))
+        .andExpect(request().sessionAttribute(EXT_AUTH_ERROR_KEY, instanceOf(ValidatorError.class)))
+        .andReturn()
+        .getRequest()
+        .getSession();
+  }
+
+  @Bean
+  @Primary
+  ValidatorResolver<SAMLCredential> validatorResolver(){
+    return r -> Optional.of(hasAttribute("1.2.3.4"));
+  }
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/validator/SamlValidatorResolverTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/validator/SamlValidatorResolverTests.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.ext_authn.saml.validator;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.security.saml.SAMLCredential;
+
+import it.infn.mw.iam.authn.common.Fail;
+import it.infn.mw.iam.authn.common.Success;
+import it.infn.mw.iam.authn.common.ValidatorResolver;
+import it.infn.mw.iam.authn.common.config.DefaultValidatorConfigParser;
+import it.infn.mw.iam.authn.common.config.ValidatorConfigParser;
+import it.infn.mw.iam.authn.common.config.ValidatorProperties;
+import it.infn.mw.iam.authn.saml.validator.DefaultSamlValidatorResolver;
+import it.infn.mw.iam.config.saml.IamSamlProperties;
+import it.infn.mw.iam.config.saml.IamSamlProperties.IssuerValidationProperties;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SamlValidatorResolverTests {
+
+  public static final String ENTITY_ID_1 = "e1";
+  public static final String ENTITY_ID_2 = "e2";
+  
+  @Mock
+  IamSamlProperties properties;
+
+  ValidatorConfigParser configParser = new DefaultValidatorConfigParser();
+  ValidatorResolver<SAMLCredential> resolver;
+  
+  @Test
+  public void noValidatorsIsFine() {
+    resolver = new DefaultSamlValidatorResolver(configParser, properties);
+    assertThat(resolver.resolveChecks(ENTITY_ID_1).isPresent(), is(false));
+  }
+  
+  @Test
+  public void defaultValidatorUnderstood() {
+    
+    ValidatorProperties defaultProps = new ValidatorProperties();
+    defaultProps.setKind("true");
+    
+    ValidatorProperties props = new ValidatorProperties();
+    props.setKind("false");
+    
+    IssuerValidationProperties entityProps = new IssuerValidationProperties();
+    entityProps.setEntityId(ENTITY_ID_1);
+    entityProps.setValidator(props);
+    
+    when(properties.getDefaultValidator()).thenReturn(defaultProps);
+    when(properties.getValidators()).thenReturn(asList(entityProps));
+    
+    resolver = new DefaultSamlValidatorResolver(configParser, properties);
+    assertThat(resolver.resolveChecks(ENTITY_ID_1).isPresent(), is(true));
+    assertThat(resolver.resolveChecks(ENTITY_ID_1).get(), instanceOf(Fail.class));
+    assertThat(resolver.resolveChecks(ENTITY_ID_2).isPresent(), is(true));
+    assertThat(resolver.resolveChecks(ENTITY_ID_2).get(), instanceOf(Success.class));
+  }
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/validator/SamlValidatorTestSupport.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/validator/SamlValidatorTestSupport.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.ext_authn.saml.validator;
+
+import org.mockito.Mock;
+import org.opensaml.saml2.core.Attribute;
+import org.springframework.security.saml.SAMLCredential;
+
+public class SamlValidatorTestSupport {
+  
+  public static final String ENTITLEMENT_ATTR_NAME = "entitlment";
+  
+  @Mock
+  protected SAMLCredential credential;
+  
+  @Mock
+  protected Attribute attribute;
+
+  public SamlValidatorTestSupport() {
+    // TODO Auto-generated constructor stub
+  }
+
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/validator/CompositeChecksTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/validator/CompositeChecksTests.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.ext_authn.validator;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import it.infn.mw.iam.authn.common.Conjunction;
+import it.infn.mw.iam.authn.common.Disjunction;
+import it.infn.mw.iam.authn.common.Error;
+import it.infn.mw.iam.authn.common.Fail;
+import it.infn.mw.iam.authn.common.Negation;
+import it.infn.mw.iam.authn.common.Success;
+import it.infn.mw.iam.authn.common.ValidatorResult;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CompositeChecksTests {
+  
+  public static final Object CREDENTIAL =  new Object();
+
+  @Test
+  public void negationTest() {
+    
+    Negation<Object> not = new Negation<>(asList(new Success<>()), null);
+    
+    assertThat(not.validate(CREDENTIAL).isFailure(), is(true));
+    
+    not = new Negation<>(asList(new Fail<>()), null);
+    assertThat(not.validate(CREDENTIAL).isSuccess(), is(true));
+    
+    not = new Negation<>(asList(new Error<>()), null);
+    assertThat(not.validate(CREDENTIAL).isError(), is(true));
+  }
+  
+  
+  @Test
+  public void conjunctionTest() {
+    
+    Conjunction<Object> and = new Conjunction<>(asList(new Success<>(), new Success<>()), null);
+    
+    assertThat(and.validate(CREDENTIAL).isSuccess(), is(true));
+    
+    and = new Conjunction<Object>(asList(new Success<>(), new Fail<>()), null);
+    
+    assertThat(and.validate(CREDENTIAL).isFailure(), is(true));
+    
+    and = new Conjunction<Object>(asList(new Fail<>(), new Success<>()), null);
+    
+    assertThat(and.validate(CREDENTIAL).isFailure(), is(true));
+    
+    and = new Conjunction<Object>(asList(new Error<>(), new Success<>()), null);
+    
+    assertThat(and.validate(CREDENTIAL).isError(), is(true));
+  }
+  
+  @Test
+  public void disjunctionTest() {
+   
+    
+    Disjunction<Object> or = new Disjunction<>(asList(new Success<>(), new Fail<>()), null);
+    
+    assertThat(or.validate(CREDENTIAL).isSuccess(), is(true));
+    
+    or = new Disjunction<>(asList(new Fail<>(), new Success<>()), null);
+    
+    assertThat(or.validate(CREDENTIAL).isSuccess(), is(true));
+    
+    or = new Disjunction<>(asList(new Fail<>(), new Fail<>()), null);    
+    
+    assertThat(or.validate(CREDENTIAL).isFailure(), is(true));
+    
+    or = new Disjunction<>(asList(new Fail<>()), null);
+    
+    assertThat(or.validate(CREDENTIAL).isFailure(), is(true));
+    
+    or = new Disjunction<>(asList(new Fail<>(), new Error<>()), null);
+    
+    assertThat(or.validate(CREDENTIAL).isError(), is(true));
+  }
+
+  @Test
+  public void failMessageTest() {
+    Disjunction<Object> or = new Disjunction<>(asList(new Fail<>()), "yo");
+    ValidatorResult result = or.validate(CREDENTIAL); 
+    assertThat(result.isFailure(), is(true));
+    assertThat(result.getMessage(), is("yo")); 
+    
+    Conjunction<Object> and = new Conjunction<>(asList(new Fail<>()), "yo");
+    result = and.validate(CREDENTIAL);
+    
+    assertThat(result.isFailure(), is(true));
+    assertThat(result.getMessage(), is("yo"));
+    
+    // Error message is not overridden
+    or = new Disjunction<>(asList(new Error<>()), "yo");
+    result = or.validate(CREDENTIAL);
+    assertThat(result.isError(), is(true));
+    assertThat(result.getMessage(), is("error"));
+    
+    and = new Conjunction<>(asList(new Error<>()), "yo");
+    result = and.validate(CREDENTIAL);
+    assertThat(result.isError(), is(true));
+    assertThat(result.getMessage(), is("error"));
+    
+  }
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/validator/ConfigParserTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/validator/ConfigParserTests.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.ext_authn.validator;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.security.saml.SAMLCredential;
+
+import com.google.common.collect.ImmutableMap;
+
+import it.infn.mw.iam.authn.common.Conjunction;
+import it.infn.mw.iam.authn.common.Disjunction;
+import it.infn.mw.iam.authn.common.Negation;
+import it.infn.mw.iam.authn.common.ValidatorCheck;
+import it.infn.mw.iam.authn.common.config.DefaultValidatorConfigParser;
+import it.infn.mw.iam.authn.common.config.ValidatorConfigError;
+import it.infn.mw.iam.authn.common.config.ValidatorConfigParser;
+import it.infn.mw.iam.authn.common.config.ValidatorProperties;
+import it.infn.mw.iam.authn.saml.validator.check.SamlHasAttributeCheck;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConfigParserTests {
+
+  @Spy
+  ValidatorProperties properties = new ValidatorProperties();
+
+  ValidatorConfigParser configParser = new DefaultValidatorConfigParser();
+
+  @Test(expected = ValidatorConfigError.class)
+  public void kindIsRequired() {
+    try {
+      configParser.parseValidatorProperties(properties);
+    } catch (ValidatorConfigError e) {
+      assertThat(e.getMessage(), containsString("kind must be non-null"));
+      throw e;
+    }
+  }
+
+  @Test(expected = ValidatorConfigError.class)
+  public void kindNonEmpty() {
+    when(properties.getKind()).thenReturn("");
+    try {
+      configParser.parseValidatorProperties(properties);
+    } catch (ValidatorConfigError e) {
+      assertThat(e.getMessage(), containsString("kind must be non-null"));
+      throw e;
+    }
+  }
+
+  @Test(expected = ValidatorConfigError.class)
+  public void kindMustBeKnown() {
+    when(properties.getKind()).thenReturn("unknown");
+    try {
+      configParser.parseValidatorProperties(properties);
+    } catch (ValidatorConfigError e) {
+      assertThat(e.getMessage(), containsString("Unsupported validator kind"));
+      throw e;
+    }
+  }
+
+  @Test(expected = ValidatorConfigError.class)
+  public void hasAttributeRequiresAttributeName() {
+    properties.setKind("hasAttr");
+
+    try {
+      configParser.parseValidatorProperties(properties);
+    } catch (ValidatorConfigError e) {
+      assertThat(e.getMessage(), containsString("attributeName param required"));
+      throw e;
+    }
+  }
+
+  @Test(expected = ValidatorConfigError.class)
+  public void hasAttributeRequiresNonEmptyAttributeName() {
+    properties.setParams(ImmutableMap.of("attributeName", ""));
+    properties.setKind("hasAttr");
+
+
+    try {
+      configParser.parseValidatorProperties(properties);
+    } catch (ValidatorConfigError e) {
+      assertThat(e.getMessage(), containsString("attributeName param required"));
+      throw e;
+    }
+  }
+
+  @Test
+  public void hasAttribute() {
+    properties.setParams(ImmutableMap.of("attributeName", "1.2.3.4"));
+    properties.setKind("hasAttr");
+
+    @SuppressWarnings("rawtypes")
+    ValidatorCheck hasAttr = configParser.parseValidatorProperties(properties);
+    assertThat(hasAttr, instanceOf(SamlHasAttributeCheck.class));
+  }
+  
+  @Test(expected = ValidatorConfigError.class)
+  public void disjunctionRequiresChildren() {
+    properties.setKind("or");
+    try {
+      configParser.parseValidatorProperties(properties);
+    } catch (ValidatorConfigError e) {
+      assertThat(e.getMessage(), containsString("children validators required"));
+      throw e;
+    }
+  }
+  
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  @Test
+  public void disjunctionRecognized() {
+    
+    ValidatorProperties child1 = new ValidatorProperties();
+    child1.setKind("hasAttr");
+    child1.setParams(ImmutableMap.of("attributeName", "1.2.3.4"));
+    
+    ValidatorProperties child2 = new ValidatorProperties();
+    child2.setKind("hasAttr");
+    child2.setParams(ImmutableMap.of("attributeName", "3.4.5.6"));
+    
+    properties.setChildrens(asList(child1, child2));
+    properties.setKind("or");
+    
+    ValidatorCheck or = configParser.parseValidatorProperties(properties);
+    assertThat(or, instanceOf(Disjunction.class));
+    
+    Disjunction<SAMLCredential> typedOr = (Disjunction<SAMLCredential>) or;
+    assertThat(typedOr.getChecks(), hasSize(2));
+    assertThat(typedOr.getChecks().get(0), instanceOf(SamlHasAttributeCheck.class));
+    assertThat(typedOr.getChecks().get(1), instanceOf(SamlHasAttributeCheck.class));
+  }
+  
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  @Test
+  public void nestedStructureRecognized() {
+    
+    ValidatorProperties child0 = new ValidatorProperties();
+    child0.setKind("hasAttr");
+    child0.setParams(ImmutableMap.of("attributeName", "1.2.3.4.5"));
+    
+    ValidatorProperties child2 = new ValidatorProperties();
+    child2.setKind("hasAttr");
+    child2.setParams(ImmutableMap.of("attributeName", "3.4.5.6"));
+    
+    ValidatorProperties child1 = new ValidatorProperties();
+    child1.setKind("not");
+    child1.setChildrens(asList(child2));
+    
+    properties.setChildrens(asList(child0, child1));
+    properties.setKind("and");
+    
+    ValidatorCheck and = configParser.parseValidatorProperties(properties);
+    assertThat(and, instanceOf(Conjunction.class));
+    
+    Conjunction<SAMLCredential> typedAnd = (Conjunction<SAMLCredential>) and;
+    assertThat(typedAnd.getChecks(), hasSize(2));
+    assertThat(typedAnd.getChecks().get(0), instanceOf(SamlHasAttributeCheck.class));
+    assertThat(typedAnd.getChecks().get(1), instanceOf(Negation.class));
+    
+    Negation<SAMLCredential> not = (Negation<SAMLCredential>) typedAnd.getChecks().get(1);
+    assertThat(not.getChecks(), hasSize(1));
+    assertThat(not.getChecks().get(0),instanceOf(SamlHasAttributeCheck.class));
+  }
+
+}

--- a/iam-persistence/pom.xml
+++ b/iam-persistence/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>it.infn.mw</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>1.5.0.rc6-SNAPSHOT</version>
+    <version>1.5.0.rc7-SNAPSHOT</version>
   </parent>
   <artifactId>iam-persistence</artifactId>
   <packaging>jar</packaging>

--- a/iam-test-client/pom.xml
+++ b/iam-test-client/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>it.infn.mw</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>1.5.0.rc6-SNAPSHOT</version>
+    <version>1.5.0.rc7-SNAPSHOT</version>
   </parent>
 
   <artifactId>iam-test-client</artifactId>

--- a/iam-test-protected-resource/pom.xml
+++ b/iam-test-protected-resource/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>it.infn.mw</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>1.5.0.rc6-SNAPSHOT</version>
+    <version>1.5.0.rc7-SNAPSHOT</version>
   </parent>
 
   <artifactId>iam-test-protected-resource</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>it.infn.mw</groupId>
   <artifactId>iam-parent</artifactId>
-  <version>1.5.0.rc6-SNAPSHOT</version>
+  <version>1.5.0.rc7-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>INDIGO Identity and Access Manager (IAM)</name>
 


### PR DESCRIPTION
Allow fine-grained validation on ID tokens and SAML credentials, to allow, for instance, filtering on the presence of a given claim (e.g., an entitlement) or attribute in order to allow access to an IAM-managed organisation.

The fine-grained validation should allow the configuration of a sequence of checks run, combined in logical conjunction or disjunction.

This is basically needed to integrate external multi-tenant providers that rely on entitlements to express collaboration membership.