### PR TITLE
Use correct scope information in userinfo endpoint

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/userinfo/DefaultOAuth2AuthenticationScopeResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/userinfo/DefaultOAuth2AuthenticationScopeResolver.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.core.userinfo;
+
+import static java.util.Objects.isNull;
+
+import java.util.Set;
+
+import org.mitre.oauth2.model.OAuth2AccessTokenEntity;
+import org.mitre.oauth2.repository.OAuth2TokenRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationDetails;
+import org.springframework.stereotype.Component;
+
+import it.infn.mw.iam.api.scim.exception.IllegalArgumentException;
+
+@Component
+public class DefaultOAuth2AuthenticationScopeResolver implements OAuth2AuthenticationScopeResolver {
+
+  private final OAuth2TokenRepository tokenRepo;
+
+  @Autowired
+  public DefaultOAuth2AuthenticationScopeResolver(OAuth2TokenRepository tokenRepo) {
+    this.tokenRepo = tokenRepo;
+  }
+
+  @Override
+  public Set<String> resolveScope(OAuth2Authentication auth) {
+
+    OAuth2AuthenticationDetails details = (OAuth2AuthenticationDetails) auth.getDetails();
+
+    if (isNull(details) || isNull(details.getTokenValue())) {
+      return auth.getOAuth2Request().getScope();
+    }
+
+    OAuth2AccessTokenEntity accessTokenEntity =
+        tokenRepo.getAccessTokenByValue(details.getTokenValue());
+
+    if (isNull(accessTokenEntity)) {
+      throw new IllegalArgumentException("Invalid token");
+    } else {
+      return accessTokenEntity.getScope();
+    }
+
+  }
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/userinfo/IamUserInfoEndpoint.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/userinfo/IamUserInfoEndpoint.java
@@ -16,12 +16,7 @@
 package it.infn.mw.iam.core.userinfo;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static java.util.Objects.isNull;
 
-import java.util.Set;
-
-import org.mitre.oauth2.model.OAuth2AccessTokenEntity;
-import org.mitre.oauth2.repository.OAuth2TokenRepository;
 import org.mitre.oauth2.service.SystemScopeService;
 import org.mitre.openid.connect.model.UserInfo;
 import org.mitre.openid.connect.view.HttpCodeView;
@@ -34,7 +29,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
-import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -42,7 +36,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import it.infn.mw.iam.api.scim.exception.IllegalArgumentException;
 import it.infn.mw.iam.core.oauth.profile.JWTProfile;
 import it.infn.mw.iam.core.oauth.profile.JWTProfileResolver;
 
@@ -54,31 +47,13 @@ public class IamUserInfoEndpoint {
 
   private final JWTProfileResolver profileResolver;
 
-  private final OAuth2TokenRepository tokenRepo;
+  private final OAuth2AuthenticationScopeResolver scopeResolver;
 
   @Autowired
-  public IamUserInfoEndpoint(JWTProfileResolver profileResolver, OAuth2TokenRepository tokenRepo) {
+  public IamUserInfoEndpoint(JWTProfileResolver profileResolver,
+      OAuth2AuthenticationScopeResolver scopeResolver) {
     this.profileResolver = profileResolver;
-    this.tokenRepo = tokenRepo;
-  }
-
-
-  private Set<String> resolveScope(OAuth2Authentication auth) {
-
-    OAuth2AuthenticationDetails details = (OAuth2AuthenticationDetails) auth.getDetails();
-
-    if (isNull(details) || isNull(details.getTokenValue())) {
-      return auth.getOAuth2Request().getScope();
-    }
-
-    OAuth2AccessTokenEntity accessTokenEntity =
-        tokenRepo.getAccessTokenByValue(details.getTokenValue());
-
-    if (isNull(accessTokenEntity)) {
-      throw new IllegalArgumentException("Invalid token");
-    } else {
-      return accessTokenEntity.getScope();
-    }
+    this.scopeResolver = scopeResolver;
   }
 
   @PreAuthorize("hasRole('ROLE_USER') and #oauth2.hasScope('" + SystemScopeService.OPENID_SCOPE
@@ -98,7 +73,7 @@ public class IamUserInfoEndpoint {
       model.addAttribute(HttpCodeView.CODE, HttpStatus.NOT_FOUND);
       return HttpCodeView.VIEWNAME;
     }
-    model.addAttribute(UserInfoView.SCOPE, resolveScope(auth));
+    model.addAttribute(UserInfoView.SCOPE, scopeResolver.resolveScope(auth));
     model.addAttribute(UserInfoView.AUTHORIZED_CLAIMS,
         auth.getOAuth2Request().getExtensions().get("claims"));
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/userinfo/OAuth2AuthenticationScopeResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/userinfo/OAuth2AuthenticationScopeResolver.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.core.userinfo;
+
+import java.util.Set;
+
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+
+public interface OAuth2AuthenticationScopeResolver {
+
+  Set<String> resolveScope(OAuth2Authentication auth);
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/OAuth2AuthenticationScopeResolverTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/OAuth2AuthenticationScopeResolverTests.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.oauth;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mitre.oauth2.model.OAuth2AccessTokenEntity;
+import org.mitre.oauth2.repository.OAuth2TokenRepository;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Request;
+import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationDetails;
+
+import com.google.common.collect.Sets;
+
+import it.infn.mw.iam.api.scim.exception.IllegalArgumentException;
+import it.infn.mw.iam.core.userinfo.DefaultOAuth2AuthenticationScopeResolver;
+import it.infn.mw.iam.test.util.oauth.MockOAuth2Request;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OAuth2AuthenticationScopeResolverTests {
+
+  public static final String TOKEN_VALUE = "token-value";
+
+  OAuth2Request oauthRequest = new MockOAuth2Request("test", new String[] {"openid", "profile"});
+
+  @Mock
+  OAuth2TokenRepository repo;
+
+  @Mock
+  OAuth2Authentication auth;
+
+  @Mock
+  OAuth2AccessTokenEntity tokenEntity;
+
+  @Mock
+  OAuth2AuthenticationDetails authDetails;
+
+  @InjectMocks
+  DefaultOAuth2AuthenticationScopeResolver scopeResolver;
+
+  @Before
+  public void setup() {
+    when(auth.getOAuth2Request()).thenReturn(oauthRequest);
+  }
+
+  @Test
+  public void testNullDetailsHandled() {
+    Set<String> scopes = scopeResolver.resolveScope(auth);
+    assertThat(scopes, hasSize(2));
+    assertThat(scopes, hasItem("openid"));
+    assertThat(scopes, hasItem("profile"));
+  }
+
+  @Test
+  public void testNullTokenValueHandled() {
+    when(auth.getDetails()).thenReturn(authDetails);
+    Set<String> scopes = scopeResolver.resolveScope(auth);
+    assertThat(scopes, hasSize(2));
+    assertThat(scopes, hasItem("openid"));
+    assertThat(scopes, hasItem("profile"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void tokenNotFoundInRepoRaisesIllegalArgumentException() {
+    when(auth.getDetails()).thenReturn(authDetails);
+    when(authDetails.getTokenValue()).thenReturn(TOKEN_VALUE);
+    scopeResolver.resolveScope(auth);
+  }
+
+  @Test
+  public void tokenFound() {
+    when(auth.getDetails()).thenReturn(authDetails);
+    when(authDetails.getTokenValue()).thenReturn(TOKEN_VALUE);
+    when(repo.getAccessTokenByValue(TOKEN_VALUE)).thenReturn(tokenEntity);
+    when(tokenEntity.getScope()).thenReturn(Sets.newHashSet("openid"));
+    Set<String> scopes = scopeResolver.resolveScope(auth);
+    assertThat(scopes, hasSize(1));
+    assertThat(scopes, hasItem("openid"));
+  }
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/UserInfoEndpointTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/UserInfoEndpointTests.java
@@ -122,4 +122,5 @@ public class UserInfoEndpointTests {
       .andExpect(status().isOk())
       .andExpect(jsonPath("$.updated_at").isNumber());
   }
+
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/UserInfoEndpointTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/UserInfoEndpointTests.java
@@ -22,6 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -81,8 +82,8 @@ public class UserInfoEndpointTests {
     // @formatter:off
     mvc.perform(get("/userinfo"))
       .andExpect(status().isOk())
-      .andExpect(jsonPath("$.sub").exists())
-      .andExpect(jsonPath("$.organisation_name").doesNotExist());
+      .andExpect(jsonPath("$.*", Matchers.hasSize(1)))
+      .andExpect(jsonPath("$.sub").exists());
     // @formatter:on
   }
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/util/oauth/WithMockOAuth2SecurityContextFactory.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/util/oauth/WithMockOAuth2SecurityContextFactory.java
@@ -18,6 +18,7 @@ package it.infn.mw.iam.test.util.oauth;
 import java.util.Map;
 
 import org.mitre.oauth2.model.SavedUserAuthentication;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -25,6 +26,7 @@ import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationDetails;
 import org.springframework.security.test.context.support.WithSecurityContextFactory;
 
 import com.google.common.collect.Maps;
@@ -100,7 +102,9 @@ public class WithMockOAuth2SecurityContextFactory
 
     authn.setAuthenticated(true);
 
-    authn.setDetails("No details");
+    OAuth2AuthenticationDetails details = Mockito.mock(OAuth2AuthenticationDetails.class);
+
+    authn.setDetails(details);
     context.setAuthentication(authn);
 
     filter.setSecurityContext(context);


### PR DESCRIPTION
This commit fixes a problem that leads to exposing too much information
on the userinfo endpoint.

The problems is caused by IAM using the set of scopes linked to the
original authorization request instead of the actual scopes linked to
the access token presented to the userinfo endpoint. These two sets of
scopes may differ for refreshed tokens where only a subset of the
original scopes is requested.

Issue: https://github.com/indigo-iam/iam/issues/348