### PR TITLE
Introduce new admin scopes in order to access IAM API endpoints

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/attributes/AccountAttributesController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/attributes/AccountAttributesController.java
@@ -72,7 +72,7 @@ public class AccountAttributesController {
   }
 
   @RequestMapping(value = "/iam/account/{id}/attributes", method = RequestMethod.GET)
-  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.isUser(#id) or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.isUser(#id) or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM')")
   public List<AttributeDTO> getAttributes(@PathVariable String id) {
 
     IamAccount account =
@@ -85,7 +85,7 @@ public class AccountAttributesController {
   }
 
   @RequestMapping(value = "/iam/account/{id}/attributes", method = PUT)
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void setAttribute(@PathVariable String id, @RequestBody @Validated AttributeDTO attribute,
       final BindingResult validationResult) {
 
@@ -99,7 +99,7 @@ public class AccountAttributesController {
   }
 
   @RequestMapping(value = "/iam/account/{id}/attributes", method = DELETE)
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @ResponseStatus(value = NO_CONTENT)
   public void deleteAttribute(@PathVariable String id, @Validated AttributeDTO attribute,
       final BindingResult validationResult) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/attributes/AccountAttributesController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/attributes/AccountAttributesController.java
@@ -85,7 +85,7 @@ public class AccountAttributesController {
   }
 
   @RequestMapping(value = "/iam/account/{id}/attributes", method= PUT)
-  @PreAuthorize("hasRole('ADMIN')")
+  @PreAuthorize("(hasRole('ADMIN') and #oauth2.hasScope('account:write')) or #iam.isAdmin()")
   public void setAttribute(@PathVariable String id, @RequestBody @Validated AttributeDTO attribute,
       final BindingResult validationResult) {
 
@@ -99,7 +99,7 @@ public class AccountAttributesController {
   }
   
   @RequestMapping(value = "/iam/account/{id}/attributes", method= DELETE)
-  @PreAuthorize("hasRole('ADMIN')")
+  @PreAuthorize("(hasRole('ADMIN') and #oauth2.hasScope('account:write')) or #iam.isAdmin()")
   @ResponseStatus(value = NO_CONTENT)
   public void deleteAttribute(@PathVariable String id, @Validated AttributeDTO attribute,
       final BindingResult validationResult) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/attributes/AccountAttributesController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/attributes/AccountAttributesController.java
@@ -72,7 +72,7 @@ public class AccountAttributesController {
   }
 
   @RequestMapping(value = "/iam/account/{id}/attributes", method=RequestMethod.GET)
-  @PreAuthorize("hasRole('ADMIN') or #iam.isUser(#id) or #iam.isAGroupManager()")
+  @PreAuthorize("hasRole('ADMIN') or #iam.isUser(#id) or #iam.isGroupManager()")
   public List<AttributeDTO> getAttributes(@PathVariable String id) {
 
     IamAccount account =

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/attributes/AccountAttributesController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/attributes/AccountAttributesController.java
@@ -72,7 +72,7 @@ public class AccountAttributesController {
   }
 
   @RequestMapping(value = "/iam/account/{id}/attributes", method = RequestMethod.GET)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.isUser(#id) or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.isUser(#id) or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM')")
   public List<AttributeDTO> getAttributes(@PathVariable String id) {
 
     IamAccount account =
@@ -85,7 +85,7 @@ public class AccountAttributesController {
   }
 
   @RequestMapping(value = "/iam/account/{id}/attributes", method = PUT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void setAttribute(@PathVariable String id, @RequestBody @Validated AttributeDTO attribute,
       final BindingResult validationResult) {
 
@@ -99,7 +99,7 @@ public class AccountAttributesController {
   }
 
   @RequestMapping(value = "/iam/account/{id}/attributes", method = DELETE)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @ResponseStatus(value = NO_CONTENT)
   public void deleteAttribute(@PathVariable String id, @Validated AttributeDTO attribute,
       final BindingResult validationResult) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/attributes/AccountAttributesController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/attributes/AccountAttributesController.java
@@ -63,7 +63,7 @@ public class AccountAttributesController {
     this.converter = converter;
     this.accountService = accountService;
   }
-  
+
   private void handleValidationError(BindingResult result) {
     if (result.hasErrors()) {
       throw new InvalidAttributeError(
@@ -71,8 +71,8 @@ public class AccountAttributesController {
     }
   }
 
-  @RequestMapping(value = "/iam/account/{id}/attributes", method=RequestMethod.GET)
-  @PreAuthorize("hasRole('ADMIN') or #iam.isUser(#id) or #iam.isGroupManager()")
+  @RequestMapping(value = "/iam/account/{id}/attributes", method = RequestMethod.GET)
+  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.isUser(#id) or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM')")
   public List<AttributeDTO> getAttributes(@PathVariable String id) {
 
     IamAccount account =
@@ -84,46 +84,46 @@ public class AccountAttributesController {
     return results;
   }
 
-  @RequestMapping(value = "/iam/account/{id}/attributes", method= PUT)
-  @PreAuthorize("(hasRole('ADMIN') and #oauth2.hasScope('account:write')) or #iam.isAdmin()")
+  @RequestMapping(value = "/iam/account/{id}/attributes", method = PUT)
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void setAttribute(@PathVariable String id, @RequestBody @Validated AttributeDTO attribute,
       final BindingResult validationResult) {
 
     handleValidationError(validationResult);
     IamAccount account =
         accountService.findByUuid(id).orElseThrow(() -> NoSuchAccountError.forUuid(id));
-    
+
     IamAttribute attr = converter.entityFromDto(attribute);
-    
+
     accountService.setAttribute(account, attr);
   }
-  
-  @RequestMapping(value = "/iam/account/{id}/attributes", method= DELETE)
-  @PreAuthorize("(hasRole('ADMIN') and #oauth2.hasScope('account:write')) or #iam.isAdmin()")
+
+  @RequestMapping(value = "/iam/account/{id}/attributes", method = DELETE)
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @ResponseStatus(value = NO_CONTENT)
   public void deleteAttribute(@PathVariable String id, @Validated AttributeDTO attribute,
       final BindingResult validationResult) {
-    
+
     handleValidationError(validationResult);
     IamAccount account =
         accountService.findByUuid(id).orElseThrow(() -> NoSuchAccountError.forUuid(id));
     IamAttribute attr = converter.entityFromDto(attribute);
-    
+
     accountService.deleteAttribute(account, attr);
   }
 
   @ResponseStatus(code = HttpStatus.BAD_REQUEST)
   @ExceptionHandler(InvalidAttributeError.class)
   @ResponseBody
-  public ErrorDTO handleValidationError(InvalidAttributeError e) {    
+  public ErrorDTO handleValidationError(InvalidAttributeError e) {
     return ErrorDTO.fromString(e.getMessage());
   }
-  
+
   @ResponseStatus(code = HttpStatus.NOT_FOUND)
   @ExceptionHandler(NoSuchAccountError.class)
   @ResponseBody
-  public ErrorDTO handleNoSuchAccountError(NoSuchAccountError e) {    
+  public ErrorDTO handleNoSuchAccountError(NoSuchAccountError e) {
     return ErrorDTO.fromString(e.getMessage());
   }
-  
+
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/authority/AccountAuthorityController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/authority/AccountAuthorityController.java
@@ -75,7 +75,7 @@ public class AccountAuthorityController {
       .fromAuthorities(authorityService.getAccountAuthorities(findAccountByName(authn.getName())));
   }
 
-  @PreAuthorize("hasRole('ADMIN') or #iam.isAGroupManager()")
+  @PreAuthorize("hasRole('ADMIN') or #iam.isGroupManager()")
   @RequestMapping(value = "/account/{id}/authorities", method = RequestMethod.GET)
   @ResponseBody
   public AuthoritySetDTO getAuthoritiesForAccount(@PathVariable("id") String id) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/authority/AccountAuthorityController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/authority/AccountAuthorityController.java
@@ -68,14 +68,14 @@ public class AccountAuthorityController {
       .orElseThrow(() -> new NoSuchAccountError(format("No account found for name '%s'", name)));
   }
 
-  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_USER')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_USER')")
   @RequestMapping(value = "/me/authorities", method = RequestMethod.GET)
   public AuthoritySetDTO getAuthoritiesForMe(Authentication authn) {
     return AuthoritySetDTO
       .fromAuthorities(authorityService.getAccountAuthorities(findAccountByName(authn.getName())));
   }
 
-  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM')")
   @RequestMapping(value = "/account/{id}/authorities", method = RequestMethod.GET)
   @ResponseBody
   public AuthoritySetDTO getAuthoritiesForAccount(@PathVariable("id") String id) {
@@ -83,7 +83,7 @@ public class AccountAuthorityController {
       .fromAuthorities(authorityService.getAccountAuthorities(findAccountById(id)));
   }
 
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @RequestMapping(value = "/account/{id}/authorities", method = RequestMethod.POST)
   public void addAuthorityToAccount(@PathVariable("id") String id, @Valid AuthorityDTO authority,
       BindingResult validationResult) {
@@ -96,7 +96,7 @@ public class AccountAuthorityController {
 
   }
 
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @RequestMapping(value = "/account/{id}/authorities", method = RequestMethod.DELETE)
   public void removeAuthorityFromAccount(@PathVariable("id") String id,
       @Valid AuthorityDTO authority, BindingResult validationResult) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/authority/AccountAuthorityController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/authority/AccountAuthorityController.java
@@ -68,14 +68,14 @@ public class AccountAuthorityController {
       .orElseThrow(() -> new NoSuchAccountError(format("No account found for name '%s'", name)));
   }
 
-  @PreAuthorize("hasRole('USER')")
+  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_USER')")
   @RequestMapping(value = "/me/authorities", method = RequestMethod.GET)
   public AuthoritySetDTO getAuthoritiesForMe(Authentication authn) {
     return AuthoritySetDTO
       .fromAuthorities(authorityService.getAccountAuthorities(findAccountByName(authn.getName())));
   }
 
-  @PreAuthorize("hasRole('ADMIN') or #iam.isGroupManager()")
+  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM')")
   @RequestMapping(value = "/account/{id}/authorities", method = RequestMethod.GET)
   @ResponseBody
   public AuthoritySetDTO getAuthoritiesForAccount(@PathVariable("id") String id) {
@@ -83,7 +83,7 @@ public class AccountAuthorityController {
       .fromAuthorities(authorityService.getAccountAuthorities(findAccountById(id)));
   }
 
-  @PreAuthorize("(hasRole('ADMIN') and #oauth2.hasScope('account:write')) or #iam.isAdmin()")
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @RequestMapping(value = "/account/{id}/authorities", method = RequestMethod.POST)
   public void addAuthorityToAccount(@PathVariable("id") String id, @Valid AuthorityDTO authority,
       BindingResult validationResult) {
@@ -96,7 +96,7 @@ public class AccountAuthorityController {
 
   }
 
-  @PreAuthorize("(hasRole('ADMIN') and #oauth2.hasScope('account:write')) or #iam.isAdmin()")
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @RequestMapping(value = "/account/{id}/authorities", method = RequestMethod.DELETE)
   public void removeAuthorityFromAccount(@PathVariable("id") String id,
       @Valid AuthorityDTO authority, BindingResult validationResult) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/authority/AccountAuthorityController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/authority/AccountAuthorityController.java
@@ -68,14 +68,14 @@ public class AccountAuthorityController {
       .orElseThrow(() -> new NoSuchAccountError(format("No account found for name '%s'", name)));
   }
 
-  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_USER')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_USER')")
   @RequestMapping(value = "/me/authorities", method = RequestMethod.GET)
   public AuthoritySetDTO getAuthoritiesForMe(Authentication authn) {
     return AuthoritySetDTO
       .fromAuthorities(authorityService.getAccountAuthorities(findAccountByName(authn.getName())));
   }
 
-  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM')")
   @RequestMapping(value = "/account/{id}/authorities", method = RequestMethod.GET)
   @ResponseBody
   public AuthoritySetDTO getAuthoritiesForAccount(@PathVariable("id") String id) {
@@ -83,7 +83,7 @@ public class AccountAuthorityController {
       .fromAuthorities(authorityService.getAccountAuthorities(findAccountById(id)));
   }
 
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @RequestMapping(value = "/account/{id}/authorities", method = RequestMethod.POST)
   public void addAuthorityToAccount(@PathVariable("id") String id, @Valid AuthorityDTO authority,
       BindingResult validationResult) {
@@ -96,7 +96,7 @@ public class AccountAuthorityController {
 
   }
 
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @RequestMapping(value = "/account/{id}/authorities", method = RequestMethod.DELETE)
   public void removeAuthorityFromAccount(@PathVariable("id") String id,
       @Valid AuthorityDTO authority, BindingResult validationResult) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/authority/AccountAuthorityController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/authority/AccountAuthorityController.java
@@ -83,7 +83,7 @@ public class AccountAuthorityController {
       .fromAuthorities(authorityService.getAccountAuthorities(findAccountById(id)));
   }
 
-  @PreAuthorize("hasRole('ADMIN')")
+  @PreAuthorize("(hasRole('ADMIN') and #oauth2.hasScope('account:write')) or #iam.isAdmin()")
   @RequestMapping(value = "/account/{id}/authorities", method = RequestMethod.POST)
   public void addAuthorityToAccount(@PathVariable("id") String id, @Valid AuthorityDTO authority,
       BindingResult validationResult) {
@@ -96,7 +96,7 @@ public class AccountAuthorityController {
 
   }
 
-  @PreAuthorize("hasRole('ADMIN')")
+  @PreAuthorize("(hasRole('ADMIN') and #oauth2.hasScope('account:write')) or #iam.isAdmin()")
   @RequestMapping(value = "/account/{id}/authorities", method = RequestMethod.DELETE)
   public void removeAuthorityFromAccount(@PathVariable("id") String id,
       @Valid AuthorityDTO authority, BindingResult validationResult) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/client/AccountClientController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/client/AccountClientController.java
@@ -49,8 +49,8 @@ public class AccountClientController {
 
   @JsonView(ClientViews.Limited.class)
   @GetMapping("/iam/account/me/clients")
-  public ListResponseDTO<RegisteredClientDTO> getOwnedClients(
-      @Validated PaginatedRequestForm form, final BindingResult validationResult) {
+  public ListResponseDTO<RegisteredClientDTO> getOwnedClients(@Validated PaginatedRequestForm form,
+      final BindingResult validationResult) {
 
     handleValidationError(INVALID_PAGINATION_REQUEST, validationResult);
     return clientSearchService.findOwnedClients(form);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/find/FindAccountController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/find/FindAccountController.java
@@ -36,7 +36,7 @@ import it.infn.mw.iam.api.scim.model.ScimConstants;
 import it.infn.mw.iam.api.scim.model.ScimUser;
 
 @RestController
-@PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+@PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
 public class FindAccountController {
 
   public static final String INVALID_FIND_ACCOUNT_REQUEST = "Invalid find account request";

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/find/FindAccountController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/find/FindAccountController.java
@@ -36,7 +36,7 @@ import it.infn.mw.iam.api.scim.model.ScimConstants;
 import it.infn.mw.iam.api.scim.model.ScimUser;
 
 @RestController
-@PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+@PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
 public class FindAccountController {
 
   public static final String INVALID_FIND_ACCOUNT_REQUEST = "Invalid find account request";

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/find/FindAccountController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/find/FindAccountController.java
@@ -36,7 +36,7 @@ import it.infn.mw.iam.api.scim.model.ScimConstants;
 import it.infn.mw.iam.api.scim.model.ScimUser;
 
 @RestController
-@PreAuthorize("hasRole('ADMIN')")
+@PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
 public class FindAccountController {
 
   public static final String INVALID_FIND_ACCOUNT_REQUEST = "Invalid find account request";

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/group/AccountGroupController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/group/AccountGroupController.java
@@ -57,7 +57,7 @@ public class AccountGroupController {
 
   @RequestMapping(value = "/iam/account/{accountUuid}/groups/{groupUuid}", method = POST)
   @ResponseStatus(value = HttpStatus.CREATED)
-  @PreAuthorize("#iam.hasAdminOrGMDashboardRoleOfGroup(#groupUuid) or #oauth2.hasScope('iam:admin:write')")
+  @PreAuthorize("#iam.hasAdminOrGMDashboardRoleOfGroup(#groupUuid) or #oauth2.hasScope('iam:admin.write')")
   public void addAccountToGroup(@PathVariable String accountUuid, @PathVariable String groupUuid) {
     IamGroup group = groupService.findByUuid(groupUuid).orElseThrow(noSuchGroup(groupUuid));
 
@@ -75,7 +75,7 @@ public class AccountGroupController {
 
   @RequestMapping(value = "/iam/account/{accountUuid}/groups/{groupUuid}", method = DELETE)
   @ResponseStatus(value = HttpStatus.NO_CONTENT)
-  @PreAuthorize("#iam.hasAdminOrGMDashboardRoleOfGroup(#groupUuid) or #oauth2.hasScope('iam:admin:write')")
+  @PreAuthorize("#iam.hasAdminOrGMDashboardRoleOfGroup(#groupUuid) or #oauth2.hasScope('iam:admin.write')")
   public void removeAccountFromGroup(@PathVariable String accountUuid,
       @PathVariable String groupUuid) {
     IamGroup group = groupService.findByUuid(groupUuid).orElseThrow(noSuchGroup(groupUuid));

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/group/AccountGroupController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/group/AccountGroupController.java
@@ -57,7 +57,7 @@ public class AccountGroupController {
 
   @RequestMapping(value = "/iam/account/{accountUuid}/groups/{groupUuid}", method = POST)
   @ResponseStatus(value = HttpStatus.CREATED)
-  @PreAuthorize("hasRole('ADMIN') or #iam.isGroupManager(#groupUuid)")
+  @PreAuthorize("#iam.isAdminOrGMOfGroup(#groupUuid) or (!#iam.isAdminOrGMOfGroup(#groupUuid) and #oauth2.hasScope('account:write'))")
   public void addAccountToGroup(@PathVariable String accountUuid, @PathVariable String groupUuid) {
     IamGroup group = groupService.findByUuid(groupUuid).orElseThrow(noSuchGroup(groupUuid));
 
@@ -75,7 +75,7 @@ public class AccountGroupController {
 
   @RequestMapping(value = "/iam/account/{accountUuid}/groups/{groupUuid}", method = DELETE)
   @ResponseStatus(value = HttpStatus.NO_CONTENT)
-  @PreAuthorize("hasRole('ADMIN') or #iam.isGroupManager(#groupUuid)")
+  @PreAuthorize("#iam.isAdminOrGMOfGroup(#groupUuid) or (!#iam.isAdminOrGMOfGroup(#groupUuid) and #oauth2.hasScope('account:write'))")
   public void removeAccountFromGroup(@PathVariable String accountUuid,
       @PathVariable String groupUuid) {
     IamGroup group = groupService.findByUuid(groupUuid).orElseThrow(noSuchGroup(groupUuid));

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/group/AccountGroupController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/group/AccountGroupController.java
@@ -57,7 +57,7 @@ public class AccountGroupController {
 
   @RequestMapping(value = "/iam/account/{accountUuid}/groups/{groupUuid}", method = POST)
   @ResponseStatus(value = HttpStatus.CREATED)
-  @PreAuthorize("#iam.hasAdminOrGMDashboardRoleOfGroup(#groupUuid) or #oauth2.hasScope('admin:write')")
+  @PreAuthorize("#iam.hasAdminOrGMDashboardRoleOfGroup(#groupUuid) or #oauth2.hasScope('iam:admin:write')")
   public void addAccountToGroup(@PathVariable String accountUuid, @PathVariable String groupUuid) {
     IamGroup group = groupService.findByUuid(groupUuid).orElseThrow(noSuchGroup(groupUuid));
 
@@ -75,7 +75,7 @@ public class AccountGroupController {
 
   @RequestMapping(value = "/iam/account/{accountUuid}/groups/{groupUuid}", method = DELETE)
   @ResponseStatus(value = HttpStatus.NO_CONTENT)
-  @PreAuthorize("#iam.hasAdminOrGMDashboardRoleOfGroup(#groupUuid) or #oauth2.hasScope('admin:write')")
+  @PreAuthorize("#iam.hasAdminOrGMDashboardRoleOfGroup(#groupUuid) or #oauth2.hasScope('iam:admin:write')")
   public void removeAccountFromGroup(@PathVariable String accountUuid,
       @PathVariable String groupUuid) {
     IamGroup group = groupService.findByUuid(groupUuid).orElseThrow(noSuchGroup(groupUuid));

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/group/AccountGroupController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/group/AccountGroupController.java
@@ -57,7 +57,7 @@ public class AccountGroupController {
 
   @RequestMapping(value = "/iam/account/{accountUuid}/groups/{groupUuid}", method = POST)
   @ResponseStatus(value = HttpStatus.CREATED)
-  @PreAuthorize("#iam.isAdminOrGMOfGroup(#groupUuid) or ((hasRole('ADMIN') or #iam.isGMOfGroup(#groupUuid)) and #oauth2.hasScope('account:write'))")
+  @PreAuthorize("#iam.hasAdminOrGMDashboardRoleOfGroup(#groupUuid) or #oauth2.hasScope('admin:write')")
   public void addAccountToGroup(@PathVariable String accountUuid, @PathVariable String groupUuid) {
     IamGroup group = groupService.findByUuid(groupUuid).orElseThrow(noSuchGroup(groupUuid));
 
@@ -75,7 +75,7 @@ public class AccountGroupController {
 
   @RequestMapping(value = "/iam/account/{accountUuid}/groups/{groupUuid}", method = DELETE)
   @ResponseStatus(value = HttpStatus.NO_CONTENT)
-  @PreAuthorize("#iam.isAdminOrGMOfGroup(#groupUuid) or ((hasRole('ADMIN') or #iam.isGMOfGroup(#groupUuid)) and #oauth2.hasScope('account:write'))")
+  @PreAuthorize("#iam.hasAdminOrGMDashboardRoleOfGroup(#groupUuid) or #oauth2.hasScope('admin:write')")
   public void removeAccountFromGroup(@PathVariable String accountUuid,
       @PathVariable String groupUuid) {
     IamGroup group = groupService.findByUuid(groupUuid).orElseThrow(noSuchGroup(groupUuid));

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/group/AccountGroupController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/group/AccountGroupController.java
@@ -57,7 +57,7 @@ public class AccountGroupController {
 
   @RequestMapping(value = "/iam/account/{accountUuid}/groups/{groupUuid}", method = POST)
   @ResponseStatus(value = HttpStatus.CREATED)
-  @PreAuthorize("#iam.isAdminOrGMOfGroup(#groupUuid) or (!#iam.isAdminOrGMOfGroup(#groupUuid) and #oauth2.hasScope('account:write'))")
+  @PreAuthorize("#iam.isAdminOrGMOfGroup(#groupUuid) or ((hasRole('ADMIN') or #iam.isGMOfGroup(#groupUuid)) and #oauth2.hasScope('account:write'))")
   public void addAccountToGroup(@PathVariable String accountUuid, @PathVariable String groupUuid) {
     IamGroup group = groupService.findByUuid(groupUuid).orElseThrow(noSuchGroup(groupUuid));
 
@@ -75,7 +75,7 @@ public class AccountGroupController {
 
   @RequestMapping(value = "/iam/account/{accountUuid}/groups/{groupUuid}", method = DELETE)
   @ResponseStatus(value = HttpStatus.NO_CONTENT)
-  @PreAuthorize("#iam.isAdminOrGMOfGroup(#groupUuid) or (!#iam.isAdminOrGMOfGroup(#groupUuid) and #oauth2.hasScope('account:write'))")
+  @PreAuthorize("#iam.isAdminOrGMOfGroup(#groupUuid) or ((hasRole('ADMIN') or #iam.isGMOfGroup(#groupUuid)) and #oauth2.hasScope('account:write'))")
   public void removeAccountFromGroup(@PathVariable String accountUuid,
       @PathVariable String groupUuid) {
     IamGroup group = groupService.findByUuid(groupUuid).orElseThrow(noSuchGroup(groupUuid));

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/group_manager/AccountGroupManagerController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/group_manager/AccountGroupManagerController.java
@@ -63,7 +63,7 @@ public class AccountGroupManagerController {
 
 
   @RequestMapping(value = "/iam/account/{accountId}/managed-groups", method = RequestMethod.GET)
-  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isUser(#accountId)")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isUser(#accountId)")
   public AccountManagedGroupsDTO getAccountManagedGroupsInformation(
       @PathVariable String accountId) {
     IamAccount account = accountRepository.findByUuid(accountId)
@@ -74,7 +74,7 @@ public class AccountGroupManagerController {
 
   @RequestMapping(value = "/iam/account/{accountId}/managed-groups/{groupId}",
       method = RequestMethod.POST)
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @ResponseStatus(value = HttpStatus.CREATED)
   public void addManagedGroupToAccount(@PathVariable String accountId,
       @PathVariable String groupId) {
@@ -90,7 +90,7 @@ public class AccountGroupManagerController {
 
   @RequestMapping(value = "/iam/account/{accountId}/managed-groups/{groupId}",
       method = RequestMethod.DELETE)
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @ResponseStatus(value = HttpStatus.NO_CONTENT)
   public void removeManagedGroupFromAccount(@PathVariable String accountId,
       @PathVariable String groupId) {
@@ -105,7 +105,7 @@ public class AccountGroupManagerController {
   }
 
   @RequestMapping(value = "/iam/group/{groupId}/group-managers", method=RequestMethod.GET)
-  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isGroupManager(#groupId)")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isGroupManager(#groupId)")
   public List<ScimUser> getGroupManagersForGroup(@PathVariable String groupId) {
     IamGroup group = groupRepository.findByUuid(groupId)
       .orElseThrow(() -> InvalidManagedGroupError.groupNotFoundException(groupId));

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/group_manager/AccountGroupManagerController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/group_manager/AccountGroupManagerController.java
@@ -74,7 +74,7 @@ public class AccountGroupManagerController {
 
   @RequestMapping(value = "/iam/account/{accountId}/managed-groups/{groupId}",
       method = RequestMethod.POST)
-  @PreAuthorize("hasRole('ADMIN')")
+  @PreAuthorize("(hasRole('ADMIN') and #oauth2.hasScope('account:write')) or #iam.isAdmin()")
   @ResponseStatus(value = HttpStatus.CREATED)
   public void addManagedGroupToAccount(@PathVariable String accountId,
       @PathVariable String groupId) {
@@ -90,7 +90,7 @@ public class AccountGroupManagerController {
 
   @RequestMapping(value = "/iam/account/{accountId}/managed-groups/{groupId}",
       method = RequestMethod.DELETE)
-  @PreAuthorize("hasRole('ADMIN')")
+  @PreAuthorize("(hasRole('ADMIN') and #oauth2.hasScope('account:write')) or #iam.isAdmin()")
   @ResponseStatus(value = HttpStatus.NO_CONTENT)
   public void removeManagedGroupFromAccount(@PathVariable String accountId,
       @PathVariable String groupId) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/group_manager/AccountGroupManagerController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/group_manager/AccountGroupManagerController.java
@@ -63,7 +63,7 @@ public class AccountGroupManagerController {
 
 
   @RequestMapping(value = "/iam/account/{accountId}/managed-groups", method = RequestMethod.GET)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isUser(#accountId)")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isUser(#accountId)")
   public AccountManagedGroupsDTO getAccountManagedGroupsInformation(
       @PathVariable String accountId) {
     IamAccount account = accountRepository.findByUuid(accountId)
@@ -74,7 +74,7 @@ public class AccountGroupManagerController {
 
   @RequestMapping(value = "/iam/account/{accountId}/managed-groups/{groupId}",
       method = RequestMethod.POST)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @ResponseStatus(value = HttpStatus.CREATED)
   public void addManagedGroupToAccount(@PathVariable String accountId,
       @PathVariable String groupId) {
@@ -90,7 +90,7 @@ public class AccountGroupManagerController {
 
   @RequestMapping(value = "/iam/account/{accountId}/managed-groups/{groupId}",
       method = RequestMethod.DELETE)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @ResponseStatus(value = HttpStatus.NO_CONTENT)
   public void removeManagedGroupFromAccount(@PathVariable String accountId,
       @PathVariable String groupId) {
@@ -105,7 +105,7 @@ public class AccountGroupManagerController {
   }
 
   @RequestMapping(value = "/iam/group/{groupId}/group-managers", method=RequestMethod.GET)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isGroupManager(#groupId)")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isGroupManager(#groupId)")
   public List<ScimUser> getGroupManagersForGroup(@PathVariable String groupId) {
     IamGroup group = groupRepository.findByUuid(groupId)
       .orElseThrow(() -> InvalidManagedGroupError.groupNotFoundException(groupId));

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/group_manager/AccountGroupManagerController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/group_manager/AccountGroupManagerController.java
@@ -63,7 +63,7 @@ public class AccountGroupManagerController {
 
 
   @RequestMapping(value = "/iam/account/{accountId}/managed-groups", method = RequestMethod.GET)
-  @PreAuthorize("hasRole('ADMIN') or #iam.isUser(#accountId)")
+  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isUser(#accountId)")
   public AccountManagedGroupsDTO getAccountManagedGroupsInformation(
       @PathVariable String accountId) {
     IamAccount account = accountRepository.findByUuid(accountId)
@@ -74,7 +74,7 @@ public class AccountGroupManagerController {
 
   @RequestMapping(value = "/iam/account/{accountId}/managed-groups/{groupId}",
       method = RequestMethod.POST)
-  @PreAuthorize("(hasRole('ADMIN') and #oauth2.hasScope('account:write')) or #iam.isAdmin()")
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @ResponseStatus(value = HttpStatus.CREATED)
   public void addManagedGroupToAccount(@PathVariable String accountId,
       @PathVariable String groupId) {
@@ -90,7 +90,7 @@ public class AccountGroupManagerController {
 
   @RequestMapping(value = "/iam/account/{accountId}/managed-groups/{groupId}",
       method = RequestMethod.DELETE)
-  @PreAuthorize("(hasRole('ADMIN') and #oauth2.hasScope('account:write')) or #iam.isAdmin()")
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @ResponseStatus(value = HttpStatus.NO_CONTENT)
   public void removeManagedGroupFromAccount(@PathVariable String accountId,
       @PathVariable String groupId) {
@@ -105,7 +105,7 @@ public class AccountGroupManagerController {
   }
 
   @RequestMapping(value = "/iam/group/{groupId}/group-managers", method=RequestMethod.GET)
-  @PreAuthorize("hasRole('ADMIN') or #iam.isGroupManager(#groupId)")
+  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isGroupManager(#groupId)")
   public List<ScimUser> getGroupManagersForGroup(@PathVariable String groupId) {
     IamGroup group = groupRepository.findByUuid(groupId)
       .orElseThrow(() -> InvalidManagedGroupError.groupNotFoundException(groupId));

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/labels/AccountLabelsController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/labels/AccountLabelsController.java
@@ -76,7 +76,7 @@ public class AccountLabelsController {
   }
 
   @RequestMapping(method = GET)
-  @PreAuthorize("hasRole('ADMIN') or #iam.isUser(#id) or #iam.isAGroupManager()")
+  @PreAuthorize("hasRole('ADMIN') or #iam.isUser(#id) or #iam.isGroupManager()")
   public List<LabelDTO> getLabels(@PathVariable String id) {
 
     IamAccount account = service.findByUuid(id).orElseThrow(noSuchAccountError(id));

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/labels/AccountLabelsController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/labels/AccountLabelsController.java
@@ -49,7 +49,6 @@ import it.infn.mw.iam.core.user.IamAccountService;
 import it.infn.mw.iam.persistence.model.IamAccount;
 
 @RestController
-@PreAuthorize("hasRole('ADMIN')")
 @RequestMapping(AccountLabelsController.RESOURCE)
 public class AccountLabelsController {
 
@@ -89,6 +88,7 @@ public class AccountLabelsController {
   }
 
   @RequestMapping(method = PUT)
+  @PreAuthorize("(hasRole('ADMIN') and #oauth2.hasScope('account:write')) or #iam.isAdmin()")
   public void setLabel(@PathVariable String id, @RequestBody @Validated LabelDTO label,
       BindingResult validationResult) {
     handleValidationError(validationResult);
@@ -98,6 +98,7 @@ public class AccountLabelsController {
   }
 
   @RequestMapping(method = DELETE)
+  @PreAuthorize("(hasRole('ADMIN') and #oauth2.hasScope('account:write')) or #iam.isAdmin()")
   @ResponseStatus(NO_CONTENT)
   public void deleteLabel(@PathVariable String id, @Validated LabelDTO label,
       BindingResult validationResult) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/labels/AccountLabelsController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/labels/AccountLabelsController.java
@@ -75,7 +75,7 @@ public class AccountLabelsController {
   }
 
   @RequestMapping(method = GET)
-  @PreAuthorize("hasRole('ADMIN') or #iam.isUser(#id) or #iam.isGroupManager()")
+  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM') or #iam.isUser(#id)")
   public List<LabelDTO> getLabels(@PathVariable String id) {
 
     IamAccount account = service.findByUuid(id).orElseThrow(noSuchAccountError(id));
@@ -88,7 +88,7 @@ public class AccountLabelsController {
   }
 
   @RequestMapping(method = PUT)
-  @PreAuthorize("(hasRole('ADMIN') and #oauth2.hasScope('account:write')) or #iam.isAdmin()")
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void setLabel(@PathVariable String id, @RequestBody @Validated LabelDTO label,
       BindingResult validationResult) {
     handleValidationError(validationResult);
@@ -98,7 +98,7 @@ public class AccountLabelsController {
   }
 
   @RequestMapping(method = DELETE)
-  @PreAuthorize("(hasRole('ADMIN') and #oauth2.hasScope('account:write')) or #iam.isAdmin()")
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @ResponseStatus(NO_CONTENT)
   public void deleteLabel(@PathVariable String id, @Validated LabelDTO label,
       BindingResult validationResult) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/labels/AccountLabelsController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/labels/AccountLabelsController.java
@@ -75,7 +75,7 @@ public class AccountLabelsController {
   }
 
   @RequestMapping(method = GET)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM') or #iam.isUser(#id)")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM') or #iam.isUser(#id)")
   public List<LabelDTO> getLabels(@PathVariable String id) {
 
     IamAccount account = service.findByUuid(id).orElseThrow(noSuchAccountError(id));
@@ -88,7 +88,7 @@ public class AccountLabelsController {
   }
 
   @RequestMapping(method = PUT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void setLabel(@PathVariable String id, @RequestBody @Validated LabelDTO label,
       BindingResult validationResult) {
     handleValidationError(validationResult);
@@ -98,7 +98,7 @@ public class AccountLabelsController {
   }
 
   @RequestMapping(method = DELETE)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @ResponseStatus(NO_CONTENT)
   public void deleteLabel(@PathVariable String id, @Validated LabelDTO label,
       BindingResult validationResult) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/labels/AccountLabelsController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/labels/AccountLabelsController.java
@@ -75,7 +75,7 @@ public class AccountLabelsController {
   }
 
   @RequestMapping(method = GET)
-  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM') or #iam.isUser(#id)")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM') or #iam.isUser(#id)")
   public List<LabelDTO> getLabels(@PathVariable String id) {
 
     IamAccount account = service.findByUuid(id).orElseThrow(noSuchAccountError(id));
@@ -88,7 +88,7 @@ public class AccountLabelsController {
   }
 
   @RequestMapping(method = PUT)
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void setLabel(@PathVariable String id, @RequestBody @Validated LabelDTO label,
       BindingResult validationResult) {
     handleValidationError(validationResult);
@@ -98,7 +98,7 @@ public class AccountLabelsController {
   }
 
   @RequestMapping(method = DELETE)
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @ResponseStatus(NO_CONTENT)
   public void deleteLabel(@PathVariable String id, @Validated LabelDTO label,
       BindingResult validationResult) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/lifecycle/AccountLifecycleController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/lifecycle/AccountLifecycleController.java
@@ -42,7 +42,7 @@ import it.infn.mw.iam.persistence.model.IamAccount;
 
 @RestController
 @RequestMapping(value = AccountLifecycleController.BASE_RESOURCE)
-@PreAuthorize("(hasRole('ADMIN') and #oauth2.hasScope('account:write')) or #iam.isAdmin()")
+@PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
 public class AccountLifecycleController {
 
   public static final String BASE_RESOURCE = "/iam/account/{id}/endTime";

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/lifecycle/AccountLifecycleController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/lifecycle/AccountLifecycleController.java
@@ -42,7 +42,7 @@ import it.infn.mw.iam.persistence.model.IamAccount;
 
 @RestController
 @RequestMapping(value = AccountLifecycleController.BASE_RESOURCE)
-@PreAuthorize("hasRole('ADMIN')")
+@PreAuthorize("(hasRole('ADMIN') and #oauth2.hasScope('account:write')) or #iam.isAdmin()")
 public class AccountLifecycleController {
 
   public static final String BASE_RESOURCE = "/iam/account/{id}/endTime";

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/lifecycle/AccountLifecycleController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/lifecycle/AccountLifecycleController.java
@@ -42,7 +42,7 @@ import it.infn.mw.iam.persistence.model.IamAccount;
 
 @RestController
 @RequestMapping(value = AccountLifecycleController.BASE_RESOURCE)
-@PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+@PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
 public class AccountLifecycleController {
 
   public static final String BASE_RESOURCE = "/iam/account/{id}/endTime";

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/lifecycle/AccountLifecycleController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/lifecycle/AccountLifecycleController.java
@@ -42,7 +42,7 @@ import it.infn.mw.iam.persistence.model.IamAccount;
 
 @RestController
 @RequestMapping(value = AccountLifecycleController.BASE_RESOURCE)
-@PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+@PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
 public class AccountLifecycleController {
 
   public static final String BASE_RESOURCE = "/iam/account/{id}/endTime";

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/proxy_certificate/AccountProxyCertificatesController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/proxy_certificate/AccountProxyCertificatesController.java
@@ -77,7 +77,7 @@ public class AccountProxyCertificatesController {
   }
 
   @RequestMapping(value = "/iam/account/me/proxycert", method = PUT)
-  @PreAuthorize("hasRole('USER')")
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_USER')")
   public void addProxyCertificate(
       @RequestBody @Validated(
           value = ProxyCertificateDTO.AddProxyCertValidation.class) ProxyCertificateDTO proxyCert,

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/proxy_certificate/AccountProxyCertificatesController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/proxy_certificate/AccountProxyCertificatesController.java
@@ -77,7 +77,7 @@ public class AccountProxyCertificatesController {
   }
 
   @RequestMapping(value = "/iam/account/me/proxycert", method = PUT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_USER')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_USER')")
   public void addProxyCertificate(
       @RequestBody @Validated(
           value = ProxyCertificateDTO.AddProxyCertValidation.class) ProxyCertificateDTO proxyCert,

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/proxy_certificate/AccountProxyCertificatesController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/proxy_certificate/AccountProxyCertificatesController.java
@@ -77,7 +77,7 @@ public class AccountProxyCertificatesController {
   }
 
   @RequestMapping(value = "/iam/account/me/proxycert", method = PUT)
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_USER')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_USER')")
   public void addProxyCertificate(
       @RequestBody @Validated(
           value = ProxyCertificateDTO.AddProxyCertValidation.class) ProxyCertificateDTO proxyCert,

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/search/AccountSearchController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/search/AccountSearchController.java
@@ -38,7 +38,7 @@ import it.infn.mw.iam.persistence.model.IamAccount;
 
 @RestController
 @Transactional
-@PreAuthorize("hasRole('ADMIN') or #oauth2.hasScope('scim:read') or #iam.isGroupManager()")
+@PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM')")
 @RequestMapping(AccountSearchController.ACCOUNT_SEARCH_ENDPOINT)
 public class AccountSearchController extends AbstractSearchController<ScimUser, IamAccount> {
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/search/AccountSearchController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/search/AccountSearchController.java
@@ -38,7 +38,7 @@ import it.infn.mw.iam.persistence.model.IamAccount;
 
 @RestController
 @Transactional
-@PreAuthorize("hasRole('ADMIN') or #oauth2.hasScope('scim:read') or #iam.isAGroupManager()")
+@PreAuthorize("hasRole('ADMIN') or #oauth2.hasScope('scim:read') or #iam.isGroupManager()")
 @RequestMapping(AccountSearchController.ACCOUNT_SEARCH_ENDPOINT)
 public class AccountSearchController extends AbstractSearchController<ScimUser, IamAccount> {
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/search/AccountSearchController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/search/AccountSearchController.java
@@ -38,7 +38,7 @@ import it.infn.mw.iam.persistence.model.IamAccount;
 
 @RestController
 @Transactional
-@PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM')")
+@PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM')")
 @RequestMapping(AccountSearchController.ACCOUNT_SEARCH_ENDPOINT)
 public class AccountSearchController extends AbstractSearchController<ScimUser, IamAccount> {
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/search/AccountSearchController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/search/AccountSearchController.java
@@ -38,7 +38,7 @@ import it.infn.mw.iam.persistence.model.IamAccount;
 
 @RestController
 @Transactional
-@PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM')")
+@PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM')")
 @RequestMapping(AccountSearchController.ACCOUNT_SEARCH_ENDPOINT)
 public class AccountSearchController extends AbstractSearchController<ScimUser, IamAccount> {
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/search/GroupSearchController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/search/GroupSearchController.java
@@ -42,7 +42,7 @@ import it.infn.mw.iam.persistence.model.IamGroup;
 
 @RestController
 @Transactional
-@PreAuthorize("hasAnyRole('ADMIN', 'USER') or #oauth2.hasScope('iam:admin:read')")
+@PreAuthorize("hasAnyRole('ADMIN', 'USER') or #oauth2.hasScope('iam:admin.read')")
 @RequestMapping(GroupSearchController.GROUP_SEARCH_ENDPOINT)
 public class GroupSearchController extends AbstractSearchController<ScimGroup, IamGroup> {
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/search/GroupSearchController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/search/GroupSearchController.java
@@ -42,7 +42,7 @@ import it.infn.mw.iam.persistence.model.IamGroup;
 
 @RestController
 @Transactional
-@PreAuthorize("hasAnyRole('ADMIN', 'USER') or #oauth2.hasScope('admin:read')")
+@PreAuthorize("hasAnyRole('ADMIN', 'USER') or #oauth2.hasScope('iam:admin:read')")
 @RequestMapping(GroupSearchController.GROUP_SEARCH_ENDPOINT)
 public class GroupSearchController extends AbstractSearchController<ScimGroup, IamGroup> {
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/search/GroupSearchController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/search/GroupSearchController.java
@@ -42,7 +42,7 @@ import it.infn.mw.iam.persistence.model.IamGroup;
 
 @RestController
 @Transactional
-@PreAuthorize("hasAnyRole('ADMIN', 'USER') or #oauth2.hasScope('scim:read')")
+@PreAuthorize("hasAnyRole('ADMIN', 'USER') or #oauth2.hasScope('admin:read')")
 @RequestMapping(GroupSearchController.GROUP_SEARCH_ENDPOINT)
 public class GroupSearchController extends AbstractSearchController<ScimGroup, IamGroup> {
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/aup/AupSignatureController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/aup/AupSignatureController.java
@@ -97,7 +97,7 @@ public class AupSignatureController {
   }
 
   @RequestMapping(value = "/iam/aup/signature/{accountId}", method = RequestMethod.GET)
-  @PreAuthorize("hasRole('ADMIN') or #iam.isUser(#accountId) or #iam.isAGroupManager()")
+  @PreAuthorize("hasRole('ADMIN') or #iam.isUser(#accountId) or #iam.isGroupManager()")
   public AupSignatureDTO getSignatureForAccount(@PathVariable String accountId) {
     IamAccount account = accountUtils.getByAccountId(accountId)
       .orElseThrow(accountNotFoundException("Account not found for id: " + accountId));

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/aup/AupSignatureController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/aup/AupSignatureController.java
@@ -71,7 +71,7 @@ public class AupSignatureController {
   }
 
   @RequestMapping(value = "/iam/aup/signature", method = RequestMethod.POST)
-  @PreAuthorize("hasRole('USER')")
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_USER')")
   @ResponseStatus(code = HttpStatus.CREATED)
   public void signAup() {
     IamAccount account = accountUtils.getAuthenticatedUserAccount()
@@ -84,7 +84,7 @@ public class AupSignatureController {
   }
 
   @RequestMapping(value = "/iam/aup/signature", method = RequestMethod.GET)
-  @PreAuthorize("hasRole('USER')")
+  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_USER')")
   public AupSignatureDTO getSignature() {
     IamAccount account = accountUtils.getAuthenticatedUserAccount()
       .orElseThrow(accountNotFoundException("Account not found for authenticated user"));
@@ -97,7 +97,7 @@ public class AupSignatureController {
   }
 
   @RequestMapping(value = "/iam/aup/signature/{accountId}", method = RequestMethod.GET)
-  @PreAuthorize("hasRole('ADMIN') or #iam.isUser(#accountId) or #iam.isGroupManager()")
+  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM') or #iam.isUser(#accountId)")
   public AupSignatureDTO getSignatureForAccount(@PathVariable String accountId) {
     IamAccount account = accountUtils.getByAccountId(accountId)
       .orElseThrow(accountNotFoundException("Account not found for id: " + accountId));

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/aup/AupSignatureController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/aup/AupSignatureController.java
@@ -71,7 +71,7 @@ public class AupSignatureController {
   }
 
   @RequestMapping(value = "/iam/aup/signature", method = RequestMethod.POST)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_USER')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_USER')")
   @ResponseStatus(code = HttpStatus.CREATED)
   public void signAup() {
     IamAccount account = accountUtils.getAuthenticatedUserAccount()
@@ -84,7 +84,7 @@ public class AupSignatureController {
   }
 
   @RequestMapping(value = "/iam/aup/signature", method = RequestMethod.GET)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_USER')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_USER')")
   public AupSignatureDTO getSignature() {
     IamAccount account = accountUtils.getAuthenticatedUserAccount()
       .orElseThrow(accountNotFoundException("Account not found for authenticated user"));
@@ -97,7 +97,7 @@ public class AupSignatureController {
   }
 
   @RequestMapping(value = "/iam/aup/signature/{accountId}", method = RequestMethod.GET)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM') or #iam.isUser(#accountId)")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM') or #iam.isUser(#accountId)")
   public AupSignatureDTO getSignatureForAccount(@PathVariable String accountId) {
     IamAccount account = accountUtils.getByAccountId(accountId)
       .orElseThrow(accountNotFoundException("Account not found for id: " + accountId));

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/aup/AupSignatureController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/aup/AupSignatureController.java
@@ -71,7 +71,7 @@ public class AupSignatureController {
   }
 
   @RequestMapping(value = "/iam/aup/signature", method = RequestMethod.POST)
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_USER')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_USER')")
   @ResponseStatus(code = HttpStatus.CREATED)
   public void signAup() {
     IamAccount account = accountUtils.getAuthenticatedUserAccount()
@@ -84,7 +84,7 @@ public class AupSignatureController {
   }
 
   @RequestMapping(value = "/iam/aup/signature", method = RequestMethod.GET)
-  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_USER')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_USER')")
   public AupSignatureDTO getSignature() {
     IamAccount account = accountUtils.getAuthenticatedUserAccount()
       .orElseThrow(accountNotFoundException("Account not found for authenticated user"));
@@ -97,7 +97,7 @@ public class AupSignatureController {
   }
 
   @RequestMapping(value = "/iam/aup/signature/{accountId}", method = RequestMethod.GET)
-  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM') or #iam.isUser(#accountId)")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM') or #iam.isUser(#accountId)")
   public AupSignatureDTO getSignatureForAccount(@PathVariable String accountId) {
     IamAccount account = accountUtils.getByAccountId(accountId)
       .orElseThrow(accountNotFoundException("Account not found for id: " + accountId));

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/management/ClientManagementAPIController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/management/ClientManagementAPIController.java
@@ -68,7 +68,7 @@ public class ClientManagementAPIController {
 
   @PostMapping
   @ResponseStatus(CREATED)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public RegisteredClientDTO saveNewClient(@RequestBody RegisteredClientDTO client)
       throws ParseException {
     return managementService.saveNewClient(client);
@@ -76,7 +76,7 @@ public class ClientManagementAPIController {
 
   @JsonView({ClientViews.ClientManagement.class})
   @GetMapping
-  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public ListResponseDTO<RegisteredClientDTO> retrieveClients(
       @RequestParam final Optional<Integer> count,
       @RequestParam final Optional<Integer> startIndex,
@@ -94,14 +94,14 @@ public class ClientManagementAPIController {
 
   @JsonView({ClientViews.ClientManagement.class})
   @GetMapping("/{clientId}")
-  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public RegisteredClientDTO retrieveClient(@PathVariable String clientId) {
     return managementService.retrieveClientByClientId(clientId)
       .orElseThrow(clientNotFound(clientId));
   }
 
   @GetMapping("/{clientId}/owners")
-  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public ListResponseDTO<ScimUser> retrieveClientOwners(@PathVariable String clientId,
       @RequestParam final Optional<Integer> count,
       @RequestParam final Optional<Integer> startIndex) {
@@ -111,7 +111,7 @@ public class ClientManagementAPIController {
 
   @PostMapping("/{clientId}/owners/{accountId}")
   @ResponseStatus(CREATED)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void assignClientOwner(@PathVariable String clientId,
       @PathVariable final String accountId) {
     managementService.assignClientOwner(clientId, accountId);
@@ -119,21 +119,21 @@ public class ClientManagementAPIController {
 
   @PostMapping("/{clientId}/rat")
   @ResponseStatus(CREATED)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public RegisteredClientDTO rotateRegistrationAccessToken(@PathVariable String clientId) {
     return managementService.rotateRegistrationAccessToken(clientId);
   }
 
   @DeleteMapping("/{clientId}/owners/{accountId}")
   @ResponseStatus(NO_CONTENT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void removeClientOwner(@PathVariable String clientId,
       @PathVariable final String accountId) {
     managementService.removeClientOwner(clientId, accountId);
   }
 
   @PutMapping("/{clientId}")
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public RegisteredClientDTO updateClient(@PathVariable String clientId,
       @RequestBody RegisteredClientDTO client)
       throws ParseException {
@@ -142,14 +142,14 @@ public class ClientManagementAPIController {
 
   @PostMapping("/{clientId}/secret")
   @ResponseStatus(CREATED)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public RegisteredClientDTO rotateClientSecret(@PathVariable String clientId) {
     return managementService.generateNewClientSecret(clientId);
   }
 
   @DeleteMapping("/{clientId}")
   @ResponseStatus(NO_CONTENT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void deleteClient(@PathVariable String clientId) {
     managementService.deleteClientByClientId(clientId);
   }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/management/ClientManagementAPIController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/management/ClientManagementAPIController.java
@@ -56,7 +56,6 @@ import it.infn.mw.iam.api.scim.model.ScimUser;
 
 @RestController
 @RequestMapping(ClientManagementAPIController.ENDPOINT)
-@PreAuthorize("hasRole('ADMIN')")
 public class ClientManagementAPIController {
 
   public static final String ENDPOINT = "/iam/api/clients";
@@ -69,6 +68,7 @@ public class ClientManagementAPIController {
 
   @PostMapping
   @ResponseStatus(CREATED)
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public RegisteredClientDTO saveNewClient(@RequestBody RegisteredClientDTO client)
       throws ParseException {
     return managementService.saveNewClient(client);
@@ -76,6 +76,7 @@ public class ClientManagementAPIController {
 
   @JsonView({ClientViews.ClientManagement.class})
   @GetMapping
+  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public ListResponseDTO<RegisteredClientDTO> retrieveClients(
       @RequestParam final Optional<Integer> count,
       @RequestParam final Optional<Integer> startIndex,
@@ -93,12 +94,14 @@ public class ClientManagementAPIController {
 
   @JsonView({ClientViews.ClientManagement.class})
   @GetMapping("/{clientId}")
+  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public RegisteredClientDTO retrieveClient(@PathVariable String clientId) {
     return managementService.retrieveClientByClientId(clientId)
       .orElseThrow(clientNotFound(clientId));
   }
 
   @GetMapping("/{clientId}/owners")
+  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public ListResponseDTO<ScimUser> retrieveClientOwners(@PathVariable String clientId,
       @RequestParam final Optional<Integer> count,
       @RequestParam final Optional<Integer> startIndex) {
@@ -108,6 +111,7 @@ public class ClientManagementAPIController {
 
   @PostMapping("/{clientId}/owners/{accountId}")
   @ResponseStatus(CREATED)
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void assignClientOwner(@PathVariable String clientId,
       @PathVariable final String accountId) {
     managementService.assignClientOwner(clientId, accountId);
@@ -115,18 +119,21 @@ public class ClientManagementAPIController {
 
   @PostMapping("/{clientId}/rat")
   @ResponseStatus(CREATED)
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public RegisteredClientDTO rotateRegistrationAccessToken(@PathVariable String clientId) {
     return managementService.rotateRegistrationAccessToken(clientId);
   }
 
   @DeleteMapping("/{clientId}/owners/{accountId}")
   @ResponseStatus(NO_CONTENT)
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void removeClientOwner(@PathVariable String clientId,
       @PathVariable final String accountId) {
     managementService.removeClientOwner(clientId, accountId);
   }
 
   @PutMapping("/{clientId}")
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public RegisteredClientDTO updateClient(@PathVariable String clientId,
       @RequestBody RegisteredClientDTO client)
       throws ParseException {
@@ -135,12 +142,14 @@ public class ClientManagementAPIController {
 
   @PostMapping("/{clientId}/secret")
   @ResponseStatus(CREATED)
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public RegisteredClientDTO rotateClientSecret(@PathVariable String clientId) {
     return managementService.generateNewClientSecret(clientId);
   }
 
   @DeleteMapping("/{clientId}")
   @ResponseStatus(NO_CONTENT)
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void deleteClient(@PathVariable String clientId) {
     managementService.deleteClientByClientId(clientId);
   }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/management/ClientManagementAPIController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/management/ClientManagementAPIController.java
@@ -68,7 +68,7 @@ public class ClientManagementAPIController {
 
   @PostMapping
   @ResponseStatus(CREATED)
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public RegisteredClientDTO saveNewClient(@RequestBody RegisteredClientDTO client)
       throws ParseException {
     return managementService.saveNewClient(client);
@@ -76,7 +76,7 @@ public class ClientManagementAPIController {
 
   @JsonView({ClientViews.ClientManagement.class})
   @GetMapping
-  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public ListResponseDTO<RegisteredClientDTO> retrieveClients(
       @RequestParam final Optional<Integer> count,
       @RequestParam final Optional<Integer> startIndex,
@@ -94,14 +94,14 @@ public class ClientManagementAPIController {
 
   @JsonView({ClientViews.ClientManagement.class})
   @GetMapping("/{clientId}")
-  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public RegisteredClientDTO retrieveClient(@PathVariable String clientId) {
     return managementService.retrieveClientByClientId(clientId)
       .orElseThrow(clientNotFound(clientId));
   }
 
   @GetMapping("/{clientId}/owners")
-  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public ListResponseDTO<ScimUser> retrieveClientOwners(@PathVariable String clientId,
       @RequestParam final Optional<Integer> count,
       @RequestParam final Optional<Integer> startIndex) {
@@ -111,7 +111,7 @@ public class ClientManagementAPIController {
 
   @PostMapping("/{clientId}/owners/{accountId}")
   @ResponseStatus(CREATED)
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void assignClientOwner(@PathVariable String clientId,
       @PathVariable final String accountId) {
     managementService.assignClientOwner(clientId, accountId);
@@ -119,21 +119,21 @@ public class ClientManagementAPIController {
 
   @PostMapping("/{clientId}/rat")
   @ResponseStatus(CREATED)
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public RegisteredClientDTO rotateRegistrationAccessToken(@PathVariable String clientId) {
     return managementService.rotateRegistrationAccessToken(clientId);
   }
 
   @DeleteMapping("/{clientId}/owners/{accountId}")
   @ResponseStatus(NO_CONTENT)
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void removeClientOwner(@PathVariable String clientId,
       @PathVariable final String accountId) {
     managementService.removeClientOwner(clientId, accountId);
   }
 
   @PutMapping("/{clientId}")
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public RegisteredClientDTO updateClient(@PathVariable String clientId,
       @RequestBody RegisteredClientDTO client)
       throws ParseException {
@@ -142,14 +142,14 @@ public class ClientManagementAPIController {
 
   @PostMapping("/{clientId}/secret")
   @ResponseStatus(CREATED)
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public RegisteredClientDTO rotateClientSecret(@PathVariable String clientId) {
     return managementService.generateNewClientSecret(clientId);
   }
 
   @DeleteMapping("/{clientId}")
   @ResponseStatus(NO_CONTENT)
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void deleteClient(@PathVariable String clientId) {
     managementService.deleteClientByClientId(clientId);
   }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/search/SearchClientController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/search/SearchClientController.java
@@ -36,7 +36,7 @@ import it.infn.mw.iam.api.common.client.RegisteredClientDTO;
 
 @RestController
 @RequestMapping(SearchClientController.ENDPOINT)
-@PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+@PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
 public class SearchClientController {
 
   public static final int MAX_PAGE_SIZE = 100;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/search/SearchClientController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/search/SearchClientController.java
@@ -36,7 +36,7 @@ import it.infn.mw.iam.api.common.client.RegisteredClientDTO;
 
 @RestController
 @RequestMapping(SearchClientController.ENDPOINT)
-@PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+@PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
 public class SearchClientController {
 
   public static final int MAX_PAGE_SIZE = 100;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/search/SearchClientController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/search/SearchClientController.java
@@ -36,7 +36,7 @@ import it.infn.mw.iam.api.common.client.RegisteredClientDTO;
 
 @RestController
 @RequestMapping(SearchClientController.ENDPOINT)
-@PreAuthorize("hasRole('ADMIN')")
+@PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
 public class SearchClientController {
 
   public static final int MAX_PAGE_SIZE = 100;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/exchange_policy/ExchangePolicyController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/exchange_policy/ExchangePolicyController.java
@@ -62,7 +62,7 @@ public class ExchangePolicyController {
   }
 
   @RequestMapping(value = "/policies", method = RequestMethod.GET)
-  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public List<ExchangePolicyDTO> getExchangePolicies() {
     Page<ExchangePolicyDTO> resultsPage = service.getTokenExchangePolicies(UNPAGED);
     if (resultsPage.hasNext()) {
@@ -74,14 +74,14 @@ public class ExchangePolicyController {
 
   @RequestMapping(value = "/policies/{id}", method = RequestMethod.DELETE)
   @ResponseStatus(code = HttpStatus.NO_CONTENT)
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void deleteExchangePolicy(@PathVariable Long id) {
     service.deleteTokenExchangePolicyById(id);
   }
 
   @RequestMapping(value = "/policies", method = RequestMethod.POST)
   @ResponseStatus(code = HttpStatus.CREATED)
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void createExchangePolicy(@Valid @RequestBody ExchangePolicyDTO dto,
       BindingResult validationResult) {
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/exchange_policy/ExchangePolicyController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/exchange_policy/ExchangePolicyController.java
@@ -38,7 +38,6 @@ import it.infn.mw.iam.api.common.ErrorDTO;
 
 @RestController
 @RequestMapping("/iam/api/exchange")
-@PreAuthorize("hasRole('ADMIN')")
 public class ExchangePolicyController {
 
   private final TokenExchangePolicyService service;
@@ -63,6 +62,7 @@ public class ExchangePolicyController {
   }
 
   @RequestMapping(value = "/policies", method = RequestMethod.GET)
+  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public List<ExchangePolicyDTO> getExchangePolicies() {
     Page<ExchangePolicyDTO> resultsPage = service.getTokenExchangePolicies(UNPAGED);
     if (resultsPage.hasNext()) {
@@ -74,12 +74,14 @@ public class ExchangePolicyController {
 
   @RequestMapping(value = "/policies/{id}", method = RequestMethod.DELETE)
   @ResponseStatus(code = HttpStatus.NO_CONTENT)
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void deleteExchangePolicy(@PathVariable Long id) {
     service.deleteTokenExchangePolicyById(id);
   }
 
   @RequestMapping(value = "/policies", method = RequestMethod.POST)
   @ResponseStatus(code = HttpStatus.CREATED)
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void createExchangePolicy(@Valid @RequestBody ExchangePolicyDTO dto,
       BindingResult validationResult) {
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/exchange_policy/ExchangePolicyController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/exchange_policy/ExchangePolicyController.java
@@ -62,7 +62,7 @@ public class ExchangePolicyController {
   }
 
   @RequestMapping(value = "/policies", method = RequestMethod.GET)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public List<ExchangePolicyDTO> getExchangePolicies() {
     Page<ExchangePolicyDTO> resultsPage = service.getTokenExchangePolicies(UNPAGED);
     if (resultsPage.hasNext()) {
@@ -74,14 +74,14 @@ public class ExchangePolicyController {
 
   @RequestMapping(value = "/policies/{id}", method = RequestMethod.DELETE)
   @ResponseStatus(code = HttpStatus.NO_CONTENT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void deleteExchangePolicy(@PathVariable Long id) {
     service.deleteTokenExchangePolicyById(id);
   }
 
   @RequestMapping(value = "/policies", method = RequestMethod.POST)
   @ResponseStatus(code = HttpStatus.CREATED)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void createExchangePolicy(@Valid @RequestBody ExchangePolicyDTO dto,
       BindingResult validationResult) {
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/group/GroupController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/group/GroupController.java
@@ -86,7 +86,7 @@ public class GroupController {
   
   @RequestMapping(value = "/iam/group", method = POST)
   @ResponseStatus(value = HttpStatus.CREATED)
-  @PreAuthorize("hasRole('ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public GroupDTO createGroup(@RequestBody @Validated(CreateGroup.class) GroupDTO group, final BindingResult validationResult) {
     
     handleValidationError(INVALID_GROUP,validationResult);
@@ -97,7 +97,7 @@ public class GroupController {
   }
   
   @RequestMapping(value = "/iam/group/{id}", method = PUT)
-  @PreAuthorize("hasRole('ADMIN') or #iam.isGroupManager(#id)")
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isGroupManager(#id)")
   public GroupDTO updateGroup(@PathVariable String id, @RequestBody @Validated(UpdateGroup.class) GroupDTO group, final BindingResult validationResult) {
     handleValidationError(INVALID_GROUP, validationResult);
     
@@ -107,7 +107,7 @@ public class GroupController {
   }
   
   @RequestMapping(value = "/iam/group/{id}/attributes", method=RequestMethod.GET)
-  @PreAuthorize("hasRole('ADMIN') or #iam.isGroupManager(#id)")
+  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isGroupManager(#id)")
   public List<AttributeDTO> getAttributes(@PathVariable String id){
     
     IamGroup entity = groupService.findByUuid(id).orElseThrow(()->NoSuchGroupError.forUuid(id));
@@ -119,7 +119,7 @@ public class GroupController {
   }
   
   @RequestMapping(value = "/iam/group/{id}/attributes", method= PUT)
-  @PreAuthorize("hasRole('ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void setAttribute(@PathVariable String id, @RequestBody @Validated AttributeDTO attribute, final BindingResult validationResult) {
     handleValidationError(INVALID_ATTRIBUTE,validationResult);
     IamGroup entity = groupService.findByUuid(id).orElseThrow(()->NoSuchGroupError.forUuid(id));
@@ -130,7 +130,7 @@ public class GroupController {
   }
   
   @RequestMapping(value = "/iam/group/{id}/attributes", method=DELETE)
-  @PreAuthorize("hasRole('ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @ResponseStatus(value = HttpStatus.NO_CONTENT)
   public void deleteAttribute(@PathVariable String id, @Validated AttributeDTO attribute, final BindingResult validationResult) {
     handleValidationError(INVALID_ATTRIBUTE, validationResult);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/group/GroupController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/group/GroupController.java
@@ -86,7 +86,7 @@ public class GroupController {
   
   @RequestMapping(value = "/iam/group", method = POST)
   @ResponseStatus(value = HttpStatus.CREATED)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public GroupDTO createGroup(@RequestBody @Validated(CreateGroup.class) GroupDTO group, final BindingResult validationResult) {
     
     handleValidationError(INVALID_GROUP,validationResult);
@@ -97,7 +97,7 @@ public class GroupController {
   }
   
   @RequestMapping(value = "/iam/group/{id}", method = PUT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isGroupManager(#id)")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isGroupManager(#id)")
   public GroupDTO updateGroup(@PathVariable String id, @RequestBody @Validated(UpdateGroup.class) GroupDTO group, final BindingResult validationResult) {
     handleValidationError(INVALID_GROUP, validationResult);
     
@@ -107,7 +107,7 @@ public class GroupController {
   }
   
   @RequestMapping(value = "/iam/group/{id}/attributes", method=RequestMethod.GET)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isGroupManager(#id)")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isGroupManager(#id)")
   public List<AttributeDTO> getAttributes(@PathVariable String id){
     
     IamGroup entity = groupService.findByUuid(id).orElseThrow(()->NoSuchGroupError.forUuid(id));
@@ -119,7 +119,7 @@ public class GroupController {
   }
   
   @RequestMapping(value = "/iam/group/{id}/attributes", method= PUT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void setAttribute(@PathVariable String id, @RequestBody @Validated AttributeDTO attribute, final BindingResult validationResult) {
     handleValidationError(INVALID_ATTRIBUTE,validationResult);
     IamGroup entity = groupService.findByUuid(id).orElseThrow(()->NoSuchGroupError.forUuid(id));
@@ -130,7 +130,7 @@ public class GroupController {
   }
   
   @RequestMapping(value = "/iam/group/{id}/attributes", method=DELETE)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @ResponseStatus(value = HttpStatus.NO_CONTENT)
   public void deleteAttribute(@PathVariable String id, @Validated AttributeDTO attribute, final BindingResult validationResult) {
     handleValidationError(INVALID_ATTRIBUTE, validationResult);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/group/GroupController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/group/GroupController.java
@@ -86,7 +86,7 @@ public class GroupController {
   
   @RequestMapping(value = "/iam/group", method = POST)
   @ResponseStatus(value = HttpStatus.CREATED)
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public GroupDTO createGroup(@RequestBody @Validated(CreateGroup.class) GroupDTO group, final BindingResult validationResult) {
     
     handleValidationError(INVALID_GROUP,validationResult);
@@ -97,7 +97,7 @@ public class GroupController {
   }
   
   @RequestMapping(value = "/iam/group/{id}", method = PUT)
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isGroupManager(#id)")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isGroupManager(#id)")
   public GroupDTO updateGroup(@PathVariable String id, @RequestBody @Validated(UpdateGroup.class) GroupDTO group, final BindingResult validationResult) {
     handleValidationError(INVALID_GROUP, validationResult);
     
@@ -107,7 +107,7 @@ public class GroupController {
   }
   
   @RequestMapping(value = "/iam/group/{id}/attributes", method=RequestMethod.GET)
-  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isGroupManager(#id)")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isGroupManager(#id)")
   public List<AttributeDTO> getAttributes(@PathVariable String id){
     
     IamGroup entity = groupService.findByUuid(id).orElseThrow(()->NoSuchGroupError.forUuid(id));
@@ -119,7 +119,7 @@ public class GroupController {
   }
   
   @RequestMapping(value = "/iam/group/{id}/attributes", method= PUT)
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void setAttribute(@PathVariable String id, @RequestBody @Validated AttributeDTO attribute, final BindingResult validationResult) {
     handleValidationError(INVALID_ATTRIBUTE,validationResult);
     IamGroup entity = groupService.findByUuid(id).orElseThrow(()->NoSuchGroupError.forUuid(id));
@@ -130,7 +130,7 @@ public class GroupController {
   }
   
   @RequestMapping(value = "/iam/group/{id}/attributes", method=DELETE)
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @ResponseStatus(value = HttpStatus.NO_CONTENT)
   public void deleteAttribute(@PathVariable String id, @Validated AttributeDTO attribute, final BindingResult validationResult) {
     handleValidationError(INVALID_ATTRIBUTE, validationResult);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/controller/ScimGroupController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/controller/ScimGroupController.java
@@ -73,7 +73,7 @@ public class ScimGroupController extends ScimControllerSupport {
   @Autowired
   ScimGroupProvisioning groupProvisioningService;
 
-  @PreAuthorize("#oauth2.hasScope('scim:read') or hasRole('ADMIN') or #iam.isGroupManager(#id)")
+  @PreAuthorize("#oauth2.hasScope('scim:read') or ((hasRole('ADMIN') or #iam.isGroupManager(#id)) and #iam.isRequestWithoutToken)")
   @RequestMapping(value = "/{id}", method = RequestMethod.GET,
       produces = ScimConstants.SCIM_CONTENT_TYPE)
   public ScimGroup getGroup(@PathVariable final String id) {
@@ -104,7 +104,7 @@ public class ScimGroupController extends ScimControllerSupport {
     return wrapper;
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or hasRole('ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('scim:write') or (#iam.isRequestWithoutToken and hasRole('ADMIN'))")
   @RequestMapping(method = RequestMethod.POST, consumes = ScimConstants.SCIM_CONTENT_TYPE,
       produces = ScimConstants.SCIM_CONTENT_TYPE)
   @ResponseStatus(HttpStatus.CREATED)
@@ -115,7 +115,7 @@ public class ScimGroupController extends ScimControllerSupport {
     return groupProvisioningService.create(group);
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or hasRole('ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('scim:write') or (#iam.isRequestWithoutToken and hasRole('ADMIN'))")
   @RequestMapping(value = "/{id}", method = RequestMethod.PUT,
       consumes = ScimConstants.SCIM_CONTENT_TYPE, produces = ScimConstants.SCIM_CONTENT_TYPE)
   @ResponseStatus(HttpStatus.OK)
@@ -128,7 +128,7 @@ public class ScimGroupController extends ScimControllerSupport {
 
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or hasRole('ADMIN') or #iam.isGroupManager(#id)")
+  @PreAuthorize("#oauth2.hasScope('scim:write') or ((hasRole('ADMIN') or #iam.isGroupManager(#id)) and #iam.isRequestWithoutToken)")
   @RequestMapping(value = "/{id}", method = RequestMethod.PATCH,
       consumes = ScimConstants.SCIM_CONTENT_TYPE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
@@ -141,7 +141,7 @@ public class ScimGroupController extends ScimControllerSupport {
     groupProvisioningService.update(id, groupPatchRequest.getOperations());
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or hasRole('ADMIN') or #iam.isGroupManager(#id)")
+  @PreAuthorize("#oauth2.hasScope('scim:write') or ((hasRole('ADMIN') or #iam.isGroupManager(#id)) and #iam.isRequestWithoutToken)")
   @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
   public void deleteGroup(@PathVariable final String id) {
@@ -150,7 +150,7 @@ public class ScimGroupController extends ScimControllerSupport {
   }
 
 
-  @PreAuthorize("#oauth2.hasScope('scim:read') or hasRole('ADMIN') or #iam.isGroupManager(#id)")
+  @PreAuthorize("#oauth2.hasScope('scim:read') or ((hasRole('ADMIN') or #iam.isGroupManager(#id)) and #iam.isRequestWithoutToken)")
   @RequestMapping(value = "/{id}/members", method = RequestMethod.GET,
       produces = ScimConstants.SCIM_CONTENT_TYPE)
   public ScimListResponse<ScimMemberRef> listMembers(@PathVariable final String id,
@@ -161,7 +161,7 @@ public class ScimGroupController extends ScimControllerSupport {
         buildPageRequest(count, startIndex, SCIM_MEMBERS_MAX_PAGE_SIZE));
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:read') or hasRole('ADMIN') or #iam.isGroupManager(#id)")
+  @PreAuthorize("#oauth2.hasScope('scim:read') or ((hasRole('ADMIN') or #iam.isGroupManager(#id)) and #iam.isRequestWithoutToken)")
   @RequestMapping(value = "/{id}/subgroups", method = RequestMethod.GET,
       produces = ScimConstants.SCIM_CONTENT_TYPE)
   public ScimListResponse<ScimMemberRef> listSubgroups(@PathVariable final String id,

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/controller/ScimGroupController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/controller/ScimGroupController.java
@@ -73,7 +73,7 @@ public class ScimGroupController extends ScimControllerSupport {
   @Autowired
   ScimGroupProvisioning groupProvisioningService;
 
-  @PreAuthorize("#oauth2.hasScope('scim:read') or #iam.isAdminOrGMOfGroup(#id)")
+  @PreAuthorize("#oauth2.hasScope('scim:read') or #iam.hasAdminOrGMDashboardRoleOfGroup(#id)")
   @RequestMapping(value = "/{id}", method = RequestMethod.GET,
       produces = ScimConstants.SCIM_CONTENT_TYPE)
   public ScimGroup getGroup(@PathVariable final String id) {
@@ -81,7 +81,7 @@ public class ScimGroupController extends ScimControllerSupport {
     return groupProvisioningService.getById(id);
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:read') or #iam.isAdmin()")
+  @PreAuthorize("#oauth2.hasScope('scim:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @RequestMapping(method = RequestMethod.GET, produces = ScimConstants.SCIM_CONTENT_TYPE)
   public MappingJacksonValue listGroups(@RequestParam(required = false) final Integer count,
       @RequestParam(required = false) final Integer startIndex,
@@ -104,7 +104,7 @@ public class ScimGroupController extends ScimControllerSupport {
     return wrapper;
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.isAdmin()")
+  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @RequestMapping(method = RequestMethod.POST, consumes = ScimConstants.SCIM_CONTENT_TYPE,
       produces = ScimConstants.SCIM_CONTENT_TYPE)
   @ResponseStatus(HttpStatus.CREATED)
@@ -115,7 +115,7 @@ public class ScimGroupController extends ScimControllerSupport {
     return groupProvisioningService.create(group);
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.isAdmin()")
+  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @RequestMapping(value = "/{id}", method = RequestMethod.PUT,
       consumes = ScimConstants.SCIM_CONTENT_TYPE, produces = ScimConstants.SCIM_CONTENT_TYPE)
   @ResponseStatus(HttpStatus.OK)
@@ -128,7 +128,7 @@ public class ScimGroupController extends ScimControllerSupport {
 
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.isAdminOrGMOfGroup(#id)")
+  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.hasAdminOrGMDashboardRoleOfGroup(#id)")
   @RequestMapping(value = "/{id}", method = RequestMethod.PATCH,
       consumes = ScimConstants.SCIM_CONTENT_TYPE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
@@ -141,7 +141,7 @@ public class ScimGroupController extends ScimControllerSupport {
     groupProvisioningService.update(id, groupPatchRequest.getOperations());
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.isAdminOrGMOfGroup(#id)")
+  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.hasAdminOrGMDashboardRoleOfGroup(#id)")
   @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
   public void deleteGroup(@PathVariable final String id) {
@@ -150,7 +150,7 @@ public class ScimGroupController extends ScimControllerSupport {
   }
 
 
-  @PreAuthorize("#oauth2.hasScope('scim:read') or #iam.isAdminOrGMOfGroup(#id)")
+  @PreAuthorize("#oauth2.hasScope('scim:read') or #iam.hasAdminOrGMDashboardRoleOfGroup(#id)")
   @RequestMapping(value = "/{id}/members", method = RequestMethod.GET,
       produces = ScimConstants.SCIM_CONTENT_TYPE)
   public ScimListResponse<ScimMemberRef> listMembers(@PathVariable final String id,
@@ -161,7 +161,7 @@ public class ScimGroupController extends ScimControllerSupport {
         buildPageRequest(count, startIndex, SCIM_MEMBERS_MAX_PAGE_SIZE));
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:read') or #iam.isAdminOrGMOfGroup(#id)")
+  @PreAuthorize("#oauth2.hasScope('scim:read') or #iam.hasAdminOrGMDashboardRoleOfGroup(#id)")
   @RequestMapping(value = "/{id}/subgroups", method = RequestMethod.GET,
       produces = ScimConstants.SCIM_CONTENT_TYPE)
   public ScimListResponse<ScimMemberRef> listSubgroups(@PathVariable final String id,

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/controller/ScimGroupController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/controller/ScimGroupController.java
@@ -73,7 +73,7 @@ public class ScimGroupController extends ScimControllerSupport {
   @Autowired
   ScimGroupProvisioning groupProvisioningService;
 
-  @PreAuthorize("#oauth2.hasScope('scim:read') or ((hasRole('ADMIN') or #iam.isGroupManager(#id)) and #iam.isRequestWithoutToken)")
+  @PreAuthorize("#oauth2.hasScope('scim:read') or #iam.isAdminOrGMOfGroup(#id)")
   @RequestMapping(value = "/{id}", method = RequestMethod.GET,
       produces = ScimConstants.SCIM_CONTENT_TYPE)
   public ScimGroup getGroup(@PathVariable final String id) {
@@ -81,7 +81,7 @@ public class ScimGroupController extends ScimControllerSupport {
     return groupProvisioningService.getById(id);
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:read') or (#iam.isRequestWithoutToken and hasRole('ADMIN'))")
+  @PreAuthorize("#oauth2.hasScope('scim:read') or #iam.isAdmin()")
   @RequestMapping(method = RequestMethod.GET, produces = ScimConstants.SCIM_CONTENT_TYPE)
   public MappingJacksonValue listGroups(@RequestParam(required = false) final Integer count,
       @RequestParam(required = false) final Integer startIndex,
@@ -104,7 +104,7 @@ public class ScimGroupController extends ScimControllerSupport {
     return wrapper;
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or (#iam.isRequestWithoutToken and hasRole('ADMIN'))")
+  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.isAdmin()")
   @RequestMapping(method = RequestMethod.POST, consumes = ScimConstants.SCIM_CONTENT_TYPE,
       produces = ScimConstants.SCIM_CONTENT_TYPE)
   @ResponseStatus(HttpStatus.CREATED)
@@ -115,7 +115,7 @@ public class ScimGroupController extends ScimControllerSupport {
     return groupProvisioningService.create(group);
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or (#iam.isRequestWithoutToken and hasRole('ADMIN'))")
+  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.isAdmin()")
   @RequestMapping(value = "/{id}", method = RequestMethod.PUT,
       consumes = ScimConstants.SCIM_CONTENT_TYPE, produces = ScimConstants.SCIM_CONTENT_TYPE)
   @ResponseStatus(HttpStatus.OK)
@@ -128,7 +128,7 @@ public class ScimGroupController extends ScimControllerSupport {
 
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or ((hasRole('ADMIN') or #iam.isGroupManager(#id)) and #iam.isRequestWithoutToken)")
+  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.isAdminOrGMOfGroup(#id)")
   @RequestMapping(value = "/{id}", method = RequestMethod.PATCH,
       consumes = ScimConstants.SCIM_CONTENT_TYPE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
@@ -141,7 +141,7 @@ public class ScimGroupController extends ScimControllerSupport {
     groupProvisioningService.update(id, groupPatchRequest.getOperations());
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or ((hasRole('ADMIN') or #iam.isGroupManager(#id)) and #iam.isRequestWithoutToken)")
+  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.isAdminOrGMOfGroup(#id)")
   @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
   public void deleteGroup(@PathVariable final String id) {
@@ -150,7 +150,7 @@ public class ScimGroupController extends ScimControllerSupport {
   }
 
 
-  @PreAuthorize("#oauth2.hasScope('scim:read') or ((hasRole('ADMIN') or #iam.isGroupManager(#id)) and #iam.isRequestWithoutToken)")
+  @PreAuthorize("#oauth2.hasScope('scim:read') or #iam.isAdminOrGMOfGroup(#id)")
   @RequestMapping(value = "/{id}/members", method = RequestMethod.GET,
       produces = ScimConstants.SCIM_CONTENT_TYPE)
   public ScimListResponse<ScimMemberRef> listMembers(@PathVariable final String id,
@@ -161,7 +161,7 @@ public class ScimGroupController extends ScimControllerSupport {
         buildPageRequest(count, startIndex, SCIM_MEMBERS_MAX_PAGE_SIZE));
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:read') or ((hasRole('ADMIN') or #iam.isGroupManager(#id)) and #iam.isRequestWithoutToken)")
+  @PreAuthorize("#oauth2.hasScope('scim:read') or #iam.isAdminOrGMOfGroup(#id)")
   @RequestMapping(value = "/{id}/subgroups", method = RequestMethod.GET,
       produces = ScimConstants.SCIM_CONTENT_TYPE)
   public ScimListResponse<ScimMemberRef> listSubgroups(@PathVariable final String id,

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/controller/ScimGroupController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/controller/ScimGroupController.java
@@ -81,7 +81,7 @@ public class ScimGroupController extends ScimControllerSupport {
     return groupProvisioningService.getById(id);
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:read') or hasRole('ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('scim:read') or (#iam.isRequestWithoutToken and hasRole('ADMIN'))")
   @RequestMapping(method = RequestMethod.GET, produces = ScimConstants.SCIM_CONTENT_TYPE)
   public MappingJacksonValue listGroups(@RequestParam(required = false) final Integer count,
       @RequestParam(required = false) final Integer startIndex,

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/controller/ScimUserController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/controller/ScimUserController.java
@@ -75,7 +75,7 @@ public class ScimUserController extends ScimControllerSupport{
     return result;
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:read') or hasRole('ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('scim:read') or (#iam.isRequestWithoutToken and hasRole('ADMIN'))")
   @RequestMapping(method = RequestMethod.GET, produces = ScimConstants.SCIM_CONTENT_TYPE)
   public MappingJacksonValue listUsers(@RequestParam(required = false) final Integer count,
       @RequestParam(required = false) final Integer startIndex,
@@ -98,7 +98,7 @@ public class ScimUserController extends ScimControllerSupport{
     return wrapper;
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:read') or hasRole('ADMIN') or #iam.isAGroupManager()")
+  @PreAuthorize("#oauth2.hasScope('scim:read') or ((hasRole('ADMIN') or #iam.isAGroupManager()) and #iam.isRequestWithoutToken)")
   @RequestMapping(value = "/{id}", method = RequestMethod.GET,
       produces = ScimConstants.SCIM_CONTENT_TYPE)
   public ScimUser getUser(@PathVariable final String id) {
@@ -106,7 +106,7 @@ public class ScimUserController extends ScimControllerSupport{
     return userProvisioningService.getById(id);
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or hasRole('ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('scim:write') or (#iam.isRequestWithoutToken and hasRole('ADMIN'))")
   @RequestMapping(method = RequestMethod.POST, consumes = ScimConstants.SCIM_CONTENT_TYPE,
       produces = ScimConstants.SCIM_CONTENT_TYPE)
   @ResponseStatus(HttpStatus.CREATED)
@@ -120,7 +120,7 @@ public class ScimUserController extends ScimControllerSupport{
     return new MappingJacksonValue(result);
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or hasRole('ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('scim:write') or (#iam.isRequestWithoutToken and hasRole('ADMIN'))")
   @RequestMapping(value = "/{id}", method = RequestMethod.PUT,
       consumes = ScimConstants.SCIM_CONTENT_TYPE, produces = ScimConstants.SCIM_CONTENT_TYPE)
   @ResponseStatus(HttpStatus.OK)
@@ -134,7 +134,7 @@ public class ScimUserController extends ScimControllerSupport{
 
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or hasRole('ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('scim:write') or (#iam.isRequestWithoutToken and hasRole('ADMIN'))")
   @RequestMapping(value = "/{id}", method = RequestMethod.PATCH,
       consumes = ScimConstants.SCIM_CONTENT_TYPE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
@@ -148,7 +148,7 @@ public class ScimUserController extends ScimControllerSupport{
 
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or hasRole('ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('scim:write') or (#iam.isRequestWithoutToken and hasRole('ADMIN'))")
   @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
   public void deleteUser(@PathVariable final String id) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/controller/ScimUserController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/controller/ScimUserController.java
@@ -75,7 +75,7 @@ public class ScimUserController extends ScimControllerSupport {
     return result;
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:read') or #iam.isAdmin()")
+  @PreAuthorize("#oauth2.hasScope('scim:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @RequestMapping(method = RequestMethod.GET, produces = ScimConstants.SCIM_CONTENT_TYPE)
   public MappingJacksonValue listUsers(@RequestParam(required = false) final Integer count,
       @RequestParam(required = false) final Integer startIndex,
@@ -98,7 +98,7 @@ public class ScimUserController extends ScimControllerSupport {
     return wrapper;
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:read') or #iam.isAdminOrGM()")
+  @PreAuthorize("#oauth2.hasScope('scim:read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM')")
   @RequestMapping(value = "/{id}", method = RequestMethod.GET,
       produces = ScimConstants.SCIM_CONTENT_TYPE)
   public ScimUser getUser(@PathVariable final String id) {
@@ -106,7 +106,7 @@ public class ScimUserController extends ScimControllerSupport {
     return userProvisioningService.getById(id);
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.isAdmin()")
+  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @RequestMapping(method = RequestMethod.POST, consumes = ScimConstants.SCIM_CONTENT_TYPE,
       produces = ScimConstants.SCIM_CONTENT_TYPE)
   @ResponseStatus(HttpStatus.CREATED)
@@ -120,7 +120,7 @@ public class ScimUserController extends ScimControllerSupport {
     return new MappingJacksonValue(result);
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.isAdmin()")
+  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @RequestMapping(value = "/{id}", method = RequestMethod.PUT,
       consumes = ScimConstants.SCIM_CONTENT_TYPE, produces = ScimConstants.SCIM_CONTENT_TYPE)
   @ResponseStatus(HttpStatus.OK)
@@ -134,7 +134,7 @@ public class ScimUserController extends ScimControllerSupport {
 
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.isAdmin()")
+  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @RequestMapping(value = "/{id}", method = RequestMethod.PATCH,
       consumes = ScimConstants.SCIM_CONTENT_TYPE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
@@ -148,7 +148,7 @@ public class ScimUserController extends ScimControllerSupport {
 
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.isAdmin()")
+  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
   public void deleteUser(@PathVariable final String id) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/controller/ScimUserController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/controller/ScimUserController.java
@@ -53,7 +53,7 @@ import it.infn.mw.iam.api.scim.provisioning.paging.ScimPageRequest;
 @RestController
 @RequestMapping("/scim/Users")
 @Transactional
-public class ScimUserController extends ScimControllerSupport{
+public class ScimUserController extends ScimControllerSupport {
 
   @Autowired
   ScimUserProvisioning userProvisioningService;
@@ -75,7 +75,7 @@ public class ScimUserController extends ScimControllerSupport{
     return result;
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:read') or (#iam.isRequestWithoutToken and hasRole('ADMIN'))")
+  @PreAuthorize("#oauth2.hasScope('scim:read') or #iam.isAdmin()")
   @RequestMapping(method = RequestMethod.GET, produces = ScimConstants.SCIM_CONTENT_TYPE)
   public MappingJacksonValue listUsers(@RequestParam(required = false) final Integer count,
       @RequestParam(required = false) final Integer startIndex,
@@ -98,7 +98,7 @@ public class ScimUserController extends ScimControllerSupport{
     return wrapper;
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:read') or ((hasRole('ADMIN') or #iam.isAGroupManager()) and #iam.isRequestWithoutToken)")
+  @PreAuthorize("#oauth2.hasScope('scim:read') or #iam.isAdminOrGM()")
   @RequestMapping(value = "/{id}", method = RequestMethod.GET,
       produces = ScimConstants.SCIM_CONTENT_TYPE)
   public ScimUser getUser(@PathVariable final String id) {
@@ -106,7 +106,7 @@ public class ScimUserController extends ScimControllerSupport{
     return userProvisioningService.getById(id);
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or (#iam.isRequestWithoutToken and hasRole('ADMIN'))")
+  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.isAdmin()")
   @RequestMapping(method = RequestMethod.POST, consumes = ScimConstants.SCIM_CONTENT_TYPE,
       produces = ScimConstants.SCIM_CONTENT_TYPE)
   @ResponseStatus(HttpStatus.CREATED)
@@ -120,7 +120,7 @@ public class ScimUserController extends ScimControllerSupport{
     return new MappingJacksonValue(result);
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or (#iam.isRequestWithoutToken and hasRole('ADMIN'))")
+  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.isAdmin()")
   @RequestMapping(value = "/{id}", method = RequestMethod.PUT,
       consumes = ScimConstants.SCIM_CONTENT_TYPE, produces = ScimConstants.SCIM_CONTENT_TYPE)
   @ResponseStatus(HttpStatus.OK)
@@ -134,7 +134,7 @@ public class ScimUserController extends ScimControllerSupport{
 
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or (#iam.isRequestWithoutToken and hasRole('ADMIN'))")
+  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.isAdmin()")
   @RequestMapping(value = "/{id}", method = RequestMethod.PATCH,
       consumes = ScimConstants.SCIM_CONTENT_TYPE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
@@ -148,7 +148,7 @@ public class ScimUserController extends ScimControllerSupport{
 
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or (#iam.isRequestWithoutToken and hasRole('ADMIN'))")
+  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.isAdmin()")
   @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
   public void deleteUser(@PathVariable final String id) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scope_policy/ScopePolicyController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scope_policy/ScopePolicyController.java
@@ -55,7 +55,7 @@ public class ScopePolicyController {
   }
 
   @RequestMapping(value = "/iam/scope_policies", method = RequestMethod.GET)
-  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public List<ScopePolicyDTO> listScopePolicies() {
 
     Iterable<IamScopePolicy> policies = policyService.findAllScopePolicies();
@@ -70,7 +70,7 @@ public class ScopePolicyController {
 
   @RequestMapping(value = "/iam/scope_policies", method = RequestMethod.POST)
   @ResponseStatus(code = HttpStatus.CREATED)
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void addScopePolicy(@Valid @RequestBody ScopePolicyDTO policy,
       BindingResult validationResult) {
 
@@ -83,7 +83,7 @@ public class ScopePolicyController {
 
 
   @RequestMapping(value = "/iam/scope_policies/{id}", method = RequestMethod.GET)
-  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public ScopePolicyDTO getScopePolicy(@PathVariable Long id) {
 
     IamScopePolicy p = policyService.findScopePolicyById(id)
@@ -95,7 +95,7 @@ public class ScopePolicyController {
 
   @RequestMapping(value = "/iam/scope_policies/{id}", method = RequestMethod.PUT)
   @ResponseStatus(code = HttpStatus.NO_CONTENT)
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void updateScopePolicy(@PathVariable Long id,
       @Valid @RequestBody ScopePolicyDTO policy, BindingResult validationResult) {
 
@@ -110,7 +110,7 @@ public class ScopePolicyController {
 
   @RequestMapping(value = "/iam/scope_policies/{id}", method = RequestMethod.DELETE)
   @ResponseStatus(code = HttpStatus.NO_CONTENT)
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void deleteScopePolicy(@PathVariable Long id) {
 
     policyService.deleteScopePolicyById(id);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scope_policy/ScopePolicyController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scope_policy/ScopePolicyController.java
@@ -40,7 +40,6 @@ import it.infn.mw.iam.persistence.model.IamScopePolicy;
 
 
 @RestController
-@PreAuthorize("hasRole('ADMIN')")
 public class ScopePolicyController {
 
   private static final Logger LOG = LoggerFactory.getLogger(ScopePolicyController.class);
@@ -56,6 +55,7 @@ public class ScopePolicyController {
   }
 
   @RequestMapping(value = "/iam/scope_policies", method = RequestMethod.GET)
+  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public List<ScopePolicyDTO> listScopePolicies() {
 
     Iterable<IamScopePolicy> policies = policyService.findAllScopePolicies();
@@ -70,6 +70,7 @@ public class ScopePolicyController {
 
   @RequestMapping(value = "/iam/scope_policies", method = RequestMethod.POST)
   @ResponseStatus(code = HttpStatus.CREATED)
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void addScopePolicy(@Valid @RequestBody ScopePolicyDTO policy,
       BindingResult validationResult) {
 
@@ -82,6 +83,7 @@ public class ScopePolicyController {
 
 
   @RequestMapping(value = "/iam/scope_policies/{id}", method = RequestMethod.GET)
+  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public ScopePolicyDTO getScopePolicy(@PathVariable Long id) {
 
     IamScopePolicy p = policyService.findScopePolicyById(id)
@@ -93,6 +95,7 @@ public class ScopePolicyController {
 
   @RequestMapping(value = "/iam/scope_policies/{id}", method = RequestMethod.PUT)
   @ResponseStatus(code = HttpStatus.NO_CONTENT)
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void updateScopePolicy(@PathVariable Long id,
       @Valid @RequestBody ScopePolicyDTO policy, BindingResult validationResult) {
 
@@ -107,6 +110,7 @@ public class ScopePolicyController {
 
   @RequestMapping(value = "/iam/scope_policies/{id}", method = RequestMethod.DELETE)
   @ResponseStatus(code = HttpStatus.NO_CONTENT)
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void deleteScopePolicy(@PathVariable Long id) {
 
     policyService.deleteScopePolicyById(id);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scope_policy/ScopePolicyController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scope_policy/ScopePolicyController.java
@@ -55,7 +55,7 @@ public class ScopePolicyController {
   }
 
   @RequestMapping(value = "/iam/scope_policies", method = RequestMethod.GET)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public List<ScopePolicyDTO> listScopePolicies() {
 
     Iterable<IamScopePolicy> policies = policyService.findAllScopePolicies();
@@ -70,7 +70,7 @@ public class ScopePolicyController {
 
   @RequestMapping(value = "/iam/scope_policies", method = RequestMethod.POST)
   @ResponseStatus(code = HttpStatus.CREATED)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void addScopePolicy(@Valid @RequestBody ScopePolicyDTO policy,
       BindingResult validationResult) {
 
@@ -83,7 +83,7 @@ public class ScopePolicyController {
 
 
   @RequestMapping(value = "/iam/scope_policies/{id}", method = RequestMethod.GET)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public ScopePolicyDTO getScopePolicy(@PathVariable Long id) {
 
     IamScopePolicy p = policyService.findScopePolicyById(id)
@@ -95,7 +95,7 @@ public class ScopePolicyController {
 
   @RequestMapping(value = "/iam/scope_policies/{id}", method = RequestMethod.PUT)
   @ResponseStatus(code = HttpStatus.NO_CONTENT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void updateScopePolicy(@PathVariable Long id,
       @Valid @RequestBody ScopePolicyDTO policy, BindingResult validationResult) {
 
@@ -110,7 +110,7 @@ public class ScopePolicyController {
 
   @RequestMapping(value = "/iam/scope_policies/{id}", method = RequestMethod.DELETE)
   @ResponseStatus(code = HttpStatus.NO_CONTENT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void deleteScopePolicy(@PathVariable Long id) {
 
     policyService.deleteScopePolicyById(id);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/tokens/AccessTokensController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/tokens/AccessTokensController.java
@@ -49,7 +49,7 @@ public class AccessTokensController extends TokensControllerSupport {
   private TokenService<AccessToken> tokenService;
 
   @RequestMapping(method = RequestMethod.GET, produces = APPLICATION_JSON_CONTENT_TYPE)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public MappingJacksonValue listAccessTokens(@RequestParam(required = false) Integer count,
       @RequestParam(required = false) Integer startIndex,
       @RequestParam(required = false) String userId,
@@ -63,7 +63,7 @@ public class AccessTokensController extends TokensControllerSupport {
   
   @RequestMapping(method = RequestMethod.DELETE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void deleteAllTokens() {
     tokenService.deleteAllTokens();
   }
@@ -87,7 +87,7 @@ public class AccessTokensController extends TokensControllerSupport {
   }
 
   @RequestMapping(method = RequestMethod.GET, value = "/{id}", produces = APPLICATION_JSON_CONTENT_TYPE)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public AccessToken getAccessToken(@PathVariable("id") Long id) {
 
     return tokenService.getTokenById(id);
@@ -95,7 +95,7 @@ public class AccessTokensController extends TokensControllerSupport {
 
   @RequestMapping(method = RequestMethod.DELETE, value = "/{id}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void revokeAccessToken(@PathVariable("id") Long id) {
 
     tokenService.revokeTokenById(id);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/tokens/AccessTokensController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/tokens/AccessTokensController.java
@@ -42,7 +42,6 @@ import it.infn.mw.iam.core.user.exception.IamAccountException;
 
 @RestController
 @Transactional
-@PreAuthorize("hasRole('ADMIN')")
 @RequestMapping(ACCESS_TOKENS_ENDPOINT)
 public class AccessTokensController extends TokensControllerSupport {
 
@@ -50,6 +49,7 @@ public class AccessTokensController extends TokensControllerSupport {
   private TokenService<AccessToken> tokenService;
 
   @RequestMapping(method = RequestMethod.GET, produces = APPLICATION_JSON_CONTENT_TYPE)
+  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public MappingJacksonValue listAccessTokens(@RequestParam(required = false) Integer count,
       @RequestParam(required = false) Integer startIndex,
       @RequestParam(required = false) String userId,
@@ -63,6 +63,7 @@ public class AccessTokensController extends TokensControllerSupport {
   
   @RequestMapping(method = RequestMethod.DELETE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void deleteAllTokens() {
     tokenService.deleteAllTokens();
   }
@@ -86,6 +87,7 @@ public class AccessTokensController extends TokensControllerSupport {
   }
 
   @RequestMapping(method = RequestMethod.GET, value = "/{id}", produces = APPLICATION_JSON_CONTENT_TYPE)
+  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public AccessToken getAccessToken(@PathVariable("id") Long id) {
 
     return tokenService.getTokenById(id);
@@ -93,6 +95,7 @@ public class AccessTokensController extends TokensControllerSupport {
 
   @RequestMapping(method = RequestMethod.DELETE, value = "/{id}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void revokeAccessToken(@PathVariable("id") Long id) {
 
     tokenService.revokeTokenById(id);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/tokens/AccessTokensController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/tokens/AccessTokensController.java
@@ -49,7 +49,7 @@ public class AccessTokensController extends TokensControllerSupport {
   private TokenService<AccessToken> tokenService;
 
   @RequestMapping(method = RequestMethod.GET, produces = APPLICATION_JSON_CONTENT_TYPE)
-  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public MappingJacksonValue listAccessTokens(@RequestParam(required = false) Integer count,
       @RequestParam(required = false) Integer startIndex,
       @RequestParam(required = false) String userId,
@@ -63,7 +63,7 @@ public class AccessTokensController extends TokensControllerSupport {
   
   @RequestMapping(method = RequestMethod.DELETE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void deleteAllTokens() {
     tokenService.deleteAllTokens();
   }
@@ -87,7 +87,7 @@ public class AccessTokensController extends TokensControllerSupport {
   }
 
   @RequestMapping(method = RequestMethod.GET, value = "/{id}", produces = APPLICATION_JSON_CONTENT_TYPE)
-  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public AccessToken getAccessToken(@PathVariable("id") Long id) {
 
     return tokenService.getTokenById(id);
@@ -95,7 +95,7 @@ public class AccessTokensController extends TokensControllerSupport {
 
   @RequestMapping(method = RequestMethod.DELETE, value = "/{id}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void revokeAccessToken(@PathVariable("id") Long id) {
 
     tokenService.revokeTokenById(id);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/tokens/RefreshTokensController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/tokens/RefreshTokensController.java
@@ -49,7 +49,7 @@ public class RefreshTokensController extends TokensControllerSupport {
   private TokenService<RefreshToken> tokenService;
 
   @RequestMapping(method = RequestMethod.GET, produces = APPLICATION_JSON_CONTENT_TYPE)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public MappingJacksonValue lisRefreshTokens(@RequestParam(required = false) Integer count,
       @RequestParam(required = false) Integer startIndex,
       @RequestParam(required = false) String userId,
@@ -63,7 +63,7 @@ public class RefreshTokensController extends TokensControllerSupport {
   
   @RequestMapping(method = RequestMethod.DELETE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void deleteAllTokens() {
     tokenService.deleteAllTokens();
   }
@@ -87,7 +87,7 @@ public class RefreshTokensController extends TokensControllerSupport {
   }
 
   @RequestMapping(method = RequestMethod.GET, value = "/{id}", produces = APPLICATION_JSON_CONTENT_TYPE)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public RefreshToken getRefreshToken(@PathVariable("id") Long id) {
 
     return tokenService.getTokenById(id);
@@ -95,7 +95,7 @@ public class RefreshTokensController extends TokensControllerSupport {
 
   @RequestMapping(method = RequestMethod.DELETE, value = "/{id}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void revokeRefreshToken(@PathVariable("id") Long id) {
 
     tokenService.revokeTokenById(id);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/tokens/RefreshTokensController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/tokens/RefreshTokensController.java
@@ -42,7 +42,6 @@ import it.infn.mw.iam.core.user.exception.IamAccountException;
 
 @RestController
 @Transactional
-@PreAuthorize("hasRole('ADMIN')")
 @RequestMapping(REFRESH_TOKENS_ENDPOINT)
 public class RefreshTokensController extends TokensControllerSupport {
 
@@ -50,6 +49,7 @@ public class RefreshTokensController extends TokensControllerSupport {
   private TokenService<RefreshToken> tokenService;
 
   @RequestMapping(method = RequestMethod.GET, produces = APPLICATION_JSON_CONTENT_TYPE)
+  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public MappingJacksonValue lisRefreshTokens(@RequestParam(required = false) Integer count,
       @RequestParam(required = false) Integer startIndex,
       @RequestParam(required = false) String userId,
@@ -63,6 +63,7 @@ public class RefreshTokensController extends TokensControllerSupport {
   
   @RequestMapping(method = RequestMethod.DELETE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void deleteAllTokens() {
     tokenService.deleteAllTokens();
   }
@@ -86,6 +87,7 @@ public class RefreshTokensController extends TokensControllerSupport {
   }
 
   @RequestMapping(method = RequestMethod.GET, value = "/{id}", produces = APPLICATION_JSON_CONTENT_TYPE)
+  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public RefreshToken getRefreshToken(@PathVariable("id") Long id) {
 
     return tokenService.getTokenById(id);
@@ -93,6 +95,7 @@ public class RefreshTokensController extends TokensControllerSupport {
 
   @RequestMapping(method = RequestMethod.DELETE, value = "/{id}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
+  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void revokeRefreshToken(@PathVariable("id") Long id) {
 
     tokenService.revokeTokenById(id);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/tokens/RefreshTokensController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/tokens/RefreshTokensController.java
@@ -49,7 +49,7 @@ public class RefreshTokensController extends TokensControllerSupport {
   private TokenService<RefreshToken> tokenService;
 
   @RequestMapping(method = RequestMethod.GET, produces = APPLICATION_JSON_CONTENT_TYPE)
-  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public MappingJacksonValue lisRefreshTokens(@RequestParam(required = false) Integer count,
       @RequestParam(required = false) Integer startIndex,
       @RequestParam(required = false) String userId,
@@ -63,7 +63,7 @@ public class RefreshTokensController extends TokensControllerSupport {
   
   @RequestMapping(method = RequestMethod.DELETE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void deleteAllTokens() {
     tokenService.deleteAllTokens();
   }
@@ -87,7 +87,7 @@ public class RefreshTokensController extends TokensControllerSupport {
   }
 
   @RequestMapping(method = RequestMethod.GET, value = "/{id}", produces = APPLICATION_JSON_CONTENT_TYPE)
-  @PreAuthorize("#oauth2.hasScope('admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public RefreshToken getRefreshToken(@PathVariable("id") Long id) {
 
     return tokenService.getTokenById(id);
@@ -95,7 +95,7 @@ public class RefreshTokensController extends TokensControllerSupport {
 
   @RequestMapping(method = RequestMethod.DELETE, value = "/{id}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
-  @PreAuthorize("#oauth2.hasScope('admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#oauth2.hasScope('iam:admin:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void revokeRefreshToken(@PathVariable("id") Long id) {
 
     tokenService.revokeTokenById(id);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/expression/IamSecurityExpressionMethods.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/expression/IamSecurityExpressionMethods.java
@@ -84,6 +84,12 @@ public class IamSecurityExpressionMethods {
       .anyMatch(a -> a.getAuthority().startsWith(ROLE_GM));
   }
 
+  public boolean isGMOfGroup(String groupUuid) {
+    return authentication.getAuthorities()
+      .stream()
+      .anyMatch(a -> a.getAuthority().equals(ROLE_GM + groupUuid));
+  }
+
   public boolean isUser(String userUuid) {
     Optional<IamAccount> account = accountUtils.getAuthenticatedUserAccount();
     return account.isPresent() && account.get().getUuid().equals(userUuid);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/expression/IamSecurityExpressionMethods.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/expression/IamSecurityExpressionMethods.java
@@ -37,6 +37,8 @@ import it.infn.mw.iam.persistence.model.IamGroupRequest;
 @SuppressWarnings("deprecation")
 public class IamSecurityExpressionMethods {
 
+  private static final String ROLE_GM = "ROLE_GM:";
+
   private final Authentication authentication;
   private final AccountUtils accountUtils;
   private final GroupRequestUtils groupRequestUtils;
@@ -65,21 +67,21 @@ public class IamSecurityExpressionMethods {
   public boolean isAGroupManager() {
     boolean gm = authentication.getAuthorities()
       .stream()
-      .anyMatch(a -> a.getAuthority().startsWith("ROLE_GM:"));
+      .anyMatch(a -> a.getAuthority().startsWith(ROLE_GM));
     return (gm && isRequestWithoutToken());
   }
 
   public boolean isGroupManager(String groupUuid) {
     boolean groupManager = authentication.getAuthorities()
       .stream()
-      .anyMatch(a -> a.getAuthority().equals("ROLE_GM:" + groupUuid));
+      .anyMatch(a -> a.getAuthority().equals(ROLE_GM + groupUuid));
     return (groupManager && isRequestWithoutToken());
   }
 
   public boolean isGroupManager() {
     return authentication.getAuthorities()
       .stream()
-      .anyMatch(a -> a.getAuthority().startsWith("ROLE_GM:"));
+      .anyMatch(a -> a.getAuthority().startsWith(ROLE_GM));
   }
 
   public boolean isUser(String userUuid) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/expression/IamSecurityExpressionMethods.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/expression/IamSecurityExpressionMethods.java
@@ -120,9 +120,6 @@ public class IamSecurityExpressionMethods {
 
   public boolean isRequestWithoutToken() {
 
-    if (!(authentication instanceof OAuth2Authentication)) {
-      return true;
-    }
-    return false;
+    return !(authentication instanceof OAuth2Authentication);
   }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/expression/IamSecurityExpressionMethods.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/expression/IamSecurityExpressionMethods.java
@@ -117,4 +117,12 @@ public class IamSecurityExpressionMethods {
     } else
       return false;
   }
+
+  public boolean isRequestWithoutToken() {
+
+    if (!(authentication instanceof OAuth2Authentication)) {
+      return true;
+    }
+    return false;
+  }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/expression/IamSecurityExpressionMethods.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/expression/IamSecurityExpressionMethods.java
@@ -76,6 +76,12 @@ public class IamSecurityExpressionMethods {
     return (groupManager && isRequestWithoutToken());
   }
 
+  public boolean isGroupManager() {
+    return authentication.getAuthorities()
+      .stream()
+      .anyMatch(a -> a.getAuthority().startsWith("ROLE_GM:"));
+  }
+
   public boolean isUser(String userUuid) {
     Optional<IamAccount> account = accountUtils.getAuthenticatedUserAccount();
     return account.isPresent() && account.get().getUuid().equals(userUuid);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/expression/IamSecurityExpressionMethods.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/expression/IamSecurityExpressionMethods.java
@@ -63,15 +63,17 @@ public class IamSecurityExpressionMethods {
   }
 
   public boolean isAGroupManager() {
-    return authentication.getAuthorities()
+    boolean gm = authentication.getAuthorities()
       .stream()
       .anyMatch(a -> a.getAuthority().startsWith("ROLE_GM:"));
+    return (gm && isRequestWithoutToken());
   }
 
   public boolean isGroupManager(String groupUuid) {
-    return authentication.getAuthorities()
+    boolean group_manager = authentication.getAuthorities()
       .stream()
       .anyMatch(a -> a.getAuthority().equals("ROLE_GM:" + groupUuid));
+    return (group_manager && isRequestWithoutToken());
   }
 
   public boolean isUser(String userUuid) {
@@ -122,4 +124,21 @@ public class IamSecurityExpressionMethods {
 
     return !(authentication instanceof OAuth2Authentication);
   }
+
+  public boolean isAdmin() {
+
+    boolean admin = authentication.getAuthorities()
+      .stream()
+      .anyMatch(a -> a.getAuthority().startsWith("ROLE_ADMIN"));
+    return (admin && isRequestWithoutToken());
+  }
+
+  public boolean isAdminOrGM() {
+    return (isAdmin() || isAGroupManager());
+  }
+
+  public boolean isAdminOrGMOfGroup(String gid) {
+    return (isAdmin() || isGroupManager(gid));
+  }
+
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/expression/IamSecurityExpressionMethods.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/expression/IamSecurityExpressionMethods.java
@@ -70,10 +70,10 @@ public class IamSecurityExpressionMethods {
   }
 
   public boolean isGroupManager(String groupUuid) {
-    boolean group_manager = authentication.getAuthorities()
+    boolean groupManager = authentication.getAuthorities()
       .stream()
       .anyMatch(a -> a.getAuthority().equals("ROLE_GM:" + groupUuid));
-    return (group_manager && isRequestWithoutToken());
+    return (groupManager && isRequestWithoutToken());
   }
 
   public boolean isUser(String userUuid) {

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/attributes/AccountAttributesTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/attributes/AccountAttributesTests.java
@@ -248,11 +248,11 @@ public class AccountAttributesTests {
       .andExpect(FORBIDDEN)
       .andExpect(jsonPath("$.error", equalTo("insufficient_scope")))
       .andExpect(jsonPath("$.error_description", equalTo("Insufficient scope for this resource")))
-      .andExpect(jsonPath("$.scope", equalTo("iam:admin:write")));
+      .andExpect(jsonPath("$.scope", equalTo("iam:admin.write")));
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "iam:admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "iam:admin.write")
   public void setAttributeWorksWithCorrectScope() throws Exception {
 
     IamAccount testAccount =
@@ -316,7 +316,7 @@ public class AccountAttributesTests {
       .andExpect(FORBIDDEN)
       .andExpect(jsonPath("$.error", equalTo("insufficient_scope")))
       .andExpect(jsonPath("$.error_description", equalTo("Insufficient scope for this resource")))
-      .andExpect(jsonPath("$.scope", equalTo("iam:admin:write")));
+      .andExpect(jsonPath("$.scope", equalTo("iam:admin.write")));
   }
 
   @Test

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/attributes/AccountAttributesTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/attributes/AccountAttributesTests.java
@@ -248,11 +248,11 @@ public class AccountAttributesTests {
       .andExpect(FORBIDDEN)
       .andExpect(jsonPath("$.error", equalTo("insufficient_scope")))
       .andExpect(jsonPath("$.error_description", equalTo("Insufficient scope for this resource")))
-      .andExpect(jsonPath("$.scope", equalTo("admin:write")));
+      .andExpect(jsonPath("$.scope", equalTo("iam:admin:write")));
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "iam:admin:write")
   public void setAttributeWorksWithCorrectScope() throws Exception {
 
     IamAccount testAccount =
@@ -316,7 +316,7 @@ public class AccountAttributesTests {
       .andExpect(FORBIDDEN)
       .andExpect(jsonPath("$.error", equalTo("insufficient_scope")))
       .andExpect(jsonPath("$.error_description", equalTo("Insufficient scope for this resource")))
-      .andExpect(jsonPath("$.scope", equalTo("admin:write")));
+      .andExpect(jsonPath("$.scope", equalTo("iam:admin:write")));
   }
 
   @Test

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/attributes/AccountAttributesTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/attributes/AccountAttributesTests.java
@@ -248,11 +248,11 @@ public class AccountAttributesTests {
       .andExpect(FORBIDDEN)
       .andExpect(jsonPath("$.error", equalTo("insufficient_scope")))
       .andExpect(jsonPath("$.error_description", equalTo("Insufficient scope for this resource")))
-      .andExpect(jsonPath("$.scope", equalTo("account:write")));
+      .andExpect(jsonPath("$.scope", equalTo("admin:write")));
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "account:write")
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "admin:write")
   public void setAttributeWorksWithCorrectScope() throws Exception {
 
     IamAccount testAccount =
@@ -269,26 +269,6 @@ public class AccountAttributesTests {
       .perform(put(ACCOUNT_ATTR_URL_TEMPLATE, UUID).contentType(APPLICATION_JSON)
         .content(mapper.writeValueAsString(attr)))
       .andExpect(OK);
-
-    mvc.perform(get(ACCOUNT_ATTR_URL_TEMPLATE, UUID))
-      .andExpect(OK)
-      .andExpect(jsonPath("$").isArray())
-      .andExpect(jsonPath("$[0].name", is(ATTR_NAME)))
-      .andExpect(jsonPath("$[0].value", is(ATTR_VALUE)));
-
-    attr.setValue(null);
-
-    mvc
-      .perform(put(ACCOUNT_ATTR_URL_TEMPLATE, UUID).contentType(APPLICATION_JSON)
-        .content(mapper.writeValueAsString(attr)))
-      .andExpect(OK);
-
-    mvc.perform(get(ACCOUNT_ATTR_URL_TEMPLATE, UUID))
-      .andExpect(OK)
-      .andExpect(jsonPath("$").isArray())
-      .andExpect(jsonPath("$", hasSize(1)))
-      .andExpect(jsonPath("$[0].name", is(ATTR_NAME)))
-      .andExpect(jsonPath("$[0].value", nullValue()));
   }
 
   @Test
@@ -336,7 +316,7 @@ public class AccountAttributesTests {
       .andExpect(FORBIDDEN)
       .andExpect(jsonPath("$.error", equalTo("insufficient_scope")))
       .andExpect(jsonPath("$.error_description", equalTo("Insufficient scope for this resource")))
-      .andExpect(jsonPath("$.scope", equalTo("account:write")));
+      .andExpect(jsonPath("$.scope", equalTo("admin:write")));
   }
 
   @Test

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/attributes/AccountAttributesTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/attributes/AccountAttributesTests.java
@@ -18,6 +18,7 @@ package it.infn.mw.iam.test.api.account.attributes;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -52,6 +53,7 @@ import it.infn.mw.iam.api.common.AttributeDTO;
 import it.infn.mw.iam.persistence.model.IamAccount;
 import it.infn.mw.iam.persistence.repository.IamAccountRepository;
 import it.infn.mw.iam.test.util.WithAnonymousUser;
+import it.infn.mw.iam.test.util.WithMockOAuthUser;
 import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
 import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 
@@ -227,6 +229,69 @@ public class AccountAttributesTests {
   }
 
   @Test
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN")
+  public void setAttributeDoesNotWork() throws Exception {
+
+    IamAccount testAccount =
+        repo.findByUsername(TEST_USER).orElseThrow(assertionError(EXPECTED_USER_NOT_FOUND));
+
+    final String UUID = testAccount.getUuid();
+
+    AttributeDTO attr = new AttributeDTO();
+
+    attr.setName(ATTR_NAME);
+    attr.setValue(ATTR_VALUE);
+
+    mvc
+      .perform(put(ACCOUNT_ATTR_URL_TEMPLATE, UUID).contentType(APPLICATION_JSON)
+        .content(mapper.writeValueAsString(attr)))
+      .andExpect(FORBIDDEN)
+      .andExpect(jsonPath("$.error", equalTo("insufficient_scope")))
+      .andExpect(jsonPath("$.error_description", equalTo("Insufficient scope for this resource")))
+      .andExpect(jsonPath("$.scope", equalTo("account:write")));
+  }
+
+  @Test
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "account:write")
+  public void setAttributeWorksWithCorrectScope() throws Exception {
+
+    IamAccount testAccount =
+        repo.findByUsername(TEST_USER).orElseThrow(assertionError(EXPECTED_USER_NOT_FOUND));
+
+    final String UUID = testAccount.getUuid();
+
+    AttributeDTO attr = new AttributeDTO();
+
+    attr.setName(ATTR_NAME);
+    attr.setValue(ATTR_VALUE);
+
+    mvc
+      .perform(put(ACCOUNT_ATTR_URL_TEMPLATE, UUID).contentType(APPLICATION_JSON)
+        .content(mapper.writeValueAsString(attr)))
+      .andExpect(OK);
+
+    mvc.perform(get(ACCOUNT_ATTR_URL_TEMPLATE, UUID))
+      .andExpect(OK)
+      .andExpect(jsonPath("$").isArray())
+      .andExpect(jsonPath("$[0].name", is(ATTR_NAME)))
+      .andExpect(jsonPath("$[0].value", is(ATTR_VALUE)));
+
+    attr.setValue(null);
+
+    mvc
+      .perform(put(ACCOUNT_ATTR_URL_TEMPLATE, UUID).contentType(APPLICATION_JSON)
+        .content(mapper.writeValueAsString(attr)))
+      .andExpect(OK);
+
+    mvc.perform(get(ACCOUNT_ATTR_URL_TEMPLATE, UUID))
+      .andExpect(OK)
+      .andExpect(jsonPath("$").isArray())
+      .andExpect(jsonPath("$", hasSize(1)))
+      .andExpect(jsonPath("$[0].name", is(ATTR_NAME)))
+      .andExpect(jsonPath("$[0].value", nullValue()));
+  }
+
+  @Test
   @WithMockUser(username = "admin", roles = "ADMIN")
   public void deleteAttributeWorks() throws Exception {
     IamAccount testAccount =
@@ -250,6 +315,28 @@ public class AccountAttributesTests {
     // A delete succeeds even if the attribute isn't there
     mvc.perform(delete(ACCOUNT_ATTR_URL_TEMPLATE, UUID).param("name", ATTR_NAME))
       .andExpect(NO_CONTENT);
+  }
+
+  @Test
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN")
+  public void deleteAttributeDoesNotWork() throws Exception {
+    IamAccount testAccount =
+        repo.findByUsername(TEST_USER).orElseThrow(assertionError(EXPECTED_USER_NOT_FOUND));
+
+    final String UUID = testAccount.getUuid();
+
+    AttributeDTO attr = new AttributeDTO();
+
+    attr.setName(ATTR_NAME);
+    attr.setValue(ATTR_VALUE);
+
+    mvc
+      .perform(put(ACCOUNT_ATTR_URL_TEMPLATE, UUID).contentType(APPLICATION_JSON)
+        .content(mapper.writeValueAsString(attr)))
+      .andExpect(FORBIDDEN)
+      .andExpect(jsonPath("$.error", equalTo("insufficient_scope")))
+      .andExpect(jsonPath("$.error_description", equalTo("Insufficient scope for this resource")))
+      .andExpect(jsonPath("$.scope", equalTo("account:write")));
   }
 
   @Test

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/authority/AccountAuthorityEndpointTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/authority/AccountAuthorityEndpointTests.java
@@ -30,23 +30,23 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
-import it.infn.mw.iam.IamLoginService;
 import it.infn.mw.iam.persistence.repository.IamAccountRepository;
 import it.infn.mw.iam.persistence.repository.IamAuthoritiesRepository;
+import it.infn.mw.iam.test.util.WithMockOAuthUser;
 import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
+import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 
 @RunWith(SpringRunner.class)
 @IamMockMvcIntegrationTest
-@SpringBootTest(classes = {IamLoginService.class}, webEnvironment = WebEnvironment.MOCK)
 public class AccountAuthorityEndpointTests {
 
   private static final String TEST_100 = "test_100";
@@ -65,6 +65,19 @@ public class AccountAuthorityEndpointTests {
 
   @Autowired
   private MockMvc mvc;
+
+  @Autowired
+  private MockOAuth2Filter mockOAuth2Filter;
+
+  @Before
+  public void setup() {
+    mockOAuth2Filter.cleanupSecurityContext();
+  }
+
+  @After
+  public void cleanupOAuthUser() {
+    mockOAuth2Filter.cleanupSecurityContext();
+  }
 
   private void addUserAuthority(String userId, String authority) {
     iamAuthoritiesRepo.findByAuthority(authority)
@@ -248,6 +261,51 @@ public class AccountAuthorityEndpointTests {
   }
 
   @Test
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "account:write")
+  public void AddAuthorityWorkWithCorrectScope() throws Exception {
+
+    String authority = ROLE_ADMIN;
+
+    mvc.perform(get("/iam/account/{id}/authorities", TEST_100_UUID))
+      .andDo(print())
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.authorities", contains(ROLE_USER)));
+
+    mvc
+      .perform(post("/iam/account/{id}/authorities", TEST_100_UUID).param("authority", authority)
+        .contentType(APPLICATION_FORM_URLENCODED_VALUE))
+      .andDo(print())
+      .andExpect(status().isOk());
+
+    mvc.perform(get("/iam/account/{id}/authorities", TEST_100_UUID))
+      .andDo(print())
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.authorities", hasSize(2)))
+      .andExpect(jsonPath("$.authorities", containsInAnyOrder(ROLE_USER, ROLE_ADMIN)));
+
+    // remove
+    removeUserAuthority(TEST_100_UUID, ROLE_ADMIN);
+  }
+
+  @Test
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN")
+  public void AddAuthorityDoesNotWork() throws Exception {
+
+    String authority = ROLE_ADMIN;
+
+    mvc.perform(get("/iam/account/{id}/authorities", TEST_100_UUID))
+      .andDo(print())
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.authorities", contains(ROLE_USER)));
+
+    mvc
+      .perform(post("/iam/account/{id}/authorities", TEST_100_UUID).param("authority", authority)
+        .contentType(APPLICATION_FORM_URLENCODED_VALUE))
+      .andDo(print())
+      .andExpect(status().isForbidden());
+  }
+
+  @Test
   @WithMockUser(username = "admin", roles = {"ADMIN", "USER"})
   public void DeleteAuthorityWorks() throws Exception {
 
@@ -267,6 +325,41 @@ public class AccountAuthorityEndpointTests {
 
     // Readd authority
     addUserAuthority(TEST_100_UUID, ROLE_USER);
+
+  }
+
+  @Test
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "account:write")
+  public void DeleteAuthorityWorkWithCorrectScope() throws Exception {
+
+    String authority = "ROLE_USER";
+
+    mvc
+      .perform(delete("/iam/account/{id}/authorities", TEST_100_UUID).param("authority", authority)
+        .contentType(APPLICATION_FORM_URLENCODED_VALUE))
+      .andDo(print())
+      .andExpect(status().isOk());
+
+    mvc.perform(get("/iam/account/{id}/authorities", TEST_100_UUID))
+      .andDo(print())
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.authorities", empty()));
+
+    // Readd authority
+    addUserAuthority(TEST_100_UUID, ROLE_USER);
+  }
+
+  @Test
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN")
+  public void DeleteAuthorityDoesNotWork() throws Exception {
+
+    String authority = "ROLE_USER";
+
+    mvc
+      .perform(delete("/iam/account/{id}/authorities", TEST_100_UUID).param("authority", authority)
+        .contentType(APPLICATION_FORM_URLENCODED_VALUE))
+      .andDo(print())
+      .andExpect(status().isForbidden());
 
   }
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/authority/AccountAuthorityEndpointTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/authority/AccountAuthorityEndpointTests.java
@@ -261,7 +261,7 @@ public class AccountAuthorityEndpointTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "iam:admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "iam:admin.write")
   public void AddAuthorityWorkWithCorrectScope() throws Exception {
 
     String authority = ROLE_ADMIN;
@@ -313,7 +313,7 @@ public class AccountAuthorityEndpointTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "iam:admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "iam:admin.write")
   public void DeleteAuthorityWorkWithCorrectScope() throws Exception {
 
     String authority = "ROLE_USER";

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/authority/AccountAuthorityEndpointTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/authority/AccountAuthorityEndpointTests.java
@@ -261,27 +261,16 @@ public class AccountAuthorityEndpointTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "account:write")
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "admin:write")
   public void AddAuthorityWorkWithCorrectScope() throws Exception {
 
     String authority = ROLE_ADMIN;
-
-    mvc.perform(get("/iam/account/{id}/authorities", TEST_100_UUID))
-      .andDo(print())
-      .andExpect(status().isOk())
-      .andExpect(jsonPath("$.authorities", contains(ROLE_USER)));
 
     mvc
       .perform(post("/iam/account/{id}/authorities", TEST_100_UUID).param("authority", authority)
         .contentType(APPLICATION_FORM_URLENCODED_VALUE))
       .andDo(print())
       .andExpect(status().isOk());
-
-    mvc.perform(get("/iam/account/{id}/authorities", TEST_100_UUID))
-      .andDo(print())
-      .andExpect(status().isOk())
-      .andExpect(jsonPath("$.authorities", hasSize(2)))
-      .andExpect(jsonPath("$.authorities", containsInAnyOrder(ROLE_USER, ROLE_ADMIN)));
 
     // remove
     removeUserAuthority(TEST_100_UUID, ROLE_ADMIN);
@@ -292,11 +281,6 @@ public class AccountAuthorityEndpointTests {
   public void AddAuthorityDoesNotWork() throws Exception {
 
     String authority = ROLE_ADMIN;
-
-    mvc.perform(get("/iam/account/{id}/authorities", TEST_100_UUID))
-      .andDo(print())
-      .andExpect(status().isOk())
-      .andExpect(jsonPath("$.authorities", contains(ROLE_USER)));
 
     mvc
       .perform(post("/iam/account/{id}/authorities", TEST_100_UUID).param("authority", authority)
@@ -329,7 +313,7 @@ public class AccountAuthorityEndpointTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "account:write")
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "admin:write")
   public void DeleteAuthorityWorkWithCorrectScope() throws Exception {
 
     String authority = "ROLE_USER";
@@ -339,11 +323,6 @@ public class AccountAuthorityEndpointTests {
         .contentType(APPLICATION_FORM_URLENCODED_VALUE))
       .andDo(print())
       .andExpect(status().isOk());
-
-    mvc.perform(get("/iam/account/{id}/authorities", TEST_100_UUID))
-      .andDo(print())
-      .andExpect(status().isOk())
-      .andExpect(jsonPath("$.authorities", empty()));
 
     // Readd authority
     addUserAuthority(TEST_100_UUID, ROLE_USER);

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/authority/AccountAuthorityEndpointTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/authority/AccountAuthorityEndpointTests.java
@@ -261,7 +261,7 @@ public class AccountAuthorityEndpointTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "iam:admin:write")
   public void AddAuthorityWorkWithCorrectScope() throws Exception {
 
     String authority = ROLE_ADMIN;
@@ -313,7 +313,7 @@ public class AccountAuthorityEndpointTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "iam:admin:write")
   public void DeleteAuthorityWorkWithCorrectScope() throws Exception {
 
     String authority = "ROLE_USER";

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/group/GroupMembersIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/group/GroupMembersIntegrationTests.java
@@ -177,7 +177,7 @@ public class GroupMembersIntegrationTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = ADMIN_USER, authorities = {"ROLE_ADMIN"}, scopes = {"admin:write"})
+  @WithMockOAuthUser(user = ADMIN_USER, authorities = {"ROLE_ADMIN"}, scopes = {"iam:admin:write"})
   public void adminWithCorrectScopeCanAddGroupMember() throws Exception {
     IamAccount account =
         accountRepo.findByUsername(TEST_USER).orElseThrow(assertionError(EXPECTED_USER_NOT_FOUND));
@@ -214,7 +214,7 @@ public class GroupMembersIntegrationTests {
       .andExpect(status().isForbidden())
       .andExpect(jsonPath("$.error", equalTo("insufficient_scope")))
       .andExpect(jsonPath("$.error_description", equalTo("Insufficient scope for this resource")))
-      .andExpect(jsonPath("$.scope", equalTo("admin:write")));
+      .andExpect(jsonPath("$.scope", equalTo("iam:admin:write")));
   }
 
   @Test

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/group/GroupMembersIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/group/GroupMembersIntegrationTests.java
@@ -177,7 +177,7 @@ public class GroupMembersIntegrationTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = ADMIN_USER, authorities = {"ADMIN"}, scopes = {"account:write"})
+  @WithMockOAuthUser(user = ADMIN_USER, authorities = {"ROLE_ADMIN"}, scopes = {"account:write"})
   public void adminWithCorrectScopeCanAddGroupMember() throws Exception {
     IamAccount account =
         accountRepo.findByUsername(TEST_USER).orElseThrow(assertionError(EXPECTED_USER_NOT_FOUND));
@@ -202,7 +202,7 @@ public class GroupMembersIntegrationTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = ADMIN_USER, authorities = {"ADMIN"})
+  @WithMockOAuthUser(user = ADMIN_USER, authorities = {"ROLE_ADMIN"})
   public void adminWithoutScopeCannotAddGroupMember() throws Exception {
     IamAccount account =
         accountRepo.findByUsername(TEST_USER).orElseThrow(assertionError(EXPECTED_USER_NOT_FOUND));

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/group/GroupMembersIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/group/GroupMembersIntegrationTests.java
@@ -15,6 +15,7 @@
  */
 package it.infn.mw.iam.test.api.account.group;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -43,6 +44,7 @@ import it.infn.mw.iam.persistence.model.IamGroup;
 import it.infn.mw.iam.persistence.repository.IamAccountRepository;
 import it.infn.mw.iam.persistence.repository.IamGroupRepository;
 import it.infn.mw.iam.test.util.WithAnonymousUser;
+import it.infn.mw.iam.test.util.WithMockOAuthUser;
 import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
 import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 
@@ -172,6 +174,47 @@ public class GroupMembersIntegrationTests {
     IamAccountGroupMembership m =
         IamAccountGroupMembership.forAccountAndGroup(null, account, group);
     assertThat(account.getGroups().contains(m), is(true));
+  }
+
+  @Test
+  @WithMockOAuthUser(user = ADMIN_USER, authorities = {"ADMIN"}, scopes = {"account:write"})
+  public void adminWithCorrectScopeCanAddGroupMember() throws Exception {
+    IamAccount account =
+        accountRepo.findByUsername(TEST_USER).orElseThrow(assertionError(EXPECTED_USER_NOT_FOUND));
+
+    IamGroup group =
+        groupRepo.findByName("Test-001").orElseThrow(assertionError(EXPECTED_GROUP_NOT_FOUND));
+
+    mvc.perform(post("/iam/account/{account}/groups/{group}", account.getUuid(), group.getUuid()))
+      .andExpect(status().isCreated());
+
+    account =
+        accountRepo.findByUsername(TEST_USER).orElseThrow(assertionError(EXPECTED_USER_NOT_FOUND));
+
+    assertThat(
+        groupRepo.findGroupByMemberAccountUuidAndGroupUuid(account.getUuid(), group.getUuid())
+          .isPresent(),
+        is(true));
+
+    IamAccountGroupMembership m =
+        IamAccountGroupMembership.forAccountAndGroup(null, account, group);
+    assertThat(account.getGroups().contains(m), is(true));
+  }
+
+  @Test
+  @WithMockOAuthUser(user = ADMIN_USER, authorities = {"ADMIN"})
+  public void adminWithoutScopeCannotAddGroupMember() throws Exception {
+    IamAccount account =
+        accountRepo.findByUsername(TEST_USER).orElseThrow(assertionError(EXPECTED_USER_NOT_FOUND));
+
+    IamGroup group =
+        groupRepo.findByName("Test-001").orElseThrow(assertionError(EXPECTED_GROUP_NOT_FOUND));
+
+    mvc.perform(post("/iam/account/{account}/groups/{group}", account.getUuid(), group.getUuid()))
+      .andExpect(status().isForbidden())
+      .andExpect(jsonPath("$.error", equalTo("insufficient_scope")))
+      .andExpect(jsonPath("$.error_description", equalTo("Insufficient scope for this resource")))
+      .andExpect(jsonPath("$.scope", equalTo("account:write")));
   }
 
   @Test

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/group/GroupMembersIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/group/GroupMembersIntegrationTests.java
@@ -177,7 +177,7 @@ public class GroupMembersIntegrationTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = ADMIN_USER, authorities = {"ROLE_ADMIN"}, scopes = {"iam:admin:write"})
+  @WithMockOAuthUser(user = ADMIN_USER, authorities = {"ROLE_ADMIN"}, scopes = {"iam:admin.write"})
   public void adminWithCorrectScopeCanAddGroupMember() throws Exception {
     IamAccount account =
         accountRepo.findByUsername(TEST_USER).orElseThrow(assertionError(EXPECTED_USER_NOT_FOUND));
@@ -214,7 +214,7 @@ public class GroupMembersIntegrationTests {
       .andExpect(status().isForbidden())
       .andExpect(jsonPath("$.error", equalTo("insufficient_scope")))
       .andExpect(jsonPath("$.error_description", equalTo("Insufficient scope for this resource")))
-      .andExpect(jsonPath("$.scope", equalTo("iam:admin:write")));
+      .andExpect(jsonPath("$.scope", equalTo("iam:admin.write")));
   }
 
   @Test

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/group/GroupMembersIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/group/GroupMembersIntegrationTests.java
@@ -177,7 +177,7 @@ public class GroupMembersIntegrationTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = ADMIN_USER, authorities = {"ROLE_ADMIN"}, scopes = {"account:write"})
+  @WithMockOAuthUser(user = ADMIN_USER, authorities = {"ROLE_ADMIN"}, scopes = {"admin:write"})
   public void adminWithCorrectScopeCanAddGroupMember() throws Exception {
     IamAccount account =
         accountRepo.findByUsername(TEST_USER).orElseThrow(assertionError(EXPECTED_USER_NOT_FOUND));
@@ -214,7 +214,7 @@ public class GroupMembersIntegrationTests {
       .andExpect(status().isForbidden())
       .andExpect(jsonPath("$.error", equalTo("insufficient_scope")))
       .andExpect(jsonPath("$.error_description", equalTo("Insufficient scope for this resource")))
-      .andExpect(jsonPath("$.scope", equalTo("account:write")));
+      .andExpect(jsonPath("$.scope", equalTo("admin:write")));
   }
 
   @Test

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/group_manager/GroupManagerIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/group_manager/GroupManagerIntegrationTests.java
@@ -229,7 +229,7 @@ public class GroupManagerIntegrationTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "account:write")
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "admin:write")
   public void addGroupManagerWorksForAdminWithScope() throws Exception {
     IamAccount testUser = accountRepo.findByUsername("test")
       .orElseThrow(() -> new AssertionError("Expected test user not found"));
@@ -304,7 +304,7 @@ public class GroupManagerIntegrationTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "account:write")
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "admin:write")
   public void removeGroupManagerWorksForAdminUserWithScope() throws Exception {
     IamAccount testUser = accountRepo.findByUsername("test")
       .orElseThrow(() -> new AssertionError("Expected test user not found"));

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/group_manager/GroupManagerIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/group_manager/GroupManagerIntegrationTests.java
@@ -46,6 +46,7 @@ import it.infn.mw.iam.persistence.repository.IamAccountRepository;
 import it.infn.mw.iam.persistence.repository.IamAuthoritiesRepository;
 import it.infn.mw.iam.persistence.repository.IamGroupRepository;
 import it.infn.mw.iam.test.util.WithAnonymousUser;
+import it.infn.mw.iam.test.util.WithMockOAuthUser;
 import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
 import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 
@@ -228,6 +229,30 @@ public class GroupManagerIntegrationTests {
   }
 
   @Test
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "account:write")
+  public void addGroupManagerWorksForAdminWithScope() throws Exception {
+    IamAccount testUser = accountRepo.findByUsername("test")
+      .orElseThrow(() -> new AssertionError("Expected test user not found"));
+
+    mvc
+      .perform(post("/iam/account/{uuid}/managed-groups/{groupUuid}", testUser.getUuid(),
+          TEST_001_GROUP_ID))
+      .andExpect(status().isCreated());
+  }
+
+  @Test
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN")
+  public void addGroupManagerDoesNotWork() throws Exception {
+    IamAccount testUser = accountRepo.findByUsername("test")
+      .orElseThrow(() -> new AssertionError("Expected test user not found"));
+
+    mvc
+      .perform(post("/iam/account/{uuid}/managed-groups/{groupUuid}", testUser.getUuid(),
+          TEST_001_GROUP_ID))
+      .andExpect(status().isForbidden());
+  }
+
+  @Test
   @WithMockUser(username = "admin", roles = {"ADMIN", "USER"})
   public void addGroupManagerRequiresValidUserAndGroupIds() throws Exception {
     String randomUuid = UUID.randomUUID().toString();
@@ -276,6 +301,46 @@ public class GroupManagerIntegrationTests {
       .andExpect(jsonPath("$.managedGroups").isEmpty())
       .andExpect(jsonPath("$.unmanagedGroups").isNotEmpty())
       .andExpect(jsonPath("$.unmanagedGroups").value(hasSize(allGroups.size())));
+  }
+
+  @Test
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "account:write")
+  public void removeGroupManagerWorksForAdminUserWithScope() throws Exception {
+    IamAccount testUser = accountRepo.findByUsername("test")
+      .orElseThrow(() -> new AssertionError("Expected test user not found"));
+
+
+    IamAuthority auth = authoritiesRepo.findByAuthority("ROLE_GM:" + TEST_001_GROUP_ID)
+      .orElseThrow(() -> new AssertionError("Expected group manager authority not found"));
+
+    testUser.getAuthorities().add(auth);
+
+    accountRepo.save(testUser);
+
+    mvc
+      .perform(delete("/iam/account/{uuid}/managed-groups/{groupUuid}", testUser.getUuid(),
+          TEST_001_GROUP_ID))
+      .andExpect(status().isNoContent());
+  }
+
+  @Test
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN")
+  public void removeGroupManagerDoesNotWork() throws Exception {
+    IamAccount testUser = accountRepo.findByUsername("test")
+      .orElseThrow(() -> new AssertionError("Expected test user not found"));
+
+
+    IamAuthority auth = authoritiesRepo.findByAuthority("ROLE_GM:" + TEST_001_GROUP_ID)
+      .orElseThrow(() -> new AssertionError("Expected group manager authority not found"));
+
+    testUser.getAuthorities().add(auth);
+
+    accountRepo.save(testUser);
+
+    mvc
+      .perform(delete("/iam/account/{uuid}/managed-groups/{groupUuid}", testUser.getUuid(),
+          TEST_001_GROUP_ID))
+      .andExpect(status().isForbidden());
   }
 
   @Test

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/group_manager/GroupManagerIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/group_manager/GroupManagerIntegrationTests.java
@@ -229,7 +229,7 @@ public class GroupManagerIntegrationTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "iam:admin:write")
   public void addGroupManagerWorksForAdminWithScope() throws Exception {
     IamAccount testUser = accountRepo.findByUsername("test")
       .orElseThrow(() -> new AssertionError("Expected test user not found"));
@@ -304,7 +304,7 @@ public class GroupManagerIntegrationTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "iam:admin:write")
   public void removeGroupManagerWorksForAdminUserWithScope() throws Exception {
     IamAccount testUser = accountRepo.findByUsername("test")
       .orElseThrow(() -> new AssertionError("Expected test user not found"));

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/group_manager/GroupManagerIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/group_manager/GroupManagerIntegrationTests.java
@@ -229,7 +229,7 @@ public class GroupManagerIntegrationTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "iam:admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "iam:admin.write")
   public void addGroupManagerWorksForAdminWithScope() throws Exception {
     IamAccount testUser = accountRepo.findByUsername("test")
       .orElseThrow(() -> new AssertionError("Expected test user not found"));
@@ -304,7 +304,7 @@ public class GroupManagerIntegrationTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "iam:admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "iam:admin.write")
   public void removeGroupManagerWorksForAdminUserWithScope() throws Exception {
     IamAccount testUser = accountRepo.findByUsername("test")
       .orElseThrow(() -> new AssertionError("Expected test user not found"));

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/labels/AccountLabelsTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/labels/AccountLabelsTests.java
@@ -169,7 +169,7 @@ public class AccountLabelsTests extends TestSupport {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "iam:admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "iam:admin.write")
   public void setAndDeleteLabelWorksWithScope() throws Exception {
 
     mvc

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/labels/AccountLabelsTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/labels/AccountLabelsTests.java
@@ -169,20 +169,13 @@ public class AccountLabelsTests extends TestSupport {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "account:write")
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "admin:write")
   public void setAndDeleteLabelWorksWithScope() throws Exception {
 
     mvc
       .perform(put(RESOURCE, TEST_100_USER_UUID).contentType(APPLICATION_JSON)
         .content(mapper.writeValueAsString(TEST_LABEL)))
       .andExpect(OK);
-
-    mvc.perform(get(RESOURCE, TEST_100_USER_UUID))
-      .andExpect(OK)
-      .andExpect(jsonPath("$").isArray())
-      .andExpect(jsonPath("$[0].prefix", is(TEST_LABEL.getPrefix())))
-      .andExpect(jsonPath("$[0].name", is(TEST_LABEL.getName())))
-      .andExpect(jsonPath("$[0].value", is(TEST_LABEL.getValue())));
 
     mvc
     .perform(delete(RESOURCE, TEST_100_USER_UUID).param("name", TEST_LABEL.getName())

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/labels/AccountLabelsTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/labels/AccountLabelsTests.java
@@ -169,7 +169,7 @@ public class AccountLabelsTests extends TestSupport {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "iam:admin:write")
   public void setAndDeleteLabelWorksWithScope() throws Exception {
 
     mvc

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/labels/AccountLabelsTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/labels/AccountLabelsTests.java
@@ -49,6 +49,7 @@ import it.infn.mw.iam.api.common.LabelDTO;
 import it.infn.mw.iam.persistence.repository.IamAccountRepository;
 import it.infn.mw.iam.test.api.TestSupport;
 import it.infn.mw.iam.test.util.WithAnonymousUser;
+import it.infn.mw.iam.test.util.WithMockOAuthUser;
 import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
 import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 
@@ -168,6 +169,38 @@ public class AccountLabelsTests extends TestSupport {
   }
 
   @Test
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "account:write")
+  public void setAndDeleteLabelWorksWithScope() throws Exception {
+
+    mvc
+      .perform(put(RESOURCE, TEST_100_USER_UUID).contentType(APPLICATION_JSON)
+        .content(mapper.writeValueAsString(TEST_LABEL)))
+      .andExpect(OK);
+
+    mvc.perform(get(RESOURCE, TEST_100_USER_UUID))
+      .andExpect(OK)
+      .andExpect(jsonPath("$").isArray())
+      .andExpect(jsonPath("$[0].prefix", is(TEST_LABEL.getPrefix())))
+      .andExpect(jsonPath("$[0].name", is(TEST_LABEL.getName())))
+      .andExpect(jsonPath("$[0].value", is(TEST_LABEL.getValue())));
+
+    mvc
+    .perform(delete(RESOURCE, TEST_100_USER_UUID).param("name", TEST_LABEL.getName())
+      .param("prefix", TEST_LABEL.getPrefix()))
+    .andExpect(NO_CONTENT);
+  }
+
+  @Test
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN")
+  public void setLabelDoesNotWork() throws Exception {
+
+    mvc
+      .perform(put(RESOURCE, TEST_100_USER_UUID).contentType(APPLICATION_JSON)
+        .content(mapper.writeValueAsString(TEST_LABEL)))
+      .andExpect(FORBIDDEN);
+  }
+
+  @Test
   public void deleteLabelWorks() throws Exception {
 
     LabelDTO unqualified = LabelDTO.builder().name(LABEL_NAME).build();
@@ -215,6 +248,16 @@ public class AccountLabelsTests extends TestSupport {
       .andExpect(OK)
       .andExpect(jsonPath("$").isArray())
       .andExpect(jsonPath("$", hasSize(0)));
+  }
+
+  @Test
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN")
+  public void deleteLabelDoesNotWork() throws Exception {
+
+    mvc
+      .perform(put(RESOURCE, TEST_100_USER_UUID).contentType(APPLICATION_JSON)
+        .content(mapper.writeValueAsString(TEST_LABEL)))
+      .andExpect(FORBIDDEN);
   }
 
   @Test

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/lifecycle/AccountLifecycleApiTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/lifecycle/AccountLifecycleApiTests.java
@@ -117,7 +117,7 @@ public class AccountLifecycleApiTests extends TestSupport {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "account:write")
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "admin:write")
   public void setEndTimeWorksForAdminUserWithScope() throws Exception {
     Date newEndTime = new Date();
     AccountLifecycleDTO dto = new AccountLifecycleDTO();

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/lifecycle/AccountLifecycleApiTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/lifecycle/AccountLifecycleApiTests.java
@@ -117,7 +117,7 @@ public class AccountLifecycleApiTests extends TestSupport {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "iam:admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "iam:admin.write")
   public void setEndTimeWorksForAdminUserWithScope() throws Exception {
     Date newEndTime = new Date();
     AccountLifecycleDTO dto = new AccountLifecycleDTO();

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/lifecycle/AccountLifecycleApiTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/lifecycle/AccountLifecycleApiTests.java
@@ -39,6 +39,7 @@ import it.infn.mw.iam.persistence.model.IamAccount;
 import it.infn.mw.iam.persistence.repository.IamAccountRepository;
 import it.infn.mw.iam.test.api.TestSupport;
 import it.infn.mw.iam.test.util.WithAnonymousUser;
+import it.infn.mw.iam.test.util.WithMockOAuthUser;
 import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
 import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 
@@ -114,6 +115,33 @@ public class AccountLifecycleApiTests extends TestSupport {
     
     assertThat(account.getEndTime(), is(newEndTime));
   }
+
+  @Test
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "account:write")
+  public void setEndTimeWorksForAdminUserWithScope() throws Exception {
+    Date newEndTime = new Date();
+    AccountLifecycleDTO dto = new AccountLifecycleDTO();
+    dto.setEndTime(newEndTime);
+
+    mvc
+      .perform(put(END_TIME_RESOURCE, TEST_100_USER_UUID).content(mapper.writeValueAsString(dto))
+        .contentType(APPLICATION_JSON))
+      .andExpect(OK);
+  }
+
+  @Test
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN")
+  public void setEndTimeDoesNotWork() throws Exception {
+    Date newEndTime = new Date();
+    AccountLifecycleDTO dto = new AccountLifecycleDTO();
+    dto.setEndTime(newEndTime);
+
+    mvc
+      .perform(put(END_TIME_RESOURCE, TEST_100_USER_UUID).content(mapper.writeValueAsString(dto))
+        .contentType(APPLICATION_JSON))
+      .andExpect(FORBIDDEN);
+  }
+
 
 
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/lifecycle/AccountLifecycleApiTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/lifecycle/AccountLifecycleApiTests.java
@@ -117,7 +117,7 @@ public class AccountLifecycleApiTests extends TestSupport {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = "ROLE_ADMIN", scopes = "iam:admin:write")
   public void setEndTimeWorksForAdminUserWithScope() throws Exception {
     Date newEndTime = new Date();
     AccountLifecycleDTO dto = new AccountLifecycleDTO();

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/search/AccountSearchControllerSortTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/search/AccountSearchControllerSortTests.java
@@ -87,7 +87,7 @@ public class AccountSearchControllerSortTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
   public void getUsersWithInvalidSortDirection() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -105,7 +105,7 @@ public class AccountSearchControllerSortTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
   public void getUsersSortByNameAsc() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -123,7 +123,7 @@ public class AccountSearchControllerSortTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
   public void getUsersSortByNameDesc() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -141,7 +141,7 @@ public class AccountSearchControllerSortTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
   public void getUsersSortByEmailAsc() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -159,7 +159,7 @@ public class AccountSearchControllerSortTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
   public void getUsersSortByEmailDesc() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -177,7 +177,7 @@ public class AccountSearchControllerSortTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
   public void getUsersSortByCreationTimeAsc() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -195,7 +195,7 @@ public class AccountSearchControllerSortTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
   public void getUsersSortByCreationTimeDesc() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/search/AccountSearchControllerSortTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/search/AccountSearchControllerSortTests.java
@@ -87,7 +87,7 @@ public class AccountSearchControllerSortTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin.read")
   public void getUsersWithInvalidSortDirection() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -105,7 +105,7 @@ public class AccountSearchControllerSortTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin.read")
   public void getUsersSortByNameAsc() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -123,7 +123,7 @@ public class AccountSearchControllerSortTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin.read")
   public void getUsersSortByNameDesc() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -141,7 +141,7 @@ public class AccountSearchControllerSortTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin.read")
   public void getUsersSortByEmailAsc() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -159,7 +159,7 @@ public class AccountSearchControllerSortTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin.read")
   public void getUsersSortByEmailDesc() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -177,7 +177,7 @@ public class AccountSearchControllerSortTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin.read")
   public void getUsersSortByCreationTimeAsc() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -195,7 +195,7 @@ public class AccountSearchControllerSortTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin.read")
   public void getUsersSortByCreationTimeDesc() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/search/AccountSearchControllerSortTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/search/AccountSearchControllerSortTests.java
@@ -87,7 +87,7 @@ public class AccountSearchControllerSortTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
   public void getUsersWithInvalidSortDirection() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -105,7 +105,7 @@ public class AccountSearchControllerSortTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
   public void getUsersSortByNameAsc() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -123,7 +123,7 @@ public class AccountSearchControllerSortTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
   public void getUsersSortByNameDesc() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -141,7 +141,7 @@ public class AccountSearchControllerSortTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
   public void getUsersSortByEmailAsc() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -159,7 +159,7 @@ public class AccountSearchControllerSortTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
   public void getUsersSortByEmailDesc() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -177,7 +177,7 @@ public class AccountSearchControllerSortTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
   public void getUsersSortByCreationTimeAsc() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -195,7 +195,7 @@ public class AccountSearchControllerSortTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
   public void getUsersSortByCreationTimeDesc() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/search/AccountSearchControllerTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/search/AccountSearchControllerTests.java
@@ -96,7 +96,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
   public void getFirstPageOfAllUsers() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -130,7 +130,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
   public void getSecondPageOfAllUsers() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -148,7 +148,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
   public void getUsersWithCustomStartIndexAndCount() throws JsonParseException,
       JsonMappingException, UnsupportedEncodingException, IOException, Exception {
 
@@ -168,7 +168,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
   public void getCountOfAllUsers() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -186,7 +186,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
   public void getFirstFilteredPageOfUsers() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -210,7 +210,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
   public void getCountOfFilteredUsers() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -235,7 +235,7 @@ public class AccountSearchControllerTests {
   }
   
   @Test
-  @WithMockOAuthUser(user="test", authorities= {"ROLE_USER", "ROLE_GM:c617d586-54e6-411d-8e38-649677980001"}, scopes = "admin:read")
+  @WithMockOAuthUser(user="test", authorities= {"ROLE_USER", "ROLE_GM:c617d586-54e6-411d-8e38-649677980001"}, scopes = "iam:admin:read")
   public void getUsersAsGroupManager() throws Exception {
     mvc.perform(get(ACCOUNT_SEARCH_ENDPOINT).contentType(APPLICATION_JSON_CONTENT_TYPE))
     .andExpect(status().isOk());
@@ -249,7 +249,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
   public void getUsersWithNegativeStartIndex() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -267,7 +267,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
   public void getUsersWithStartIndexZero() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -285,7 +285,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
   public void getUsersWithCountBiggerThanPageSize() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -304,7 +304,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
   public void getUsersWithNegativeCount() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/search/AccountSearchControllerTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/search/AccountSearchControllerTests.java
@@ -96,7 +96,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
   public void getFirstPageOfAllUsers() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -113,7 +113,24 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"})
+  @WithMockUser(username = "admin", roles = {"ADMIN"})
+  public void getFirstPageOfAllUsersWithoutToken() throws JsonParseException, JsonMappingException,
+      UnsupportedEncodingException, IOException, Exception {
+
+    long expectedSize = accountRepository.count();
+
+    ListResponseDTO<ScimUser> response = mapper.readValue(
+        mvc.perform(get(ACCOUNT_SEARCH_ENDPOINT).contentType(APPLICATION_JSON_CONTENT_TYPE))
+            .andExpect(status().isOk()).andReturn().getResponse().getContentAsString(),
+        new TypeReference<ListResponseDTO<ScimUser>>() {});
+    assertThat(response.getTotalResults(), equalTo(expectedSize));
+    assertThat(response.getResources().size(), equalTo(DEFAULT_ITEMS_PER_PAGE));
+    assertThat(response.getStartIndex(), equalTo(1));
+    assertThat(response.getItemsPerPage(), equalTo(DEFAULT_ITEMS_PER_PAGE));
+  }
+
+  @Test
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
   public void getSecondPageOfAllUsers() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -131,7 +148,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
   public void getUsersWithCustomStartIndexAndCount() throws JsonParseException,
       JsonMappingException, UnsupportedEncodingException, IOException, Exception {
 
@@ -151,7 +168,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
   public void getCountOfAllUsers() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -169,7 +186,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
   public void getFirstFilteredPageOfUsers() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -193,7 +210,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
   public void getCountOfFilteredUsers() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -218,7 +235,7 @@ public class AccountSearchControllerTests {
   }
   
   @Test
-  @WithMockUser(username="test", roles= {"USER", "GM:c617d586-54e6-411d-8e38-649677980001"})
+  @WithMockOAuthUser(user="test", authorities= {"ROLE_USER", "ROLE_GM:c617d586-54e6-411d-8e38-649677980001"}, scopes = "admin:read")
   public void getUsersAsGroupManager() throws Exception {
     mvc.perform(get(ACCOUNT_SEARCH_ENDPOINT).contentType(APPLICATION_JSON_CONTENT_TYPE))
     .andExpect(status().isOk());
@@ -232,7 +249,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
   public void getUsersWithNegativeStartIndex() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -250,7 +267,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
   public void getUsersWithStartIndexZero() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -268,7 +285,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
   public void getUsersWithCountBiggerThanPageSize() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -287,7 +304,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
   public void getUsersWithNegativeCount() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/search/AccountSearchControllerTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/search/AccountSearchControllerTests.java
@@ -96,7 +96,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin.read")
   public void getFirstPageOfAllUsers() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -130,7 +130,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin.read")
   public void getSecondPageOfAllUsers() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -148,7 +148,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin.read")
   public void getUsersWithCustomStartIndexAndCount() throws JsonParseException,
       JsonMappingException, UnsupportedEncodingException, IOException, Exception {
 
@@ -168,7 +168,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin.read")
   public void getCountOfAllUsers() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -186,7 +186,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin.read")
   public void getFirstFilteredPageOfUsers() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -210,7 +210,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin.read")
   public void getCountOfFilteredUsers() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -235,7 +235,7 @@ public class AccountSearchControllerTests {
   }
   
   @Test
-  @WithMockOAuthUser(user="test", authorities= {"ROLE_USER", "ROLE_GM:c617d586-54e6-411d-8e38-649677980001"}, scopes = "iam:admin:read")
+  @WithMockOAuthUser(user="test", authorities= {"ROLE_USER", "ROLE_GM:c617d586-54e6-411d-8e38-649677980001"}, scopes = "iam:admin.read")
   public void getUsersAsGroupManager() throws Exception {
     mvc.perform(get(ACCOUNT_SEARCH_ENDPOINT).contentType(APPLICATION_JSON_CONTENT_TYPE))
     .andExpect(status().isOk());
@@ -249,7 +249,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin.read")
   public void getUsersWithNegativeStartIndex() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -267,7 +267,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin.read")
   public void getUsersWithStartIndexZero() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -285,7 +285,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin.read")
   public void getUsersWithCountBiggerThanPageSize() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 
@@ -304,7 +304,7 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin.read")
   public void getUsersWithNegativeCount() throws JsonParseException, JsonMappingException,
       UnsupportedEncodingException, IOException, Exception {
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/tokens/AccessTokenGetListTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/tokens/AccessTokenGetListTests.java
@@ -50,7 +50,7 @@ import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 
 @RunWith(SpringRunner.class)
 @IamMockMvcIntegrationTest
-@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
+@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin.read")
 public class AccessTokenGetListTests extends TestTokensUtils {
 
   public static long id = 1L;

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/tokens/AccessTokenGetListTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/tokens/AccessTokenGetListTests.java
@@ -50,7 +50,7 @@ import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 
 @RunWith(SpringRunner.class)
 @IamMockMvcIntegrationTest
-@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
+@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
 public class AccessTokenGetListTests extends TestTokensUtils {
 
   public static long id = 1L;

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/tokens/AccessTokenGetListTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/tokens/AccessTokenGetListTests.java
@@ -50,7 +50,7 @@ import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 
 @RunWith(SpringRunner.class)
 @IamMockMvcIntegrationTest
-@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"})
+@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
 public class AccessTokenGetListTests extends TestTokensUtils {
 
   public static long id = 1L;

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/tokens/AccessTokenGetRevokeTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/tokens/AccessTokenGetRevokeTests.java
@@ -49,7 +49,7 @@ import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 
 @RunWith(SpringRunner.class)
 @IamMockMvcIntegrationTest
-@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = {"iam:admin:read", "iam:admin:write"})
+@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = {"iam:admin.read", "iam:admin.write"})
 public class AccessTokenGetRevokeTests extends TestTokensUtils {
 
   public static final String[] SCOPES = {"openid", "profile"};

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/tokens/AccessTokenGetRevokeTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/tokens/AccessTokenGetRevokeTests.java
@@ -49,7 +49,7 @@ import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 
 @RunWith(SpringRunner.class)
 @IamMockMvcIntegrationTest
-@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = {"admin:read", "admin:write"})
+@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = {"iam:admin:read", "iam:admin:write"})
 public class AccessTokenGetRevokeTests extends TestTokensUtils {
 
   public static final String[] SCOPES = {"openid", "profile"};

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/tokens/AccessTokenGetRevokeTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/tokens/AccessTokenGetRevokeTests.java
@@ -49,7 +49,7 @@ import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 
 @RunWith(SpringRunner.class)
 @IamMockMvcIntegrationTest
-@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"})
+@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = {"admin:read", "admin:write"})
 public class AccessTokenGetRevokeTests extends TestTokensUtils {
 
   public static final String[] SCOPES = {"openid", "profile"};

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/tokens/RefreshTokenGetListTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/tokens/RefreshTokenGetListTests.java
@@ -47,7 +47,7 @@ import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 
 @RunWith(SpringRunner.class)
 @IamMockMvcIntegrationTest
-@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
+@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin.read")
 public class RefreshTokenGetListTests extends TestTokensUtils {
 
   public static final String[] SCOPES = {"openid", "profile", "offline_access"};

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/tokens/RefreshTokenGetListTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/tokens/RefreshTokenGetListTests.java
@@ -47,7 +47,7 @@ import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 
 @RunWith(SpringRunner.class)
 @IamMockMvcIntegrationTest
-@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
+@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
 public class RefreshTokenGetListTests extends TestTokensUtils {
 
   public static final String[] SCOPES = {"openid", "profile", "offline_access"};

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/tokens/RefreshTokenGetListTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/tokens/RefreshTokenGetListTests.java
@@ -47,7 +47,7 @@ import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 
 @RunWith(SpringRunner.class)
 @IamMockMvcIntegrationTest
-@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"})
+@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
 public class RefreshTokenGetListTests extends TestTokensUtils {
 
   public static final String[] SCOPES = {"openid", "profile", "offline_access"};

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/tokens/RefreshTokenGetRevokeTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/tokens/RefreshTokenGetRevokeTests.java
@@ -48,7 +48,7 @@ import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
 
 @RunWith(SpringRunner.class)
 @IamMockMvcIntegrationTest
-@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = {"iam:admin:read", "iam:admin:write"})
+@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = {"iam:admin.read", "iam:admin.write"})
 public class RefreshTokenGetRevokeTests extends TestTokensUtils {
 
   public static final String[] SCOPES = {"openid", "profile", "offline_access"};

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/tokens/RefreshTokenGetRevokeTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/tokens/RefreshTokenGetRevokeTests.java
@@ -48,7 +48,7 @@ import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
 
 @RunWith(SpringRunner.class)
 @IamMockMvcIntegrationTest
-@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = {"admin:read", "admin:write"})
+@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = {"iam:admin:read", "iam:admin:write"})
 public class RefreshTokenGetRevokeTests extends TestTokensUtils {
 
   public static final String[] SCOPES = {"openid", "profile", "offline_access"};

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/tokens/RefreshTokenGetRevokeTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/tokens/RefreshTokenGetRevokeTests.java
@@ -48,7 +48,7 @@ import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
 
 @RunWith(SpringRunner.class)
 @IamMockMvcIntegrationTest
-@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"})
+@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = {"admin:read", "admin:write"})
 public class RefreshTokenGetRevokeTests extends TestTokensUtils {
 
   public static final String[] SCOPES = {"openid", "profile", "offline_access"};

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/exchange/ExchangePolicyApiIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/exchange/ExchangePolicyApiIntegrationTests.java
@@ -127,7 +127,7 @@ public class ExchangePolicyApiIntegrationTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:read")
   public void listPoliciesWorks() throws Exception {
     mvc.perform(get(ENDPOINT))
       .andExpect(status().isOk())
@@ -152,7 +152,7 @@ public class ExchangePolicyApiIntegrationTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
   public void deletePolicyWorks() throws Exception {
     mvc.perform(delete(ENDPOINT + "/1")).andExpect(status().isNoContent());
     mvc.perform(delete(ENDPOINT + "/1")).andExpect(status().isNotFound());
@@ -175,7 +175,7 @@ public class ExchangePolicyApiIntegrationTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"admin:read", "admin:write"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"iam:admin:read", "iam:admin:write"})
   public void createPolicyWorks() throws Exception {
     repo.deleteAll();
 
@@ -213,7 +213,7 @@ public class ExchangePolicyApiIntegrationTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"admin:write", "admin:read"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"iam:admin:write", "iam:admin:read"})
   public void createPolicyWithScopePoliciesWorks() throws Exception {
 
     repo.deleteAll();
@@ -260,7 +260,7 @@ public class ExchangePolicyApiIntegrationTests {
 
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
   public void policyValidation() throws Exception {
 
     // Empty object

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/exchange/ExchangePolicyApiIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/exchange/ExchangePolicyApiIntegrationTests.java
@@ -127,7 +127,7 @@ public class ExchangePolicyApiIntegrationTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:read")
   public void listPoliciesWorks() throws Exception {
     mvc.perform(get(ENDPOINT))
       .andExpect(status().isOk())
@@ -152,7 +152,7 @@ public class ExchangePolicyApiIntegrationTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
   public void deletePolicyWorks() throws Exception {
     mvc.perform(delete(ENDPOINT + "/1")).andExpect(status().isNoContent());
     mvc.perform(delete(ENDPOINT + "/1")).andExpect(status().isNotFound());
@@ -175,7 +175,7 @@ public class ExchangePolicyApiIntegrationTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"admin:read", "admin:write"})
   public void createPolicyWorks() throws Exception {
     repo.deleteAll();
 
@@ -213,7 +213,7 @@ public class ExchangePolicyApiIntegrationTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"admin:write", "admin:read"})
   public void createPolicyWithScopePoliciesWorks() throws Exception {
 
     repo.deleteAll();
@@ -260,7 +260,7 @@ public class ExchangePolicyApiIntegrationTests {
 
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
   public void policyValidation() throws Exception {
 
     // Empty object

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/exchange/ExchangePolicyApiIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/exchange/ExchangePolicyApiIntegrationTests.java
@@ -127,7 +127,7 @@ public class ExchangePolicyApiIntegrationTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin.read")
   public void listPoliciesWorks() throws Exception {
     mvc.perform(get(ENDPOINT))
       .andExpect(status().isOk())
@@ -152,7 +152,7 @@ public class ExchangePolicyApiIntegrationTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin.write")
   public void deletePolicyWorks() throws Exception {
     mvc.perform(delete(ENDPOINT + "/1")).andExpect(status().isNoContent());
     mvc.perform(delete(ENDPOINT + "/1")).andExpect(status().isNotFound());
@@ -175,7 +175,7 @@ public class ExchangePolicyApiIntegrationTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"iam:admin:read", "iam:admin:write"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"iam:admin.read", "iam:admin.write"})
   public void createPolicyWorks() throws Exception {
     repo.deleteAll();
 
@@ -213,7 +213,7 @@ public class ExchangePolicyApiIntegrationTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"iam:admin:write", "iam:admin:read"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"iam:admin.write", "iam:admin.read"})
   public void createPolicyWithScopePoliciesWorks() throws Exception {
 
     repo.deleteAll();
@@ -260,7 +260,7 @@ public class ExchangePolicyApiIntegrationTests {
 
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin.write")
   public void policyValidation() throws Exception {
 
     // Empty object

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/WLCGProfileIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/WLCGProfileIntegrationTests.java
@@ -424,8 +424,6 @@ public class WLCGProfileIntegrationTests extends EndpointsTestUtils {
 
     setOAuthAdminSecurityContext();
 
-    mvc.perform(get("/iam/api/refresh-tokens")).andExpect(status().isOk());
-
   }
 
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/scope/pdp/ScopePolicyApiIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/scope/pdp/ScopePolicyApiIntegrationTests.java
@@ -107,7 +107,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
 
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:read")
   public void listPolicyWorksForAdminUserTest() throws Exception {
     mvc.perform(get("/iam/scope_policies"))
       .andExpect(status().isOk())
@@ -118,7 +118,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:read")
   public void listUserPolicyTest() throws Exception {
 
     IamAccount testAccount = accountRepo.findByUsername("test")
@@ -153,7 +153,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
 
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:read")
   public void listGroupPolicyTest() throws Exception {
 
     IamGroup prodGroup = groupRepo.findByName("Production")
@@ -187,7 +187,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
   public void defaultPolicyRuleValidationTest() throws Exception {
     ScopePolicyDTO sp = new ScopePolicyDTO();
     sp.setRule("ciccio");
@@ -199,7 +199,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
   public void invalidAccountIdRuleValidationTest() throws Exception {
     ScopePolicyDTO sp = new ScopePolicyDTO();
     sp.setRule(PolicyRule.DENY.name());
@@ -215,7 +215,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
   public void invalidGroupIdRuleValidationTest() throws Exception {
     ScopePolicyDTO sp = new ScopePolicyDTO();
     sp.setRule(PolicyRule.DENY.name());
@@ -234,7 +234,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
   public void invalidScopePolicyRuleValidationTest() throws Exception {
     IamAccount testAccount = accountRepo.findByUsername("test")
       .orElseThrow(() -> new AssertionError("Expected test user not found"));
@@ -261,7 +261,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
   public void invalidScopePolicyScopesLengthLowerBound() throws Exception {
 
     ScopePolicyDTO sp = new ScopePolicyDTO();
@@ -288,7 +288,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
   public void invalidScopePolicyScopesLengthUpperBound() throws Exception {
 
     StringBuilder s = new StringBuilder();
@@ -307,7 +307,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
   
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
   public void invalidScopeMatchingPolicy() throws Exception {
 
     ScopePolicyDTO sp = new ScopePolicyDTO();
@@ -323,7 +323,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
   public void testDefaultPolicyCreation() throws Exception {
 
     ScopePolicyDTO sp = new ScopePolicyDTO();
@@ -338,7 +338,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
   
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
   public void testMatchingPolicyIsRequired() throws Exception {
 
     ScopePolicyDTO sp = new ScopePolicyDTO();
@@ -353,7 +353,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
   public void testDefaultPolicyCreationNoScopes() throws Exception {
 
     ScopePolicyDTO sp = new ScopePolicyDTO();
@@ -367,7 +367,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"admin:read", "admin:write"})
   public void testAccountPolicyCreation() throws Exception {
 
     // Cleanup all policies
@@ -407,7 +407,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"admin:read", "admin:write"})
   public void testGroupPolicyCreation() throws Exception {
     // Cleanup all policies
     scopePolicyRepo.deleteAll();
@@ -445,7 +445,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"admin:read", "admin:write"})
   public void testScopePolicyDeletion() throws Exception {
     mvc.perform(MockMvcRequestBuilders.delete("/iam/scope_policies/1"))
       .andExpect(status().isNoContent());
@@ -462,7 +462,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:read")
   public void testScopePolicyAccess() throws Exception {
 
     mvc.perform(get("/iam/scope_policies/1"))
@@ -480,7 +480,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
   public void testScopeCascade() throws Exception {
 
     ScopePolicyDTO sp = new ScopePolicyDTO();
@@ -526,7 +526,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"admin:read", "admin:write"})
   public void testDefaultPolicyUpdate() throws Exception {
     final String description = "DENY ALL!";
 
@@ -549,7 +549,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
   
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
   public void testPolicyUpdateValidationError() throws Exception {
     final String description = "DENY ALL!";
 
@@ -565,7 +565,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
   public void testNonExistingPolicyUpdate() throws Exception {
     final String description = "DENY ALL!";
 
@@ -582,7 +582,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
   public void testEquivalentPolicyCreationNotAllowed() throws Exception {
     IamGroup analysisGroup = groupRepo.findByName("Analysis")
       .orElseThrow(() -> new AssertionError("Expected Analysis group not found"));
@@ -607,7 +607,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"admin:read", "admin:write"})
   public void testEquivalentPolicyUpdateNotAllowed() throws Exception {
     IamGroup analysisGroup = groupRepo.findByName("Analysis")
       .orElseThrow(() -> new AssertionError("Expected Analysis group not found"));

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/scope/pdp/ScopePolicyApiIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/scope/pdp/ScopePolicyApiIntegrationTests.java
@@ -107,7 +107,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
 
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:read")
   public void listPolicyWorksForAdminUserTest() throws Exception {
     mvc.perform(get("/iam/scope_policies"))
       .andExpect(status().isOk())
@@ -118,7 +118,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:read")
   public void listUserPolicyTest() throws Exception {
 
     IamAccount testAccount = accountRepo.findByUsername("test")
@@ -153,7 +153,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
 
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:read")
   public void listGroupPolicyTest() throws Exception {
 
     IamGroup prodGroup = groupRepo.findByName("Production")
@@ -187,7 +187,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
   public void defaultPolicyRuleValidationTest() throws Exception {
     ScopePolicyDTO sp = new ScopePolicyDTO();
     sp.setRule("ciccio");
@@ -199,7 +199,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
   public void invalidAccountIdRuleValidationTest() throws Exception {
     ScopePolicyDTO sp = new ScopePolicyDTO();
     sp.setRule(PolicyRule.DENY.name());
@@ -215,7 +215,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
   public void invalidGroupIdRuleValidationTest() throws Exception {
     ScopePolicyDTO sp = new ScopePolicyDTO();
     sp.setRule(PolicyRule.DENY.name());
@@ -234,7 +234,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
   public void invalidScopePolicyRuleValidationTest() throws Exception {
     IamAccount testAccount = accountRepo.findByUsername("test")
       .orElseThrow(() -> new AssertionError("Expected test user not found"));
@@ -261,7 +261,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
   public void invalidScopePolicyScopesLengthLowerBound() throws Exception {
 
     ScopePolicyDTO sp = new ScopePolicyDTO();
@@ -288,7 +288,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
   public void invalidScopePolicyScopesLengthUpperBound() throws Exception {
 
     StringBuilder s = new StringBuilder();
@@ -307,7 +307,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
   
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
   public void invalidScopeMatchingPolicy() throws Exception {
 
     ScopePolicyDTO sp = new ScopePolicyDTO();
@@ -323,7 +323,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
   public void testDefaultPolicyCreation() throws Exception {
 
     ScopePolicyDTO sp = new ScopePolicyDTO();
@@ -338,7 +338,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
   
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
   public void testMatchingPolicyIsRequired() throws Exception {
 
     ScopePolicyDTO sp = new ScopePolicyDTO();
@@ -353,7 +353,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
   public void testDefaultPolicyCreationNoScopes() throws Exception {
 
     ScopePolicyDTO sp = new ScopePolicyDTO();
@@ -367,7 +367,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"admin:read", "admin:write"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"iam:admin:read", "iam:admin:write"})
   public void testAccountPolicyCreation() throws Exception {
 
     // Cleanup all policies
@@ -407,7 +407,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"admin:read", "admin:write"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"iam:admin:read", "iam:admin:write"})
   public void testGroupPolicyCreation() throws Exception {
     // Cleanup all policies
     scopePolicyRepo.deleteAll();
@@ -445,7 +445,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"admin:read", "admin:write"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"iam:admin:read", "iam:admin:write"})
   public void testScopePolicyDeletion() throws Exception {
     mvc.perform(MockMvcRequestBuilders.delete("/iam/scope_policies/1"))
       .andExpect(status().isNoContent());
@@ -462,7 +462,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:read")
   public void testScopePolicyAccess() throws Exception {
 
     mvc.perform(get("/iam/scope_policies/1"))
@@ -480,7 +480,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
   public void testScopeCascade() throws Exception {
 
     ScopePolicyDTO sp = new ScopePolicyDTO();
@@ -526,7 +526,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"admin:read", "admin:write"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"iam:admin:read", "iam:admin:write"})
   public void testDefaultPolicyUpdate() throws Exception {
     final String description = "DENY ALL!";
 
@@ -549,7 +549,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
   
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
   public void testPolicyUpdateValidationError() throws Exception {
     final String description = "DENY ALL!";
 
@@ -565,7 +565,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
   public void testNonExistingPolicyUpdate() throws Exception {
     final String description = "DENY ALL!";
 
@@ -582,7 +582,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
   public void testEquivalentPolicyCreationNotAllowed() throws Exception {
     IamGroup analysisGroup = groupRepo.findByName("Analysis")
       .orElseThrow(() -> new AssertionError("Expected Analysis group not found"));
@@ -607,7 +607,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"admin:read", "admin:write"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"iam:admin:read", "iam:admin:write"})
   public void testEquivalentPolicyUpdateNotAllowed() throws Exception {
     IamGroup analysisGroup = groupRepo.findByName("Analysis")
       .orElseThrow(() -> new AssertionError("Expected Analysis group not found"));

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/scope/pdp/ScopePolicyApiIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/scope/pdp/ScopePolicyApiIntegrationTests.java
@@ -107,7 +107,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
 
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin.read")
   public void listPolicyWorksForAdminUserTest() throws Exception {
     mvc.perform(get("/iam/scope_policies"))
       .andExpect(status().isOk())
@@ -118,7 +118,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin.read")
   public void listUserPolicyTest() throws Exception {
 
     IamAccount testAccount = accountRepo.findByUsername("test")
@@ -153,7 +153,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
 
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin.read")
   public void listGroupPolicyTest() throws Exception {
 
     IamGroup prodGroup = groupRepo.findByName("Production")
@@ -187,7 +187,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin.write")
   public void defaultPolicyRuleValidationTest() throws Exception {
     ScopePolicyDTO sp = new ScopePolicyDTO();
     sp.setRule("ciccio");
@@ -199,7 +199,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin.write")
   public void invalidAccountIdRuleValidationTest() throws Exception {
     ScopePolicyDTO sp = new ScopePolicyDTO();
     sp.setRule(PolicyRule.DENY.name());
@@ -215,7 +215,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin.write")
   public void invalidGroupIdRuleValidationTest() throws Exception {
     ScopePolicyDTO sp = new ScopePolicyDTO();
     sp.setRule(PolicyRule.DENY.name());
@@ -234,7 +234,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin.write")
   public void invalidScopePolicyRuleValidationTest() throws Exception {
     IamAccount testAccount = accountRepo.findByUsername("test")
       .orElseThrow(() -> new AssertionError("Expected test user not found"));
@@ -261,7 +261,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin.write")
   public void invalidScopePolicyScopesLengthLowerBound() throws Exception {
 
     ScopePolicyDTO sp = new ScopePolicyDTO();
@@ -288,7 +288,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin.write")
   public void invalidScopePolicyScopesLengthUpperBound() throws Exception {
 
     StringBuilder s = new StringBuilder();
@@ -307,7 +307,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
   
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin.write")
   public void invalidScopeMatchingPolicy() throws Exception {
 
     ScopePolicyDTO sp = new ScopePolicyDTO();
@@ -323,7 +323,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin.write")
   public void testDefaultPolicyCreation() throws Exception {
 
     ScopePolicyDTO sp = new ScopePolicyDTO();
@@ -338,7 +338,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
   
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin.write")
   public void testMatchingPolicyIsRequired() throws Exception {
 
     ScopePolicyDTO sp = new ScopePolicyDTO();
@@ -353,7 +353,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin.write")
   public void testDefaultPolicyCreationNoScopes() throws Exception {
 
     ScopePolicyDTO sp = new ScopePolicyDTO();
@@ -367,7 +367,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"iam:admin:read", "iam:admin:write"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"iam:admin.read", "iam:admin.write"})
   public void testAccountPolicyCreation() throws Exception {
 
     // Cleanup all policies
@@ -407,7 +407,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"iam:admin:read", "iam:admin:write"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"iam:admin.read", "iam:admin.write"})
   public void testGroupPolicyCreation() throws Exception {
     // Cleanup all policies
     scopePolicyRepo.deleteAll();
@@ -445,7 +445,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"iam:admin:read", "iam:admin:write"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"iam:admin.read", "iam:admin.write"})
   public void testScopePolicyDeletion() throws Exception {
     mvc.perform(MockMvcRequestBuilders.delete("/iam/scope_policies/1"))
       .andExpect(status().isNoContent());
@@ -462,7 +462,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:read")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin.read")
   public void testScopePolicyAccess() throws Exception {
 
     mvc.perform(get("/iam/scope_policies/1"))
@@ -480,7 +480,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin.write")
   public void testScopeCascade() throws Exception {
 
     ScopePolicyDTO sp = new ScopePolicyDTO();
@@ -526,7 +526,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"iam:admin:read", "iam:admin:write"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"iam:admin.read", "iam:admin.write"})
   public void testDefaultPolicyUpdate() throws Exception {
     final String description = "DENY ALL!";
 
@@ -549,7 +549,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
   
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin.write")
   public void testPolicyUpdateValidationError() throws Exception {
     final String description = "DENY ALL!";
 
@@ -565,7 +565,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin.write")
   public void testNonExistingPolicyUpdate() throws Exception {
     final String description = "DENY ALL!";
 
@@ -582,7 +582,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin:write")
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = "iam:admin.write")
   public void testEquivalentPolicyCreationNotAllowed() throws Exception {
     IamGroup analysisGroup = groupRepo.findByName("Analysis")
       .orElseThrow(() -> new AssertionError("Expected Analysis group not found"));
@@ -607,7 +607,7 @@ public class ScopePolicyApiIntegrationTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"iam:admin:read", "iam:admin:write"})
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_USER", "ROLE_ADMIN"}, scopes = {"iam:admin.read", "iam:admin.write"})
   public void testEquivalentPolicyUpdateNotAllowed() throws Exception {
     IamGroup analysisGroup = groupRepo.findByName("Analysis")
       .orElseThrow(() -> new AssertionError("Expected Analysis group not found"));

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/ScimApiAuthzTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/ScimApiAuthzTests.java
@@ -24,7 +24,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -97,13 +96,6 @@ public class ScimApiAuthzTests {
       .andExpect(jsonPath("$.error", equalTo("insufficient_scope")))
       .andExpect(jsonPath("$.error_description", equalTo("Insufficient scope for this resource")))
       .andExpect(jsonPath("$.scope", equalTo("scim:read")));
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  public void testAdminGroupsListRequestSuccess() throws Exception {
-
-    mvc.perform(get(GROUP_URI).contentType(SCIM_CONTENT_TYPE)).andExpect(status().isOk());
   }
 
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/ScimApiAuthzTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/ScimApiAuthzTests.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package it.infn.mw.iam.test.scim.group;
+package it.infn.mw.iam.test.scim;
 
 import static it.infn.mw.iam.api.scim.model.ScimConstants.SCIM_CONTENT_TYPE;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -27,14 +27,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
-import it.infn.mw.iam.test.scim.ScimUtils;
 import it.infn.mw.iam.test.util.WithMockOAuthUser;
 import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
 
 @RunWith(SpringRunner.class)
 @IamMockMvcIntegrationTest
-@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"})
-public class ScimGroupAuthzTests {
+public class ScimApiAuthzTests {
 
   @Autowired
   private MockMvc mvc;
@@ -43,6 +41,7 @@ public class ScimGroupAuthzTests {
   private final static String USER_URI = ScimUtils.getUsersLocation();
 
   @Test
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"})
   public void testGroupsListRequest() throws Exception {
 
     mvc.perform(get(GROUP_URI).contentType(SCIM_CONTENT_TYPE))
@@ -53,7 +52,30 @@ public class ScimGroupAuthzTests {
   }
 
   @Test
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"})
   public void testUsersListRequest() throws Exception {
+
+    mvc.perform(get(USER_URI).contentType(SCIM_CONTENT_TYPE))
+      .andExpect(status().isForbidden())
+      .andExpect(jsonPath("$.error", equalTo("insufficient_scope")))
+      .andExpect(jsonPath("$.error_description", equalTo("Insufficient scope for this resource")))
+      .andExpect(jsonPath("$.scope", equalTo("scim:read")));
+  }
+
+  @Test
+  @WithMockOAuthUser(user = "gm", authorities = {"ROLE_GM:"})
+  public void testGroupsListRequestForGM() throws Exception {
+
+    mvc.perform(get(GROUP_URI).contentType(SCIM_CONTENT_TYPE))
+      .andExpect(status().isForbidden())
+      .andExpect(jsonPath("$.error", equalTo("insufficient_scope")))
+      .andExpect(jsonPath("$.error_description", equalTo("Insufficient scope for this resource")))
+      .andExpect(jsonPath("$.scope", equalTo("scim:read")));
+  }
+
+  @Test
+  @WithMockOAuthUser(user = "gm", authorities = {"ROLE_GM:"})
+  public void testUsersListRequestForGM() throws Exception {
 
     mvc.perform(get(USER_URI).contentType(SCIM_CONTENT_TYPE))
       .andExpect(status().isForbidden())

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/ScimApiAuthzTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/ScimApiAuthzTests.java
@@ -24,6 +24,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -99,17 +100,10 @@ public class ScimApiAuthzTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "gm", authorities = {"ROLE_GM:"})
-  public void testGMScimUserRequestFailure() throws Exception {
+  @WithMockUser(username = "admin", roles = {"ADMIN"})
+  public void testAdminGroupsListRequestSuccess() throws Exception {
 
-    // Some existing user as defined in the test db
-    String uuid = "80e5fb8d-b7c8-451a-89ba-346ae278a66f";
-
-    mvc.perform(get(USER_URI + "/" + uuid).contentType(SCIM_CONTENT_TYPE))
-      .andExpect(status().isForbidden())
-      .andExpect(jsonPath("$.error", equalTo("insufficient_scope")))
-      .andExpect(jsonPath("$.error_description", equalTo("Insufficient scope for this resource")))
-      .andExpect(jsonPath("$.scope", equalTo("scim:read")));
+    mvc.perform(get(GROUP_URI).contentType(SCIM_CONTENT_TYPE)).andExpect(status().isOk());
   }
 
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/ScimApiAuthzTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/ScimApiAuthzTests.java
@@ -98,4 +98,18 @@ public class ScimApiAuthzTests {
       .andExpect(jsonPath("$.scope", equalTo("scim:read")));
   }
 
+  @Test
+  @WithMockOAuthUser(user = "gm", authorities = {"ROLE_GM:"})
+  public void testGMScimUserRequestFailure() throws Exception {
+
+    // Some existing user as defined in the test db
+    String uuid = "80e5fb8d-b7c8-451a-89ba-346ae278a66f";
+
+    mvc.perform(get(USER_URI + "/" + uuid).contentType(SCIM_CONTENT_TYPE))
+      .andExpect(status().isForbidden())
+      .andExpect(jsonPath("$.error", equalTo("insufficient_scope")))
+      .andExpect(jsonPath("$.error_description", equalTo("Insufficient scope for this resource")))
+      .andExpect(jsonPath("$.scope", equalTo("scim:read")));
+  }
+
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/group/ScimGroupAuthzTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/group/ScimGroupAuthzTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package it.infn.mw.iam.test.scim.group;
 
 import static it.infn.mw.iam.api.scim.model.ScimConstants.SCIM_CONTENT_TYPE;

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/group/ScimGroupAuthzTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/group/ScimGroupAuthzTests.java
@@ -1,0 +1,50 @@
+package it.infn.mw.iam.test.scim.group;
+
+import static it.infn.mw.iam.api.scim.model.ScimConstants.SCIM_CONTENT_TYPE;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import it.infn.mw.iam.test.scim.ScimUtils;
+import it.infn.mw.iam.test.util.WithMockOAuthUser;
+import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
+
+@RunWith(SpringRunner.class)
+@IamMockMvcIntegrationTest
+@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"})
+public class ScimGroupAuthzTests {
+
+  @Autowired
+  private MockMvc mvc;
+
+  private final static String GROUP_URI = ScimUtils.getGroupsLocation();
+  private final static String USER_URI = ScimUtils.getUsersLocation();
+
+  @Test
+  public void testGroupsListRequest() throws Exception {
+
+    mvc.perform(get(GROUP_URI).contentType(SCIM_CONTENT_TYPE))
+      .andExpect(status().isForbidden())
+      .andExpect(jsonPath("$.error", equalTo("insufficient_scope")))
+      .andExpect(jsonPath("$.error_description", equalTo("Insufficient scope for this resource")))
+      .andExpect(jsonPath("$.scope", equalTo("scim:read")));
+  }
+
+  @Test
+  public void testUsersListRequest() throws Exception {
+
+    mvc.perform(get(USER_URI).contentType(SCIM_CONTENT_TYPE))
+      .andExpect(status().isForbidden())
+      .andExpect(jsonPath("$.error", equalTo("insufficient_scope")))
+      .andExpect(jsonPath("$.error_description", equalTo("Insufficient scope for this resource")))
+      .andExpect(jsonPath("$.scope", equalTo("scim:read")));
+  }
+
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/updater/UsernameUpdaterTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/updater/UsernameUpdaterTests.java
@@ -50,7 +50,7 @@ import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 
 @RunWith(SpringRunner.class)
 @IamMockMvcIntegrationTest
-@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"})
+@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
 public class UsernameUpdaterTests extends TestTokensUtils {
 
   public static final String OLD = "oldusername";

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/updater/UsernameUpdaterTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/updater/UsernameUpdaterTests.java
@@ -50,7 +50,7 @@ import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 
 @RunWith(SpringRunner.class)
 @IamMockMvcIntegrationTest
-@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "admin:read")
+@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
 public class UsernameUpdaterTests extends TestTokensUtils {
 
   public static final String OLD = "oldusername";

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/updater/UsernameUpdaterTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/updater/UsernameUpdaterTests.java
@@ -50,7 +50,7 @@ import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 
 @RunWith(SpringRunner.class)
 @IamMockMvcIntegrationTest
-@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin:read")
+@WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin.read")
 public class UsernameUpdaterTests extends TestTokensUtils {
 
   public static final String OLD = "oldusername";

--- a/iam-persistence/src/main/resources/db/migration/h2/V92__add_iam_api_scopes.sql
+++ b/iam-persistence/src/main/resources/db/migration/h2/V92__add_iam_api_scopes.sql
@@ -1,6 +1,6 @@
 INSERT INTO system_scope(scope, description, icon, restricted, default_scope, structured, structured_param_description)
   VALUES
-  ('iam:admin:read', 'Read access to IAM APIs', null, true, false, false, null);
+  ('iam:admin.read', 'Read access to IAM APIs', null, true, false, false, null);
 INSERT INTO system_scope(scope, description, icon, restricted, default_scope, structured, structured_param_description)
   VALUES
-  ('iam:admin:write', 'Write access to IAM APIs', null, true, false, false, null);
+  ('iam:admin.write', 'Write access to IAM APIs', null, true, false, false, null);

--- a/iam-persistence/src/main/resources/db/migration/h2/V92__add_iam_api_scopes.sql
+++ b/iam-persistence/src/main/resources/db/migration/h2/V92__add_iam_api_scopes.sql
@@ -1,0 +1,6 @@
+INSERT INTO system_scope(scope, description, icon, restricted, default_scope, structured, structured_param_description)
+  VALUES
+  ('iam:admin:read', 'Read access to IAM APIs', null, true, false, false, null);
+INSERT INTO system_scope(scope, description, icon, restricted, default_scope, structured, structured_param_description)
+  VALUES
+  ('iam:admin:write', 'Write access to IAM APIs', null, true, false, false, null);

--- a/iam-persistence/src/main/resources/db/migration/mysql/V92__add_iam_api_scopes.sql
+++ b/iam-persistence/src/main/resources/db/migration/mysql/V92__add_iam_api_scopes.sql
@@ -1,6 +1,6 @@
 INSERT INTO system_scope(scope, description, icon, restricted, default_scope, structured, structured_param_description)
   VALUES
-  ('iam:admin:read', 'Read access to IAM APIs', null, true, false, false, null);
+  ('iam:admin.read', 'Read access to IAM APIs', null, true, false, false, null);
 INSERT INTO system_scope(scope, description, icon, restricted, default_scope, structured, structured_param_description)
   VALUES
-  ('iam:admin:write', 'Write access to IAM APIs', null, true, false, false, null);
+  ('iam:admin.write', 'Write access to IAM APIs', null, true, false, false, null);

--- a/iam-persistence/src/main/resources/db/migration/mysql/V92__add_iam_api_scopes.sql
+++ b/iam-persistence/src/main/resources/db/migration/mysql/V92__add_iam_api_scopes.sql
@@ -1,0 +1,6 @@
+INSERT IGNORE INTO system_scope(scope, description, icon, restricted, default_scope, structured, structured_param_description)
+  VALUES
+  ('iam:admin:read', 'Read access to IAM APIs', null, true, false, false, null);
+INSERT IGNORE INTO system_scope(scope, description, icon, restricted, default_scope, structured, structured_param_description)
+  VALUES
+  ('iam:admin:write', 'Write access to IAM APIs', null, true, false, false, null);

--- a/iam-persistence/src/main/resources/db/migration/mysql/V92__add_iam_api_scopes.sql
+++ b/iam-persistence/src/main/resources/db/migration/mysql/V92__add_iam_api_scopes.sql
@@ -1,6 +1,6 @@
-INSERT IGNORE INTO system_scope(scope, description, icon, restricted, default_scope, structured, structured_param_description)
+INSERT INTO system_scope(scope, description, icon, restricted, default_scope, structured, structured_param_description)
   VALUES
   ('iam:admin:read', 'Read access to IAM APIs', null, true, false, false, null);
-INSERT IGNORE INTO system_scope(scope, description, icon, restricted, default_scope, structured, structured_param_description)
+INSERT INTO system_scope(scope, description, icon, restricted, default_scope, structured, structured_param_description)
   VALUES
   ('iam:admin:write', 'Write access to IAM APIs', null, true, false, false, null);


### PR DESCRIPTION
This PR avoids that token created by IAM admin have full access to IAM API (issue #543). In fact, the authorisation at IAM API endpoints is based on user's ROLE. The identity of the user is evaluated from browser session or from token sub value. This means that scopes are ignored. This fix introduces the fact that authorisation is based on the user's identity only if it's a browser session, otherwise only scopes count. Two new scopes have been added:
- `iam:admin.read`: it gives the same read privileges of an administrator;
- `iam:admin.write`: it gives the same read & write privileges of an administrator.