### PR TITLE
Add Cache-Control to /jwk endpoint

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/web/jwk/IamJWKSetPublishingEndpoint.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/web/jwk/IamJWKSetPublishingEndpoint.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import org.mitre.jwt.signer.service.JWTSigningAndValidationService;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.CacheControl;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -43,11 +44,14 @@ public class IamJWKSetPublishingEndpoint implements InitializingBean {
 
   @Autowired
   private IamJWTSigningService jwtService;
+  
+  @Value("${spring.web.resources.cache.cachecontrol.max-age}")
+  private int maxAge;
 
   @GetMapping(value = "/" + URL, produces = MediaType.APPLICATION_JSON_VALUE)
   @ResponseBody
   public ResponseEntity<String> getJwk() {
-    return ResponseEntity.ok().cacheControl(CacheControl.maxAge(6, TimeUnit.HOURS).noTransform().mustRevalidate()).body(jsonKeys);
+    return ResponseEntity.ok().cacheControl(CacheControl.maxAge(maxAge, TimeUnit.SECONDS).noTransform().mustRevalidate()).body(jsonKeys);
   }
 
   /**

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/web/jwk/IamJWKSetPublishingEndpoint.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/web/jwk/IamJWKSetPublishingEndpoint.java
@@ -17,16 +17,22 @@ package it.infn.mw.iam.core.web.jwk;
 
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.mitre.jwt.signer.service.JWTSigningAndValidationService;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.CacheControl;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
+
+import it.infn.mw.iam.core.jwk.IamJWTSigningService;
 
 @RestController
 public class IamJWKSetPublishingEndpoint implements InitializingBean {
@@ -36,12 +42,12 @@ public class IamJWKSetPublishingEndpoint implements InitializingBean {
   private String jsonKeys;
 
   @Autowired
-  private JWTSigningAndValidationService jwtService;
+  private IamJWTSigningService jwtService;
 
   @GetMapping(value = "/" + URL, produces = MediaType.APPLICATION_JSON_VALUE)
-  public String getJwk() {
-
-    return jsonKeys;
+  @ResponseBody
+  public ResponseEntity<String> getJwk() {
+    return ResponseEntity.ok().cacheControl(CacheControl.maxAge(6, TimeUnit.HOURS).noTransform().mustRevalidate()).body(jsonKeys);
   }
 
   /**
@@ -54,7 +60,7 @@ public class IamJWKSetPublishingEndpoint implements InitializingBean {
   /**
    * @param jwtService the jwtService to set
    */
-  public void setJwtService(JWTSigningAndValidationService jwtService) {
+  public void setJwtService(IamJWTSigningService jwtService) {
     this.jwtService = jwtService;
   }
 

--- a/iam-login-service/src/main/resources/application.yml
+++ b/iam-login-service/src/main/resources/application.yml
@@ -81,7 +81,12 @@ spring:
 
   main:
     allow-circular-references: true
-
+    
+  web:
+    resources:
+      cache:
+        cachecontrol:
+          max-age: ${IAM_JWK_CACHE_LIFETIME:21600}
 iam:
   
   host: ${IAM_HOST:localhost}


### PR DESCRIPTION
Response Headers:
```
Cache-Control: max-age=21600, must-revalidate, no-transform
Connection: keep-alive
Content-Length: 397
Content-Type: application/json
Date: Thu, 21 Apr 2022 12:43:33 GMT
Keep-Alive: timeout=60
Vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-XSS-Protection: 1; mode=block
```

Request Headers:
```
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8
Accept-Encoding: gzip, deflate, br
Accept-Language: en-US,en;q=0.5
Connection: keep-alive
Host: localhost:8080
Sec-Fetch-Dest: document
Sec-Fetch-Mode: navigate
Sec-Fetch-Site: none
Sec-Fetch-User: ?1
Upgrade-Insecure-Requests: 1
User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:99.0) Gecko/20100101 Firefox/99.0
```
