### PR TITLE
Support hiding "apply for an account" button

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/IamProperties.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/IamProperties.java
@@ -30,40 +30,36 @@ import it.infn.mw.iam.config.login.LoginButtonProperties;
 @Component
 @ConfigurationProperties(prefix = "iam")
 public class IamProperties {
-  
+
   public enum EditableFields {
-    NAME,
-    SURNAME,
-    EMAIL,
-    PICTURE
+    NAME, SURNAME, EMAIL, PICTURE
   }
-  
+
   public enum LocalAuthenticationAllowedUsers {
-    ALL,
-    VO_ADMINS,
-    NONE
+    ALL, VO_ADMINS, NONE
   }
-  
+
   public enum LocalAuthenticationLoginPageMode {
-    VISIBLE,
-    HIDDEN,
-    HIDDEN_WITH_LINK
+    VISIBLE, HIDDEN, HIDDEN_WITH_LINK
   }
-  
+
   public static class LocalAuthenticationProperties {
-    
+
     LocalAuthenticationLoginPageMode loginPageVisibility;
     LocalAuthenticationAllowedUsers enabledFor;
-    
+
     public LocalAuthenticationLoginPageMode getLoginPageVisibility() {
       return loginPageVisibility;
     }
+
     public void setLoginPageVisibility(LocalAuthenticationLoginPageMode loginPageVisibility) {
       this.loginPageVisibility = loginPageVisibility;
     }
+
     public LocalAuthenticationAllowedUsers getEnabledFor() {
       return enabledFor;
     }
+
     public void setEnabledFor(LocalAuthenticationAllowedUsers enabledFor) {
       this.enabledFor = enabledFor;
     }
@@ -107,8 +103,10 @@ public class IamProperties {
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   public static class RegistrationProperties {
 
+    boolean showRegistrationButtonInLoginPage = true;
+
     boolean requireExternalAuthentication = false;
-    
+
     ExternalAuthenticationType authenticationType;
 
     String oidcIssuer;
@@ -116,6 +114,14 @@ public class IamProperties {
     String samlEntityId;
 
     Map<String, RegistrationFieldProperties> fields;
+
+    public boolean isShowRegistrationButtonInLoginPage() {
+      return showRegistrationButtonInLoginPage;
+    }
+
+    public void setShowRegistrationButtonInLoginPage(boolean showRegistrationButtonInLoginPage) {
+      this.showRegistrationButtonInLoginPage = showRegistrationButtonInLoginPage;
+    }
 
     public boolean isRequireExternalAuthentication() {
       return requireExternalAuthentication;
@@ -192,9 +198,7 @@ public class IamProperties {
   public static class JWTProfile {
 
     public enum Profile {
-      IAM,
-      WLCG,
-      AARC
+      IAM, WLCG, AARC
     }
 
     Profile defaultProfile = Profile.IAM;
@@ -420,7 +424,7 @@ public class IamProperties {
   private UserProfileProperties userProfile = new UserProfileProperties();
 
   private AarcProfileProperties aarcProfile = new AarcProfileProperties();
-  
+
   private LocalAuthenticationProperties localAuthn = new LocalAuthenticationProperties();
 
   public String getBaseUrl() {
@@ -582,13 +586,13 @@ public class IamProperties {
   public void setAarcProfile(AarcProfileProperties aarcProfile) {
     this.aarcProfile = aarcProfile;
   }
-  
+
   public LocalAuthenticationProperties getLocalAuthn() {
     return localAuthn;
   }
-  
+
   public void setLocalAuthn(LocalAuthenticationProperties localAuthn) {
     this.localAuthn = localAuthn;
   }
-  
+
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/web/DefaultLoginPageConfiguration.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/web/DefaultLoginPageConfiguration.java
@@ -171,4 +171,10 @@ public class DefaultLoginPageConfiguration implements LoginPageConfiguration, En
   public boolean isShowLinkToLocalAuthenticationPage() {
     return showLinkToLocalAuthn;
   }
+
+
+  @Override
+  public boolean isShowRegistrationButton() {
+    return iamProperties.getRegistration().isShowRegistrationButtonInLoginPage();
+  }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/web/LoginPageConfiguration.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/web/LoginPageConfiguration.java
@@ -23,6 +23,8 @@ import it.infn.mw.iam.config.oidc.OidcProvider;
 
 public interface LoginPageConfiguration {
 
+  boolean isShowRegistrationButton();
+
   boolean isLocalAuthenticationVisible();
   
   boolean isShowLinkToLocalAuthenticationPage();

--- a/iam-login-service/src/main/resources/application.yml
+++ b/iam-login-service/src/main/resources/application.yml
@@ -99,6 +99,7 @@ iam:
     allow-complete-verification-uri: ${IAM_DEVICE_CODE_ALLOW_COMPLETE_VERIFICATION_URI:true}
   
   registration:
+    show-registration-button-in-login-page: ${IAM_REGISTRATION_SHOW_REGISTRATION_BUTTON_IN_LOGIN_PAGE:true}
     require-external-authentication: ${IAM_REGISTRATION_REQUIRE_EXTERNAL_AUTHENTICATION:false}
     authentication-type: ${IAM_REGISTRATION_AUTHENTICATION_TYPE:oidc}
     oidc-issuer: ${IAM_REGISTRATION_OIDC_ISSUER:https://example.org}

--- a/iam-login-service/src/main/webapp/WEB-INF/views/iam/login.jsp
+++ b/iam-login-service/src/main/webapp/WEB-INF/views/iam/login.jsp
@@ -127,7 +127,7 @@
         </div>
         
 
-        <c:if test="${loginPageConfiguration.registrationEnabled}">
+        <c:if test="${loginPageConfiguration.registrationEnabled && loginPageConfiguration.showRegistrationButton}">
             
             <div id="login-registration">
                 <div class="registration-preamble text-muted">

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/TestUtils.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/TestUtils.java
@@ -156,6 +156,11 @@ public class TestUtils {
       return this;
     }
 
+    public AccessTokenGetter port(int port) {
+      this.port = port;
+      return this;
+    }
+
     public String getAccessToken() {
 
       RequestSpecification req = given().port(port)

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/password/PasswordUpdateTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/password/PasswordUpdateTests.java
@@ -46,10 +46,10 @@ import it.infn.mw.iam.test.TestUtils;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = IamLoginService.class)
-@WebIntegrationTest
+@WebIntegrationTest(randomPort = true)
 public class PasswordUpdateTests {
 
-  @Value("${server.port}")
+  @Value("${local.server.port}")
   private Integer iamPort;
 
   private ScimUser testUser;
@@ -131,13 +131,17 @@ public class PasswordUpdateTests {
     String newPassword = "secure_password";
 
 
-    String accessToken = passwordTokenGetter().username(testUser.getUserName())
+    String accessToken = passwordTokenGetter().port(iamPort)
+      .username(testUser.getUserName())
       .password(currentPassword)
       .getAccessToken();
 
     doPost(accessToken, currentPassword, newPassword).statusCode(HttpStatus.OK.value());
 
-    passwordTokenGetter().username(testUser.getUserName()).password(newPassword).getAccessToken();
+    passwordTokenGetter().port(iamPort)
+      .username(testUser.getUserName())
+      .password(newPassword)
+      .getAccessToken();
   }
 
   @Test
@@ -157,12 +161,14 @@ public class PasswordUpdateTests {
 
     String currentPassword = "password";
     String newPassword = "secure_password";
-    String accessToken = passwordTokenGetter().username(testUser.getUserName())
+    String accessToken = passwordTokenGetter().port(iamPort)
+      .username(testUser.getUserName())
       .password(currentPassword)
       .getAccessToken();
 
     doPost(accessToken, "thisisnotthecurrentpassword", newPassword)
-      .statusCode(HttpStatus.BAD_REQUEST.value()).body(equalTo("Wrong password provided"));
+      .statusCode(HttpStatus.BAD_REQUEST.value())
+      .body(equalTo("Wrong password provided"));
   }
 
   @Test
@@ -170,7 +176,7 @@ public class PasswordUpdateTests {
 
     String currentPassword = "password";
     String newPassword = "secure_password";
-    String accessToken = TestUtils.clientCredentialsTokenGetter().getAccessToken();
+    String accessToken = TestUtils.clientCredentialsTokenGetter().port(iamPort).getAccessToken();
 
     doPost(accessToken, currentPassword, newPassword).statusCode(HttpStatus.FORBIDDEN.value());
   }
@@ -180,7 +186,8 @@ public class PasswordUpdateTests {
 
     String currentPassword = "password";
     String newPassword = null;
-    String accessToken = passwordTokenGetter().username(testUser.getUserName())
+    String accessToken = passwordTokenGetter().port(iamPort)
+      .username(testUser.getUserName())
       .password(currentPassword)
       .getAccessToken();
 
@@ -193,7 +200,8 @@ public class PasswordUpdateTests {
 
     String currentPassword = "password";
     String newPassword = "";
-    String accessToken = passwordTokenGetter().username(testUser.getUserName())
+    String accessToken = passwordTokenGetter().port(iamPort)
+      .username(testUser.getUserName())
       .password(currentPassword)
       .getAccessToken();
 
@@ -206,7 +214,8 @@ public class PasswordUpdateTests {
 
     String currentPassword = "password";
     String newPassword = "pass";
-    String accessToken = passwordTokenGetter().username(testUser.getUserName())
+    String accessToken = passwordTokenGetter().port(iamPort)
+      .username(testUser.getUserName())
       .password(currentPassword)
       .getAccessToken();
 
@@ -219,14 +228,15 @@ public class PasswordUpdateTests {
 
     String currentPassword = "password";
     String newPassword = "newPassword";
-    String accessToken = passwordTokenGetter().username(testUser.getUserName())
+    String accessToken = passwordTokenGetter().port(iamPort)
+      .username(testUser.getUserName())
       .password(currentPassword)
       .getAccessToken();
 
     IamAccount account = accountRepository.findByUsername(testUser.getUserName())
-        .orElseThrow(() -> new Exception("Test user not found"));
-      account.setActive(false);
-      accountRepository.save(account);
+      .orElseThrow(() -> new Exception("Test user not found"));
+    account.setActive(false);
+    accountRepository.save(account);
 
     doPost(accessToken, currentPassword, newPassword).statusCode(HttpStatus.CONFLICT.value())
       .body(containsString("Account is not active or email is not verified"));

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/oidc/OidcExternalAuthenticationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/oidc/OidcExternalAuthenticationTests.java
@@ -51,7 +51,7 @@ import it.infn.mw.iam.test.util.oidc.MockRestTemplateFactory;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = {IamLoginService.class, OidcTestConfig.class})
-@WebIntegrationTest("server.port:0")
+@WebIntegrationTest(randomPort = true)
 @Transactional
 public class OidcExternalAuthenticationTests extends OidcExternalAuthenticationTestsSupport {
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/oidc/validator/OidcValidatorIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/oidc/validator/OidcValidatorIntegrationTests.java
@@ -57,7 +57,7 @@ import it.infn.mw.iam.test.util.oidc.MockRestTemplateFactory;
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(
     classes = {IamLoginService.class, OidcTestConfig.class, OidcValidatorIntegrationTests.Config.class})
-@WebIntegrationTest("server.port:0")
+@WebIntegrationTest(randomPort = true)
 @Transactional
 public class OidcValidatorIntegrationTests extends OidcExternalAuthenticationTestsSupport {
   

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/login/RegistrationButtonDisabledTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/login/RegistrationButtonDisabledTests.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.login;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.jayway.restassured.RestAssured;
+
+import it.infn.mw.iam.IamLoginService;
+import it.infn.mw.iam.test.TestUtils;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = IamLoginService.class)
+@WebIntegrationTest(randomPort = true)
+@TestPropertySource(properties = {"iam.registration.show-registration-button-in-login-page=false"})
+public class RegistrationButtonDisabledTests {
+
+  @Value("${local.server.port}")
+  private Integer serverPort;
+
+  @BeforeClass
+  public static void init() {
+    TestUtils.initRestAssured();
+  }
+
+  @Test
+  public void registrationButtonIsNotShown() {
+    RestAssured.given()
+      .port(serverPort)
+      .log()
+      .all(true)
+      .when()
+      .get("/login")
+      .then()
+      .statusCode(200)
+      .body(not(containsString("Apply for an account")));
+  }
+
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/login/RegistrationButtonEnabledByDefaultTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/login/RegistrationButtonEnabledByDefaultTests.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.login;
+
+import static org.hamcrest.CoreMatchers.containsString;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.jayway.restassured.RestAssured;
+
+import it.infn.mw.iam.IamLoginService;
+import it.infn.mw.iam.test.TestUtils;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = IamLoginService.class)
+@WebIntegrationTest(randomPort = true)
+public class RegistrationButtonEnabledByDefaultTests {
+  @Value("${local.server.port}")
+  private Integer serverPort;
+
+  @BeforeClass
+  public static void init() {
+    TestUtils.initRestAssured();
+  }
+
+  @Test
+  public void registrationButtonIsShown() {
+    RestAssured.given()
+      .port(serverPort)
+      .log()
+      .all(true)
+      .when()
+      .get("/login")
+      .then()
+      .log()
+      .all()
+      .statusCode(200)
+      .body(containsString("Apply for an account"));
+  }
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/AuthorizationCodeIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/AuthorizationCodeIntegrationTests.java
@@ -48,7 +48,7 @@ import it.infn.mw.iam.test.TestUtils;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = {IamLoginService.class})
-@WebIntegrationTest("server.port:0")
+@WebIntegrationTest(randomPort = true)
 @Transactional
 public class AuthorizationCodeIntegrationTests {
 


### PR DESCRIPTION
The apply for an account button (enabled by default) can be disabled by setting
a property as follows:

iam.registration.show-registration-button-in-login-page=false

or setting the

IAM_REGISTRATION_SHOW_REGISTRATION_BUTTON_IN_LOGIN_PAGE=false

env variable.

Integration tests are added (checking that the JSP produced for the
login page complies with requirements).

Other integration tests are also refactored to correctly bind on a
random port.

Issue: #355