### PR TITLE
Add compose file for linux users

### DIFF
--- a/compose/nginx-local-dev/docker-compose_linux.yml
+++ b/compose/nginx-local-dev/docker-compose_linux.yml
@@ -1,0 +1,38 @@
+version: '3'
+
+volumes:
+  trustanchors:
+  cabundle:
+
+services:
+
+  trust:
+    image: indigoiam/trustanchors
+    volumes:
+      - trustanchors:/etc/grid-security/certificates
+      - cabundle:/etc/pki
+
+  iam:
+    image: indigoiam/nginx
+    dns_search: local.io
+    container_name: iam
+
+    environment:
+      TZ: Europe/Rome
+      NGINX_HOST: iam
+      NGINX_PORT: 443
+
+    ports:
+      - "443:443"
+
+    volumes:
+      - /dev/urandom:/dev/random
+      - ./assets/iam.conf:/etc/nginx/conf.d/default.conf:ro
+
+    networks:
+      default:
+        aliases:
+          - iam.local.io
+
+    extra_hosts:
+    - "host.docker.internal:host-gateway"


### PR DESCRIPTION
which maps host.docker.internal into host-gateway.

It prevents 'host not found in upstream "host.docker.internal" in /etc/nginx/conf.d/default.conf:24' error in linux OS.
Solution for this error found [here](https://stackoverflow.com/questions/48546124/what-is-linux-equivalent-of-host-docker-internal/61001152)