### PR TITLE
Forbid same-client token exchange requesting offline_access scope

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/exchange_policy/DefaultTokenExchangePolicyService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/exchange_policy/DefaultTokenExchangePolicyService.java
@@ -32,7 +32,7 @@ import it.infn.mw.iam.persistence.repository.IamTokenExchangePolicyRepository;
 
 @Service
 @Transactional
-public class DefaultExchangePolicyService implements TokenExchangePolicyService {
+public class DefaultTokenExchangePolicyService implements TokenExchangePolicyService {
 
   private final IamTokenExchangePolicyRepository repo;
   private final ExchangePolicyConverter converter;
@@ -40,7 +40,7 @@ public class DefaultExchangePolicyService implements TokenExchangePolicyService 
   private final TokenExchangePdp pdp;
 
   @Autowired
-  public DefaultExchangePolicyService(IamTokenExchangePolicyRepository repo,
+  public DefaultTokenExchangePolicyService(IamTokenExchangePolicyRepository repo,
       ExchangePolicyConverter converter, Clock clock, TokenExchangePdp pdp) {
     this.repo = repo;
     this.converter = converter;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/granters/TokenExchangeTokenGranter.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/granters/TokenExchangeTokenGranter.java
@@ -57,6 +57,7 @@ public class TokenExchangeTokenGranter extends AbstractTokenGranter {
       "urn:ietf:params:oauth:grant-type:token-exchange";
   private static final String TOKEN_TYPE = "urn:ietf:params:oauth:token-type:jwt";
   private static final String AUDIENCE_FIELD = "audience";
+  private static final String OFFLINE_ACCESS_SCOPE = "offline_access";
 
   private final OAuth2TokenEntityService tokenServices;
 
@@ -98,6 +99,11 @@ public class TokenExchangeTokenGranter extends AbstractTokenGranter {
       LOG.info(
           "Client '{}' requests token exchange from client '{}' on audience '{}' with scopes '{}'",
           actorClient.getClientId(), subjectClient.getClientId(), audience, requestedScopes);
+    }
+
+    if (subjectClient.equals(actorClient) && requestedScopes.contains(OFFLINE_ACCESS_SCOPE)) {
+      throw new OAuth2AccessDeniedException(
+          "Token exchange not allowed: the actor and the subject are the same client and offline_access is in the requested scopes");
     }
 
     TokenExchangePdpResult result =

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/WLCGProfileIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/WLCGProfileIntegrationTests.java
@@ -465,6 +465,8 @@ public class WLCGProfileIntegrationTests extends EndpointsTestUtils {
       .audience(ACTOR_CLIENT_ID)
       .getAccessTokenValue();
 
+    // Exchange the token to client 'token-exchange-actor', reduce a bit the scopes
+    // but request a refresh token
     String tokenResponse =
         mvc
           .perform(post("/token").with(httpBasic(ACTOR_CLIENT_ID, ACTOR_CLIENT_SECRET))
@@ -501,25 +503,24 @@ public class WLCGProfileIntegrationTests extends EndpointsTestUtils {
       .andExpect(status().isOk())
       .andExpect(jsonPath("$.active", equalTo(true)));
 
-    tokenResponse =
-        mvc
-          .perform(post("/token").with(httpBasic(ACTOR_CLIENT_ID, ACTOR_CLIENT_SECRET))
-            .param("grant_type", TOKEN_EXCHANGE_GRANT_TYPE)
-            .param("subject_token", tokenResponseObject.getValue())
-            .param("subject_token_type", "urn:ietf:params:oauth:token-type:jwt")
-            .param("scope",
-                "storage.read:/subpath storage.write:/subpath/test openid offline_access")
-            .param("audience", "se4.example"))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$.access_token").exists())
-          .andExpect(jsonPath("$.refresh_token").exists())
-          .andExpect(jsonPath("$.scope",
-              allOf(containsString("storage.read:/subpath "), containsString("offline_access"),
-                  containsString("storage.write:/subpath/test"), containsString("openid"),
-                  containsString("offline_access"))))
-          .andReturn()
-          .getResponse()
-          .getContentAsString();
+    // Check that the token can be further exchange by the same actor client
+    // without the offline_access scope
+    tokenResponse = mvc
+      .perform(post("/token").with(httpBasic(ACTOR_CLIENT_ID, ACTOR_CLIENT_SECRET))
+        .param("grant_type", TOKEN_EXCHANGE_GRANT_TYPE)
+        .param("subject_token", tokenResponseObject.getValue())
+        .param("subject_token_type", "urn:ietf:params:oauth:token-type:jwt")
+        .param("scope", "storage.read:/subpath storage.write:/subpath/test openid")
+        .param("audience", "se4.example"))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.access_token").exists())
+      .andExpect(jsonPath("$.refresh_token").doesNotExist())
+      .andExpect(jsonPath("$.scope",
+          allOf(containsString("storage.read:/subpath "),
+              containsString("storage.write:/subpath/test"), containsString("openid"))))
+      .andReturn()
+      .getResponse()
+      .getContentAsString();
 
     DefaultOAuth2AccessToken tokenResponseObject2 =
         mapper.readValue(tokenResponse, DefaultOAuth2AccessToken.class);


### PR DESCRIPTION
Token exchange in IAM is implemenented mainly to provide a mechanism to
allow controlled delegation of privileges across different client
applications.

There are however clients (e.g., htgettoken) that leverage the token
exchange grant to implement token attenuation.

With this commit we introduce a check to forbid requesting the
offline_access scope in a single-client token exchange, as that kind of
request could be used to extend indefinetely the lifetime of an
exchanged refresh token.