### PR TITLE
Support device code grant public clients

### DIFF
--- a/iam-common/pom.xml
+++ b/iam-common/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>it.infn.mw</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>1.6.0-issue-316-SNAPSHOT</version>
   </parent>
 
   <artifactId>iam-common</artifactId>

--- a/iam-login-service/pom.xml
+++ b/iam-login-service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>it.infn.mw</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>1.6.0-issue-316-SNAPSHOT</version>
   </parent>
 
   <artifactId>iam-login-service</artifactId>

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/password_reset/PasswordResetService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/password_reset/PasswordResetService.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 package it.infn.mw.iam.api.account.password_reset;
-
+// Keep these includes, as the Javadoc refers to them...
 import it.infn.mw.iam.api.account.password_reset.error.BadUserPasswordError;
 import it.infn.mw.iam.api.account.password_reset.error.InvalidPasswordResetTokenError;
 import it.infn.mw.iam.api.account.password_reset.error.UserNotActiveOrNotVerified;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/security/MitreSecurityConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/security/MitreSecurityConfig.java
@@ -306,9 +306,15 @@ public class MitreSecurityConfig {
     protected void configure(final HttpSecurity http) throws Exception {
 
       // @formatter:off
-      http.antMatcher("/devicecode/**")
-        .csrf().disable()
-        .authorizeRequests().anyRequest().permitAll();
+      http
+        .antMatcher("/devicecode")
+          .csrf().disable()
+          .authorizeRequests()
+            .anyRequest()
+              .permitAll()
+          .and()
+            .sessionManagement()
+              .sessionCreationPolicy(STATELESS);
       // @formatter:on
     }
   }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/security/MitreSecurityConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/security/MitreSecurityConfig.java
@@ -302,39 +302,15 @@ public class MitreSecurityConfig {
   @Order(27)
   public static class DeviceCodeEnpointConfig extends WebSecurityConfigurerAdapter {
 
-    @Autowired
-    @Qualifier("clientUserDetailsService")
-    private UserDetailsService userDetailsService;
-
-    @Autowired
-    private CorsFilter corsFilter;
-
-    @Autowired
-    private OAuth2AuthenticationEntryPoint authenticationEntryPoint;
-
-    @Override
-    protected void configure(final AuthenticationManagerBuilder auth) throws Exception {
-
-      auth.userDetailsService(userDetailsService);
-    }
-
     @Override
     protected void configure(final HttpSecurity http) throws Exception {
 
       // @formatter:off
       http.antMatcher("/devicecode/**")
-        .httpBasic()
-          .authenticationEntryPoint(authenticationEntryPoint)
-        .and()
-          .addFilterBefore(corsFilter, SecurityContextPersistenceFilter.class)
-          .sessionManagement()
-            .sessionCreationPolicy(STATELESS).and()
-        .csrf()
-          .disable()
-        .authorizeRequests()
-          .anyRequest()
-            .fullyAuthenticated();
+        .csrf().disable()
+        .authorizeRequests().anyRequest().permitAll();
       // @formatter:on
     }
   }
+  
 }

--- a/iam-persistence/pom.xml
+++ b/iam-persistence/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>it.infn.mw</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>1.6.0-issue-316-SNAPSHOT</version>
   </parent>
   <artifactId>iam-persistence</artifactId>
   <packaging>jar</packaging>

--- a/iam-persistence/src/main/resources/db/migration/test/V100000___test_data.sql
+++ b/iam-persistence/src/main/resources/db/migration/test/V100000___test_data.sql
@@ -20,9 +20,10 @@ INSERT INTO client_details (id, client_id, client_secret, client_name, dynamical
    600);
 
 INSERT INTO client_details (id, client_id, client_secret, client_name, dynamically_registered,
-  refresh_token_validity_seconds, access_token_validity_seconds, id_token_validity_seconds, allow_introspection,
-  token_endpoint_auth_method, require_auth_time) VALUES
-(13, 'implicit-flow-client', null, 'Implicit Flow client', false, null, 3600, 600, false, null, false);
+  refresh_token_validity_seconds, access_token_validity_seconds, id_token_validity_seconds, device_code_validity_seconds, 
+  allow_introspection, token_endpoint_auth_method, require_auth_time) VALUES
+(13, 'implicit-flow-client', null, 'Implicit Flow client', false, null, 3600, 600, 600, false, null, false),
+(14, 'public-dc-client', null, 'Public Device Code client', false, null, 3600, 600, 600, false, null, false);
 
 INSERT INTO client_scope (owner_id, scope) VALUES
   (1, 'openid'),
@@ -117,7 +118,12 @@ INSERT INTO client_scope (owner_id, scope) VALUES
   (13, 'profile'),
   (13, 'email'),
   (13, 'address'),
-  (13, 'phone');
+  (13, 'phone'),
+  (14, 'profile'),
+  (14, 'email'),
+  (14, 'address'),
+  (14, 'phone');
+  
   
   
 INSERT INTO client_redirect_uri (owner_id, redirect_uri) VALUES
@@ -155,7 +161,8 @@ INSERT INTO client_grant_type (owner_id, grant_type) VALUES
   (11, 'client_credentials'),
   (12, 'refresh_token'),
   (12, 'urn:ietf:params:oauth:grant-type:device_code'),
-  (13, 'implicit');
+  (13, 'implicit'),
+  (14, 'urn:ietf:params:oauth:grant-type:device_code');
     
 INSERT INTO iam_user_info(ID,GIVENNAME,FAMILYNAME, EMAIL, EMAILVERIFIED, BIRTHDATE, GENDER) VALUES
 (2, 'Test', 'User', 'test@iam.test', true, '1950-01-01','M');

--- a/iam-test-client/pom.xml
+++ b/iam-test-client/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>it.infn.mw</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>1.6.0-issue-316-SNAPSHOT</version>
   </parent>
 
   <artifactId>iam-test-client</artifactId>

--- a/iam-test-protected-resource/pom.xml
+++ b/iam-test-protected-resource/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>it.infn.mw</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>1.6.0-issue-316-SNAPSHOT</version>
   </parent>
 
   <artifactId>iam-test-protected-resource</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>it.infn.mw</groupId>
   <artifactId>iam-parent</artifactId>
-  <version>1.6.0-SNAPSHOT</version>
+  <version>1.6.0-issue-316-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>INDIGO Identity and Access Manager (IAM)</name>
 


### PR DESCRIPTION
IAM currently requires client authentication for the device code grant
implementation.

This approach is too restrictive according to RFC 8628.
This commit introduces the changes to the default behaviour needed to
support public clients, in particular:

- client authentication is no longer required on the /devicecode endpoint;
- authentication on the /token endpoint depends on client configuration,
  supporting public clients
- test have been added to check that the complete flow work as expected
  for public and confidential clients

Issue: https://github.com/indigo-iam/iam/issues/316