### PR TITLE
Fix pagination handling

### DIFF
--- a/iam-common/pom.xml
+++ b/iam-common/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>it.infn.mw</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>1.6.0-issue-318-SNAPSHOT</version>
   </parent>
 
   <artifactId>iam-common</artifactId>

--- a/iam-login-service/pom.xml
+++ b/iam-login-service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>it.infn.mw</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>1.6.0-issue-318-SNAPSHOT</version>
   </parent>
 
   <artifactId>iam-login-service</artifactId>

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/controllers/add-user-group.controller.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/controllers/add-user-group.controller.js
@@ -15,112 +15,110 @@
  */
 'use strict';
 
-angular.module('dashboardApp').controller('AddUserGroupController',
-		AddUserGroupController);
+angular.module('dashboardApp')
+    .controller('AddUserGroupController', AddUserGroupController);
 
-AddUserGroupController.$inject = [ '$scope', '$state', '$filter', 'Utils', '$q',
-		'$uibModalInstance', '$sanitize', 'scimFactory', 'user' ];
+AddUserGroupController.$inject = [
+  '$scope', '$state', '$filter', 'Utils', '$q', '$uibModalInstance',
+  '$sanitize', 'scimFactory', 'user'
+];
 
-function AddUserGroupController($scope, $state, $filter, Utils, $q, $uibModalInstance,
-		$sanitize, scimFactory, user) {
+function AddUserGroupController(
+    $scope, $state, $filter, Utils, $q, $uibModalInstance, $sanitize,
+    scimFactory, user) {
+  var addGroupCtrl = this;
 
-	var addGroupCtrl = this;
+  // methods
+  addGroupCtrl.cancel = cancel;
+  addGroupCtrl.lookupGroups = lookupGroups;
+  addGroupCtrl.addGroup = addGroup;
+  addGroupCtrl.getAllGroups = getAllGroups;
+  addGroupCtrl.getNotMemberGroups = getNotMemberGroups;
+  addGroupCtrl.loadGroups = loadGroups;
 
-	// methods
-	addGroupCtrl.cancel = cancel;
-	addGroupCtrl.lookupGroups = lookupGroups;
-	addGroupCtrl.addGroup = addGroup;
-	addGroupCtrl.getAllGroups = getAllGroups;
-	addGroupCtrl.getNotMemberGroups = getNotMemberGroups;
-	addGroupCtrl.loadGroups = loadGroups;
+  // params
+  addGroupCtrl.user = user;
 
-	// params
-	addGroupCtrl.user = user;
+  // fields
+  addGroupCtrl.groupsSelected = null;
+  addGroupCtrl.groups = [];
+  addGroupCtrl.oGroups = [];
+  addGroupCtrl.enabled = true;
 
-	// fields
-	addGroupCtrl.groupsSelected = null;
-	addGroupCtrl.groups = [];
-	addGroupCtrl.oGroups = [];
-	addGroupCtrl.enabled = true;
+  addGroupCtrl.loadGroups();
 
-	addGroupCtrl.loadGroups();
+  function lookupGroups() {
+    return addGroupCtrl.oGroups;
+  }
 
-	function lookupGroups() {
+  function loadGroups() {
+    addGroupCtrl.loadingGroupsProgress = 30;
+    addGroupCtrl.getAllGroups(1, 10);
+  }
 
-		return addGroupCtrl.oGroups;
-	}
+  function cancel() {
+    $uibModalInstance.dismiss('Cancel');
+  }
 
-	function loadGroups() {
+  function addGroup() {
+    addGroupCtrl.enabled = false;
+    var requests = [];
+    var groupNames = [];
+    angular.forEach(addGroupCtrl.groupsSelected, function(groupToAdd) {
+      groupNames.push(groupToAdd.displayName);
+      requests.push(
+          scimFactory.addUserToGroup(groupToAdd.id, addGroupCtrl.user));
+    });
 
-		addGroupCtrl.loadingGroupsProgress = 30;
-		addGroupCtrl.getAllGroups(1, 10);
-	}
+    $q.all(requests).then(
+        function(response) {
+          console.log('Added ', addGroupCtrl.groupsSelected);
+          $uibModalInstance.close(
+              `User added to groups: '${groupNames.join(',')}'`);
+          addGroupCtrl.enabled = true;
+        },
+        function(error) {
+          console.error(error);
+          $scope.operationResult = Utils.buildErrorOperationResult(error);
+          addGroupCtrl.enabled = true;
+        });
+  }
 
-	function cancel() {
+  function getAllGroups(startIndex, count) {
+    scimFactory.getGroups(startIndex, count)
+        .then(
+            function(response) {
+              angular.forEach(response.data.Resources, function(group) {
+                addGroupCtrl.groups.push(group);
+              });
+              addGroupCtrl.groups =
+                  $filter('orderBy')(addGroupCtrl.groups, 'displayName', false);
 
-		$uibModalInstance.dismiss('Cancel');
-	}
+              if (response.data.totalResults >=
+                  (response.data.startIndex + response.data.itemsPerPage)) {
+                addGroupCtrl.loadingGroupsProgress = Math.floor(
+                    (startIndex + count) * 100 / response.data.totalResults);
+                addGroupCtrl.getAllGroups(startIndex + count, count);
 
-	function addGroup() {
+              } else {
+                addGroupCtrl.loadingGroupsProgress = 100;
+                addGroupCtrl.oGroups = addGroupCtrl.getNotMemberGroups();
+              }
+            },
+            function(error) {
+              console.error(error);
+              $scope.operationResult = Utils.buildErrorOperationResult(error);
+            });
+  }
 
-		addGroupCtrl.enabled = false;
-		var requests = [];
-		var groupNames = [];
-		angular.forEach(addGroupCtrl.groupsSelected, function(groupToAdd) {
-			groupNames.push(groupToAdd.displayName);
-			requests.push(scimFactory.addUserToGroup(groupToAdd.id,
-					addGroupCtrl.user));
-		});
-
-		$q.all(requests).then(function(response) {
-			console.log("Added ", addGroupCtrl.groupsSelected);
-			$uibModalInstance.close(`User added to groups: '${groupNames.join(",")}'`);
-			addGroupCtrl.enabled = true;
-		}, function(error) {
-			console.error(error);
-			$scope.operationResult = Utils.buildErrorOperationResult(error);
-			addGroupCtrl.enabled = true;
-		});
-	}
-	
-	function getAllGroups(startIndex, count) {
-
-		scimFactory
-			.getGroups(startIndex, count)
-				.then(function(response) {
-
-					angular.forEach(response.data.Resources, function(group) {
-						addGroupCtrl.groups.push(group);
-					});
-					addGroupCtrl.groups = $filter('orderBy')(addGroupCtrl.groups, "displayName", false);
-
-					if (response.data.totalResults > (response.data.startIndex + response.data.itemsPerPage)) {
-
-						addGroupCtrl.loadingGroupsProgress = Math.floor((startIndex + count) * 100 / response.data.totalResults);
-						addGroupCtrl.getAllGroups(startIndex + count, count);
-
-					} else {
-
-						addGroupCtrl.loadingGroupsProgress = 100;
-						addGroupCtrl.oGroups = addGroupCtrl.getNotMemberGroups();
-					}
-				}, function(error) {
-
-					console.error(error);
-					$scope.operationResult = Utils.buildErrorOperationResult(error);
-				});
-	}
-
-	function getNotMemberGroups() {
-	
-		return addGroupCtrl.groups.filter(function(group) {
-			for ( var i in addGroupCtrl.user.groups) {
-				if (group.id === addGroupCtrl.user.groups[i].value) {
-					return false;
-				}
-			}
-			return true;
-		});
-	}
-
+  function getNotMemberGroups() {
+    return addGroupCtrl.groups.filter(function(group) {
+      for (var i in addGroupCtrl.user.groups) {
+        if (group.id === addGroupCtrl.user.groups[i].value) {
+          return false;
+        }
+      }
+      return true;
+    });
+  }
 }

--- a/iam-persistence/pom.xml
+++ b/iam-persistence/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>it.infn.mw</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>1.6.0-issue-318-SNAPSHOT</version>
   </parent>
   <artifactId>iam-persistence</artifactId>
   <packaging>jar</packaging>

--- a/iam-test-client/pom.xml
+++ b/iam-test-client/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>it.infn.mw</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>1.6.0-issue-318-SNAPSHOT</version>
   </parent>
 
   <artifactId>iam-test-client</artifactId>

--- a/iam-test-protected-resource/pom.xml
+++ b/iam-test-protected-resource/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>it.infn.mw</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>1.6.0-issue-318-SNAPSHOT</version>
   </parent>
 
   <artifactId>iam-test-protected-resource</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>it.infn.mw</groupId>
   <artifactId>iam-parent</artifactId>
-  <version>1.6.0-SNAPSHOT</version>
+  <version>1.6.0-issue-318-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>INDIGO Identity and Access Manager (IAM)</name>
 


### PR DESCRIPTION
A bug in the boundary condition test hides some groups when the group
number is 11, 21, 31, etc., i.e. when it's just one item in the next
page (the page size by default is 10 entries).

This commit fixes the page boundary condition check.

Issue: https://github.com/indigo-iam/iam/issues/318