### PR TITLE
WIP: Issue 391 show group labels in account home page

### DIFF
--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/groups/user.groups.component.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/groups/user.groups.component.html
@@ -29,13 +29,16 @@
                 <span ng-if="!$ctrl.isVoAdmin()">{{group.display}}</span>
             </div>
 
-            <div class="iam-user-group-labels col-xs-2 col-sm-2">
-                <div ng-repeat="label in $ctrl.userGroupLabels[group.value]">
-                {{label.name}}
+            <style type="text/css">div.allinea { float:left; margin-left: .5em; margin-top: 10px }</style> 
+            <div class="iam-user-group-labels col-xs-4 col-sm-4">
+                <div class="allinea" ng-repeat="label in $ctrl.userGroupLabels[group.value]">
+                    <span style="background-color:#bee1f4; padding: 4px 7.2px 4px 7.2px; font-size: 12px">
+                    <b><font color="#00659c">{{label.name}}</font></b>
+                    </span>
                 </div> 
             </div>
                 
-            <div class="iam-user-group-actions col-xs-4 col-sm-4 text-right">
+            <div class="iam-user-group-actions col-xs-2 col-sm-2 text-right">
                 <div class="btn-group">
                     <button class="btn btn-xs btn-danger" ng-click="$ctrl.openRemoveGroupDialog(group)" ng-if="$ctrl.isVoAdmin()">
                     <i class="fa fa-times"></i> Remove

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/groups/user.groups.component.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/groups/user.groups.component.html
@@ -24,10 +24,17 @@
     <div class="box-body">
         <div ng-if="!$ctrl.user.groups.length">No groups found</div>
         <div class="row iam-user-group-row" ng-repeat="group in $ctrl.user.groups | orderBy:'display' ">
-            <div class="iam-user-group-detail col-xs-8 col-sm-8">
+            <div class="iam-user-group-detail col-xs-6 col-sm-6">
                 <a ui-sref="group({id: group.value})" ng-if="$ctrl.isVoAdmin()">{{group.display}}</a>
                 <span ng-if="!$ctrl.isVoAdmin()">{{group.display}}</span>
             </div>
+
+            <div class="iam-user-group-labels col-xs-2 col-sm-2">
+                <div ng-repeat="label in $ctrl.userGroupLabels[group.value]">
+                {{label.name}}
+                </div> 
+            </div>
+                
             <div class="iam-user-group-actions col-xs-4 col-sm-4 text-right">
                 <div class="btn-group">
                     <button class="btn btn-xs btn-danger" ng-click="$ctrl.openRemoveGroupDialog(group)" ng-if="$ctrl.isVoAdmin()">

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/groups/user.groups.component.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/groups/user.groups.component.html
@@ -29,13 +29,33 @@
                 <span ng-if="!$ctrl.isVoAdmin()">{{group.display}}</span>
             </div>
 
+            <!--
             <style type="text/css">div.allinea { float:left; margin-left: .5em; margin-top: 10px }</style> 
             <div class="iam-user-group-labels col-xs-4 col-sm-4">
                 <div class="allinea" ng-repeat="label in $ctrl.userGroupLabels[group.value]">
-                    <span style="background-color:#bee1f4; padding: 4px 7.2px 4px 7.2px; font-size: 12px">
+                    <span style="background-color:#bee1f4; padding: 4px 7.2px 4px 7.2px; font-size: 12px" ng-if="!label.prefix">
                     <b><font color="#00659c">{{label.name}}</font></b>
                     </span>
+                    <span style="background-color:#bee1f4; padding: 4px 7.2px 4px 7.2px; font-size: 12px" ng-if="label.prefix">
+                        <b><font color="#00659c">{{label.prefix + "/" + label.name}}</font></b>
+                        </span>
+                    <span style="background-color:#7dc3e8; padding: 4px 7.2px 4px 7.2px; font-size: 12px" ng-if="label.value">
+                        <b><font color="#FFF">{{label.value}}</font></b>
+                    </span>
                 </div> 
+            </div>
+            -->
+
+            <!-- By using CSS classes -->
+            <div class="iam-user-group-labels col-xs-4 col-sm-4">
+                <span class="label-pair" ng-repeat="label in $ctrl.userGroupLabels[group.value]">
+                    <span class="label-key label">
+                        {{$ctrl.labelName(label)}}
+                    </span>
+                    <span class="label-value label" ng-if="label.value">
+                        {{label.value}}
+                    </span>
+                </span>        
             </div>
                 
             <div class="iam-user-group-actions col-xs-2 col-sm-2 text-right">

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/groups/user.groups.component.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/groups/user.groups.component.html
@@ -29,24 +29,6 @@
                 <span ng-if="!$ctrl.isVoAdmin()">{{group.display}}</span>
             </div>
 
-            <!--
-            <style type="text/css">div.allinea { float:left; margin-left: .5em; margin-top: 10px }</style> 
-            <div class="iam-user-group-labels col-xs-4 col-sm-4">
-                <div class="allinea" ng-repeat="label in $ctrl.userGroupLabels[group.value]">
-                    <span style="background-color:#bee1f4; padding: 4px 7.2px 4px 7.2px; font-size: 12px" ng-if="!label.prefix">
-                    <b><font color="#00659c">{{label.name}}</font></b>
-                    </span>
-                    <span style="background-color:#bee1f4; padding: 4px 7.2px 4px 7.2px; font-size: 12px" ng-if="label.prefix">
-                        <b><font color="#00659c">{{label.prefix + "/" + label.name}}</font></b>
-                        </span>
-                    <span style="background-color:#7dc3e8; padding: 4px 7.2px 4px 7.2px; font-size: 12px" ng-if="label.value">
-                        <b><font color="#FFF">{{label.value}}</font></b>
-                    </span>
-                </div> 
-            </div>
-            -->
-
-            <!-- By using CSS classes -->
             <div class="iam-user-group-labels col-xs-4 col-sm-4">
                 <span class="label-pair" ng-repeat="label in $ctrl.userGroupLabels[group.value]">
                     <span class="label-key label">

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/groups/user.groups.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/groups/user.groups.component.js
@@ -45,8 +45,6 @@
                 });
             });
         };
-
-        // By knowing the group id and by calling the appropriate service I can recover group labels
         
         self.groupLabels = function(groupId){
             

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/groups/user.groups.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/groups/user.groups.component.js
@@ -22,7 +22,6 @@
         self.$onInit = function() {
             console.log('UserGroupsController onInit');
             self.enabled = true;
-
             self.userGroupLabels = {};
 
             angular.forEach(self.user.groups, function(g){
@@ -46,11 +45,11 @@
             });
         };
 
-        // conoscendo l'id di un gruppo vado dal servizio e mi faccio dare le etichette
+        // Knowing the group id I recover its labels calling the appropriate service
         
         self.groupLabels = function(groupId){
             
-                return scimFactory.getGroup(groupId).then(function(res){     //'then' chiamata asincrona --> non termina
+                return scimFactory.getGroup(groupId).then(function(res){     
                    var r = res.data;
                    var labels = r['urn:indigo-dc:scim:schemas:IndigoGroup'].labels;
                    return labels;

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/groups/user.groups.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/groups/user.groups.component.js
@@ -22,7 +22,17 @@
         self.$onInit = function() {
             console.log('UserGroupsController onInit');
             self.enabled = true;
-        };
+
+            self.userGroupLabels = {};
+
+            angular.forEach(self.user.groups, function(g){
+                var gl = [];
+                self.groupLabels(g.value).then(function(res){
+                    gl = res;
+                    self.userGroupLabels[g.value] = gl;
+                });
+            });  
+    };
 
         self.isVoAdmin = function() { return self.userCtrl.isVoAdmin(); };
 
@@ -36,6 +46,17 @@
             });
         };
 
+        // conoscendo l'id di un gruppo vado dal servizio e mi faccio dare le etichette
+        
+        self.groupLabels = function(groupId){
+            
+                return scimFactory.getGroup(groupId).then(function(res){     //'then' chiamata asincrona --> non termina
+                   var r = res.data;
+                   var labels = r['urn:indigo-dc:scim:schemas:IndigoGroup'].labels;
+                   return labels;
+            });
+        };
+        
         self.openAddGroupDialog = function() {
             var modalInstance = $uibModal.open({
                 templateUrl: '/resources/iam/apps/dashboard-app/templates/user/addusergroup.html',

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/groups/user.groups.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/groups/user.groups.component.js
@@ -23,6 +23,7 @@
             console.log('UserGroupsController onInit');
             self.enabled = true;
             self.userGroupLabels = {};
+            self.labelName = labelName;
 
             angular.forEach(self.user.groups, function(g){
                 var gl = [];
@@ -45,7 +46,7 @@
             });
         };
 
-        // Knowing the group id I recover its labels calling the appropriate service
+        // By knowing the group id and by calling the appropriate service I can recover group labels
         
         self.groupLabels = function(groupId){
             
@@ -55,6 +56,13 @@
                    return labels;
             });
         };
+
+        function labelName(label) {
+            if (label.prefix) {
+                return label.prefix + "/" + label.name;
+            }
+            return label.name;
+        }
         
         self.openAddGroupDialog = function() {
             var modalInstance = $uibModal.open({

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/groups/user.groups.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/groups/user.groups.component.js
@@ -26,10 +26,8 @@
             self.labelName = labelName;
 
             angular.forEach(self.user.groups, function(g){
-                var gl = [];
                 self.groupLabels(g.value).then(function(res){
-                    gl = res;
-                    self.userGroupLabels[g.value] = gl;
+                    self.userGroupLabels[g.value] = res;
                 });
             });  
     };


### PR DESCRIPTION
To show group labels in account home page, I modified two files:

**user.groups.components.js**:
I added a _groupLabels_ function that takes as input the group id and returns the labels, through the _scimFactory_ service. Then I created and populated a _userGroupLabels_ vector with the recovered labels.

**user.groups.components.html**:
I looped over the _userGroupLabels_  vector and displayed the name, prefix (if any) and value (if any) of each label per group, by using the CSS classes. These allow to reproduce the style of the labels on the group list page.