### PR TITLE
Fix refresh token lifetime value in case of client credentials or implicit grant types

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/DefaultClientDefaultsService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/DefaultClientDefaultsService.java
@@ -15,7 +15,6 @@
  */
 package it.infn.mw.iam.api.client.service;
 
-import static it.infn.mw.iam.api.common.client.AuthorizationGrantType.IMPLICIT;
 import static java.util.Objects.isNull;
 
 import java.math.BigInteger;
@@ -33,7 +32,6 @@ import org.springframework.stereotype.Service;
 
 import com.google.common.collect.Sets;
 
-import it.infn.mw.iam.api.common.client.AuthorizationGrantType;
 import it.infn.mw.iam.authn.util.Authorities;
 import it.infn.mw.iam.config.client_registration.ClientRegistrationProperties;
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/DefaultClientDefaultsService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/DefaultClientDefaultsService.java
@@ -77,11 +77,6 @@ public class DefaultClientDefaultsService implements ClientDefaultsService {
       client.setRefreshTokenValiditySeconds(rtSecs);
     }
 
-    if (client.getGrantTypes().contains(IMPLICIT.getGrantType()) || client.getGrantTypes()
-      .contains(AuthorizationGrantType.CLIENT_CREDENTIALS.getGrantType())) {
-      client.setRefreshTokenValiditySeconds(0);
-    }
-
     client.setAllowIntrospection(true);
 
     if (isNull(client.getContacts())) {


### PR DESCRIPTION
When a client is dynamically registered and contains client credentials or implicit as grant types, the refresh token lifetime is unnecessarily set to zero.