### PR TITLE
Fixed default urn namespace value for aarc profile

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcClaimValueHelper.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcClaimValueHelper.java
@@ -39,7 +39,7 @@ public class AarcClaimValueHelper {
   @Value("${iam.organisation.name}")
   String organisationName;
 
-  @Value("${iam.aarcProfile.urnNamespace}")
+  @Value("${iam.aarc-profile.urn-namespace}")
   String urnNamespace;
 
   public Object getClaimValueFromUserInfo(String claim, IamUserInfo info) {

--- a/iam-login-service/src/main/resources/application.yml
+++ b/iam-login-service/src/main/resources/application.yml
@@ -97,7 +97,10 @@ iam:
   
   device-code:
     allow-complete-verification-uri: ${IAM_DEVICE_CODE_ALLOW_COMPLETE_VERIFICATION_URI:true}
-    
+
+  aarc-profile:
+    urn-namespace: ${IAM_AARC_PROFILE_URN_NAMESPACE:example:iam}
+
 x509:
   trustAnchorsDir: ${IAM_X509_TRUST_ANCHORS_DIR:/etc/grid-security/certificates}
   trustAnchorsRefreshMsec: ${IAM_X509_TRUST_ANCHORS_REFRESH:14400}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/AarcClaimValueHelperTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/AarcClaimValueHelperTests.java
@@ -47,7 +47,7 @@ import it.infn.mw.iam.test.core.CoreControllerTestSupport;
   // @formatter:off
   "iam.host=example.org",
   "iam.organisation.name=org",
-  "iam.aarcProfile.urnNamespace=example:iam:test",
+  "iam.aarc-profile.urn-namespace=example:iam:test",
   // @formatter:on
 })
 public class AarcClaimValueHelperTests {

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/AarcProfileIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/AarcProfileIntegrationTests.java
@@ -71,7 +71,6 @@ import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
     "iam.host=example.org",
     "iam.jwt-profile.default-profile=aarc",
     "iam.organisation.name=org",
-    "iam.aarcProfile.urnNamespace=example:iam:test",
     // @formatter:on
 })
 public class AarcProfileIntegrationTests extends EndpointsTestUtils {
@@ -81,8 +80,8 @@ public class AarcProfileIntegrationTests extends EndpointsTestUtils {
   private static final String USERNAME = "test";
   private static final String PASSWORD = "password";
 
-  private static final String URN_GROUP_ANALYSIS = "urn:example:iam:test:group:Analysis#example.org";
-  private static final String URN_GROUP_PRODUCTION = "urn:example:iam:test:group:Production#example.org";
+  private static final String URN_GROUP_ANALYSIS = "urn:example:iam:group:Analysis#example.org";
+  private static final String URN_GROUP_PRODUCTION = "urn:example:iam:group:Production#example.org";
 
   protected static final Set<String> BASE_SCOPES = Sets.newHashSet("openid", "profile");
   protected static final Set<String> EDUPERSON_AFFILIATION_SCOPE =


### PR DESCRIPTION
The autowired `iam.aarc-profile.urn-namespace` property name has been fixed to accomplish the one defined here:
https://github.com/indigo-iam/iam/blob/develop/iam-login-service/src/main/java/it/infn/mw/iam/config/IamProperties.java#L282

A default value has been added into `application.yml`.
The default value is used now by the integration tests.
