### PR TITLE
Do not allow token exchange when a single client app is involved

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/exchange_policy/DefaultTokenExchangePolicyService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/exchange_policy/DefaultTokenExchangePolicyService.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package it.infn.mw.iam.api.exchange_policy;
 
 import static java.util.stream.Collectors.toList;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/exchange_policy/DefaultTokenExchangePolicyService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/exchange_policy/DefaultTokenExchangePolicyService.java
@@ -1,0 +1,84 @@
+package it.infn.mw.iam.api.exchange_policy;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.StreamSupport.stream;
+
+import java.time.Clock;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import it.infn.mw.iam.core.oauth.exchange.TokenExchangePdp;
+import it.infn.mw.iam.persistence.model.IamTokenExchangePolicyEntity;
+import it.infn.mw.iam.persistence.repository.IamTokenExchangePolicyRepository;
+
+@Service
+@Transactional
+public class DefaultTokenExchangePolicyService implements TokenExchangePolicyService {
+
+  private final Clock clock;
+  private final IamTokenExchangePolicyRepository repo;
+  private final ExchangePolicyConverter converter;
+  private final TokenExchangePdp pdp;
+
+  @Autowired
+  public DefaultTokenExchangePolicyService(Clock clock, IamTokenExchangePolicyRepository repo,
+      ExchangePolicyConverter converter, TokenExchangePdp pdp) {
+    this.clock = clock;
+    this.repo = repo;
+    this.converter = converter;
+    this.pdp = pdp;
+  }
+
+  private Supplier<ExchangePolicyNotFoundError> notFoundError(Long id) {
+    return () -> new ExchangePolicyNotFoundError("Exchange policy not found for id: " + id);
+  }
+
+
+  @Override
+  public List<ExchangePolicyDTO> getTokenExchangePolicies() {
+    return stream(repo.findAll().spliterator(), false).map(converter::dtoFromEntity)
+      .collect(toList());
+  }
+
+  @Override
+  public ExchangePolicyDTO getTokenExchangePolicyById(Long policyId) {
+
+    return Optional.ofNullable(repo.findOne(policyId))
+      .map(converter::dtoFromEntity)
+      .orElseThrow(notFoundError(policyId));
+  }
+
+  @Override
+  public ExchangePolicyDTO createTokenExchangePolicy(ExchangePolicyDTO policyDTO) {
+
+    Date now = Date.from(clock.instant());
+
+    IamTokenExchangePolicyEntity policy = converter.entityFromDto(policyDTO);
+
+    policy.setCreationTime(now);
+    policy.setLastUpdateTime(now);
+
+    policy = repo.save(policy);
+
+    return converter.dtoFromEntity(policy);
+  }
+
+  @Override
+  public void deleteTokenExchangePolicyById(Long policyId) {
+    IamTokenExchangePolicyEntity p =
+        Optional.ofNullable(repo.findOne(policyId)).orElseThrow(notFoundError(policyId));
+    repo.delete(p.getId());
+  }
+
+  @Override
+  public void clearTokenExchangePolicyCache() {
+    pdp.clearPolicyCache();
+  }
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/exchange_policy/TokenExchangePolicyService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/exchange_policy/TokenExchangePolicyService.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package it.infn.mw.iam.api.exchange_policy;
 
 import java.util.List;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/exchange_policy/TokenExchangePolicyService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/exchange_policy/TokenExchangePolicyService.java
@@ -1,0 +1,16 @@
+package it.infn.mw.iam.api.exchange_policy;
+
+import java.util.List;
+
+public interface TokenExchangePolicyService {
+
+  List<ExchangePolicyDTO> getTokenExchangePolicies();
+
+  ExchangePolicyDTO getTokenExchangePolicyById(Long policyId);
+
+  ExchangePolicyDTO createTokenExchangePolicy(ExchangePolicyDTO policy);
+
+  void deleteTokenExchangePolicyById(Long policyId);
+
+  void clearTokenExchangePolicyCache();
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/IamProperties.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/IamProperties.java
@@ -43,6 +43,19 @@ public class IamProperties {
     VISIBLE, HIDDEN, HIDDEN_WITH_LINK
   }
 
+  public static class TokenExchangeProperties {
+    Long expirePolicyCacheAfterSeconds = 300L;
+
+    public Long getExpirePolicyCacheAfterSeconds() {
+      return expirePolicyCacheAfterSeconds;
+    }
+
+    public void setExpirePolicyCacheAfterSeconds(Long expirePolicyCacheAfterSeconds) {
+      this.expirePolicyCacheAfterSeconds = expirePolicyCacheAfterSeconds;
+    }
+
+  }
+
   public static class LocalAuthenticationProperties {
 
     LocalAuthenticationLoginPageMode loginPageVisibility;
@@ -429,6 +442,8 @@ public class IamProperties {
 
   private IamTokenEnhancerProperties tokenEnhancer = new IamTokenEnhancerProperties();
 
+  private TokenExchangeProperties tokenExchange = new TokenExchangeProperties();
+
   public String getBaseUrl() {
     return baseUrl;
   }
@@ -605,4 +620,11 @@ public class IamProperties {
     this.tokenEnhancer = tokenEnhancer;
   }
 
+  public TokenExchangeProperties getTokenExchange() {
+    return tokenExchange;
+  }
+
+  public void setTokenExchange(TokenExchangeProperties tokenExchange) {
+    this.tokenExchange = tokenExchange;
+  }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/exchange/DefaultTokenExchangePdp.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/exchange/DefaultTokenExchangePdp.java
@@ -15,12 +15,16 @@
  */
 package it.infn.mw.iam.core.oauth.exchange;
 
-import static it.infn.mw.iam.core.oauth.exchange.TokenExchangePdpResult.fromPolicy;
 import static it.infn.mw.iam.core.oauth.exchange.TokenExchangePdpResult.invalidScope;
 import static it.infn.mw.iam.core.oauth.exchange.TokenExchangePdpResult.notApplicable;
+import static it.infn.mw.iam.core.oauth.exchange.TokenExchangePdpResult.resultFromPolicy;
 import static java.util.Comparator.comparing;
 
+import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -31,8 +35,13 @@ import org.springframework.security.oauth2.provider.ClientDetails;
 import org.springframework.security.oauth2.provider.TokenRequest;
 import org.springframework.stereotype.Service;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Lists;
 
+import it.infn.mw.iam.config.IamProperties;
 import it.infn.mw.iam.core.oauth.scope.matchers.ScopeMatcher;
 import it.infn.mw.iam.core.oauth.scope.matchers.ScopeMatcherRegistry;
 import it.infn.mw.iam.persistence.model.IamTokenExchangePolicyEntity;
@@ -45,48 +54,51 @@ public class DefaultTokenExchangePdp implements TokenExchangePdp {
   public static final String NOT_APPLICABLE_ERROR_TEMPLATE =
       "No applicable policies found for clients: %s -> %s";
 
-  final IamTokenExchangePolicyRepository repo;
-
-  final ScopeMatcherRegistry scopeMatcherRegistry;
+  private final ScopeMatcherRegistry scopeMatcherRegistry;
 
   List<TokenExchangePolicy> policies = Lists.newArrayList();
 
+  private final LoadingCache<TokenExchangePolicyCacheKey, Set<TokenExchangePolicy>> policyCache;
+
   @Autowired
-  public DefaultTokenExchangePdp(IamTokenExchangePolicyRepository repo,
+  public DefaultTokenExchangePdp(IamProperties iamProperties, IamTokenExchangePolicyRepository repo,
       ScopeMatcherRegistry scopeMatcherRegistry) {
-    this.repo = repo;
     this.scopeMatcherRegistry = scopeMatcherRegistry;
+    final Long cacheExpireAfterWriteSecs =
+        iamProperties.getTokenExchange().getExpirePolicyCacheAfterSeconds();
+
+    LOG.debug("Token exchange policy cache entries expire after '{}' seconds since last update",
+        cacheExpireAfterWriteSecs);
+
+    this.policyCache = CacheBuilder.newBuilder()
+      .expireAfterWrite(
+          Duration.ofSeconds(cacheExpireAfterWriteSecs))
+      .build(new TokenExchangePolicyCacheLoader(repo));
   }
 
-
-  void loadPolicies() {
-    policies.clear();
-
-    for (IamTokenExchangePolicyEntity p : repo.findAll()) {
-      policies.add(TokenExchangePolicy.builder().fromEntity(p).build());
-    }
+  public Cache<TokenExchangePolicyCacheKey, Set<TokenExchangePolicy>> getPolicyCache() {
+    return policyCache;
   }
 
   Set<TokenExchangePolicy> applicablePolicies(ClientDetails origin, ClientDetails destination) {
-    loadPolicies();
-    return policies.stream()
-      .filter(p -> p.appicableFor(origin, destination))
-      .collect(Collectors.toSet());
+    return Optional
+      .ofNullable(policyCache.getUnchecked(TokenExchangePolicyCacheKey.forClients(origin, destination)))
+      .orElse(Collections.emptySet());
   }
 
   private TokenExchangePdpResult verifyScopes(TokenExchangePolicy p, TokenRequest request,
       ClientDetails origin, ClientDetails destination) {
 
     if (p.isDeny() || request.getScope().isEmpty()) {
-      return fromPolicy(p);
+      return resultFromPolicy(p);
     }
 
-    // The requested scopes must be allowed by the origin client (destination is impersonating the
+    // The requested scopes must be allowed for the origin client (destination is impersonating the
     // origin client)
     Set<ScopeMatcher> originClientMatchers = scopeMatcherRegistry.findMatchersForClient(origin);
 
     for (String scope : request.getScope()) {
-      // Check requested scope is permitted by client configuration
+      // Check requested scope is allowed by client configuration
       if (originClientMatchers.stream().noneMatch(m -> m.matches(scope))) {
         return invalidScope(p, scope, "scope not allowed by client configuration");
       }
@@ -100,7 +112,7 @@ public class DefaultTokenExchangePdp implements TokenExchangePdp {
       }
     }
 
-    return fromPolicy(p);
+    return resultFromPolicy(p);
   }
 
 
@@ -114,4 +126,81 @@ public class DefaultTokenExchangePdp implements TokenExchangePdp {
       .orElse(notApplicable());
   }
 
+
+
+  private static class TokenExchangePolicyCacheKey {
+
+    private ClientDetails originClient;
+    private ClientDetails destinationClient;
+
+    private TokenExchangePolicyCacheKey() {
+
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(destinationClient.getClientId(), originClient.getClientId());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj)
+        return true;
+      if (obj == null)
+        return false;
+      if (getClass() != obj.getClass())
+        return false;
+      TokenExchangePolicyCacheKey other = (TokenExchangePolicyCacheKey) obj;
+      return Objects.equals(destinationClient.getClientId(), other.destinationClient.getClientId())
+          && Objects.equals(originClient.getClientId(), other.originClient.getClientId());
+    }
+
+
+    static TokenExchangePolicyCacheKey forClients(ClientDetails originClient, ClientDetails destinationClient) {
+      TokenExchangePolicyCacheKey key = new TokenExchangePolicyCacheKey();
+      key.originClient = originClient;
+      key.destinationClient = destinationClient;
+      return key;
+    }
+
+    @Override
+    public String toString() {
+      return "TEPCK[o=" + originClient.getClientId() + ", d="
+          + destinationClient.getClientId() + "]";
+    }
+  }
+
+  private static class TokenExchangePolicyCacheLoader
+      extends CacheLoader<TokenExchangePolicyCacheKey, Set<TokenExchangePolicy>> {
+
+    public static final Logger LOG = LoggerFactory.getLogger(TokenExchangePolicyCacheLoader.class);
+
+    private final IamTokenExchangePolicyRepository repo;
+
+    public TokenExchangePolicyCacheLoader(IamTokenExchangePolicyRepository repo) {
+      this.repo = repo;
+    }
+
+    @Override
+    public Set<TokenExchangePolicy> load(TokenExchangePolicyCacheKey key) throws Exception {
+
+      LOG.debug("Loading token exchange policies for key: {}", key);
+
+      List<TokenExchangePolicy> policies = Lists.newArrayList();
+
+      for (IamTokenExchangePolicyEntity p : repo.findAll()) {
+        policies.add(TokenExchangePolicy.builder().fromEntity(p).build());
+      }
+
+      return policies.stream()
+        .filter(p -> p.appicableFor(key.originClient, key.destinationClient))
+        .collect(Collectors.toSet());
+    }
+
+  }
+
+  @Override
+  public void clearPolicyCache() {
+    getPolicyCache().invalidateAll();
+  }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/exchange/TokenExchangePdp.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/exchange/TokenExchangePdp.java
@@ -23,4 +23,6 @@ public interface TokenExchangePdp {
   TokenExchangePdpResult validateTokenExchange(TokenRequest request, ClientDetails originClient,
       ClientDetails destinationClient);
 
+  void clearPolicyCache();
+
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/exchange/TokenExchangePdpResult.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/exchange/TokenExchangePdpResult.java
@@ -70,7 +70,7 @@ public class TokenExchangePdpResult {
     return Optional.ofNullable(message);
   }
 
-  public static TokenExchangePdpResult fromPolicy(TokenExchangePolicy policy) {
+  public static TokenExchangePdpResult resultFromPolicy(TokenExchangePolicy policy) {
     checkNotNull(policy);
     if (PolicyRule.DENY.equals(policy.getRule())) {
       return new TokenExchangePdpResult(Decision.DENY, policy);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/granters/TokenExchangeTokenGranter.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/granters/TokenExchangeTokenGranter.java
@@ -93,6 +93,11 @@ public class TokenExchangeTokenGranter extends AbstractTokenGranter {
           actorClient.getClientId(), subjectClient.getClientId(), audience, requestedScopes);
     }
 
+    if (subjectClient.equals(actorClient)) {
+      throw new OAuth2AccessDeniedException(
+          "Token exchange not allowed: the actor and the subject are the same client");
+    }
+
     TokenExchangePdpResult result =
         exchangePdp.validateTokenExchange(tokenRequest, subjectClient, actorClient);
 

--- a/iam-login-service/src/main/resources/application.yml
+++ b/iam-login-service/src/main/resources/application.yml
@@ -121,6 +121,9 @@ iam:
    
   aarc-profile:
     urn-namespace: ${IAM_AARC_PROFILE_URN_NAMESPACE:example:iam}
+    
+  token-exchange:
+    expire-policy-cache-after-seconds: ${IAM_TOKEN_EXCHANGE_EXPIRE_POLICY_CACHE_AFTER_SECONDS:300}
 
 x509:
   trustAnchorsDir: ${IAM_X509_TRUST_ANCHORS_DIR:/etc/grid-security/certificates}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/core/CoreControllerTestSupport.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/core/CoreControllerTestSupport.java
@@ -37,19 +37,17 @@ public class CoreControllerTestSupport {
 
     return new MockOAuth2Filter();
   }
-  
+
   @Bean
   @Primary
   MockTimeProvider mockTimeProvider() {
     return new MockTimeProvider();
   }
-  
+
   @Bean
   @Primary
   ApplicationEventPublisher mockApplicationEventPublisher() {
     return Mockito.mock(ApplicationEventPublisher.class);
   }
-  
 
-  
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/exchange/TokenExchangePdPTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/exchange/TokenExchangePdPTests.java
@@ -33,13 +33,14 @@ import java.util.Collections;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.security.oauth2.provider.ClientDetails;
 import org.springframework.security.oauth2.provider.TokenRequest;
 
+import it.infn.mw.iam.config.IamProperties;
+import it.infn.mw.iam.config.IamProperties.TokenExchangeProperties;
 import it.infn.mw.iam.core.oauth.exchange.DefaultTokenExchangePdp;
 import it.infn.mw.iam.core.oauth.exchange.TokenExchangePdpResult;
 import it.infn.mw.iam.core.oauth.exchange.TokenExchangePdpResult.Decision;
@@ -65,9 +66,14 @@ public class TokenExchangePdPTests extends TokenExchangePdpTestSupport {
   IamTokenExchangePolicyRepository repo;
 
   @Mock
+  IamProperties iamProperties;
+
+  @Mock
+  TokenExchangeProperties teProperties;
+
+  @Mock
   ScopeMatcherRegistry scopeMatchersRegistry;
 
-  @InjectMocks
   DefaultTokenExchangePdp pdp;
 
   private TokenRequest buildTokenRequest() {
@@ -87,6 +93,11 @@ public class TokenExchangePdPTests extends TokenExchangePdpTestSupport {
         .map(StringEqualsScopeMatcher::stringEqualsMatcher)
         .collect(toSet()));
     when(repo.findAll()).thenReturn(emptyList());
+    when(teProperties.getExpirePolicyCacheAfterSeconds()).thenReturn(60L);
+    when(iamProperties.getTokenExchange()).thenReturn(teProperties);
+
+    pdp = new DefaultTokenExchangePdp(iamProperties, repo, scopeMatchersRegistry);
+
   }
 
   @Test
@@ -239,6 +250,5 @@ public class TokenExchangePdPTests extends TokenExchangePdpTestSupport {
     assertThat(result.invalidScope().get(), is("s1"));
     assertThat(result.message().isPresent(), is (true));
     assertThat(result.message().get(), is("scope exchange not allowed by policy"));
-    
   }
 }


### PR DESCRIPTION
Token exchange in IAM is implemenented mainly to provide a mechanism to
allow controlled delegation of privileges across different client
applications. As such, with this commit we introduce a check that
forbids single client token exchanges.

This commit also introduces a token exchange policy cache mechanism that
should improve performance in token exchange at scale by limiting the
connections to the database.