### PR TITLE
Avoid upper case characters into VO names

### DIFF
--- a/iam-voms-aa/src/main/java/it/infn/mw/voms/properties/VomsProperties.java
+++ b/iam-voms-aa/src/main/java/it/infn/mw/voms/properties/VomsProperties.java
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Positive;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -103,6 +104,7 @@ public class VomsProperties {
   public static class VOMSAAProperties {
 
     @NotBlank
+    @Pattern(regexp="^[a-z_]([a-z0-9_-]*$)$")
     private String voName;
 
     @NotBlank

--- a/iam-voms-aa/src/main/java/it/infn/mw/voms/properties/VomsProperties.java
+++ b/iam-voms-aa/src/main/java/it/infn/mw/voms/properties/VomsProperties.java
@@ -104,7 +104,7 @@ public class VomsProperties {
   public static class VOMSAAProperties {
 
     @NotBlank
-    @Pattern(regexp="^[a-z_]([a-z0-9_-]*$)$")
+    @Pattern(regexp = "^[a-z][a-z0-9\\-]*(\\.[a-z][a-z0-9\\-]*)*$")
     private String voName;
 
     @NotBlank

--- a/iam-voms-aa/src/test/java/it/infn/mw/voms/properties/VomsPropertiesValidatorTests.java
+++ b/iam-voms-aa/src/test/java/it/infn/mw/voms/properties/VomsPropertiesValidatorTests.java
@@ -18,6 +18,7 @@ package it.infn.mw.voms.properties;
 import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import java.util.Set;
 
 import javax.validation.ConstraintViolation;
@@ -34,6 +35,10 @@ import it.infn.mw.voms.properties.VomsProperties.VOMSAAProperties;
 public class VomsPropertiesValidatorTests {
   private static ValidatorFactory validatorFactory;
   private static Validator validator;
+  private static final List<String> invalidExampleVONames = List.of("VO-name.test", "vo_name.test", "1vo-name.test",
+      "_vo-name.test", "vo_name.test", "vo_name.test1");
+  private static final String validVOName = "vo1-name.test";
+  private static final String validVOHost = "vo-host";
 
   @BeforeClass
   public static void createValidator() {
@@ -47,20 +52,22 @@ public class VomsPropertiesValidatorTests {
   }
 
   @Test
-  public void invalidUppercaseVoName() {
+  public void invalidVoName() {
     VOMSAAProperties vomsaa = new VOMSAAProperties();
-    vomsaa.setHost("vo-host");
-    vomsaa.setVoName("VO-name");
-    Set<ConstraintViolation<VOMSAAProperties>> violations = validator.validate(vomsaa);
-    assertFalse(violations.isEmpty());
+    vomsaa.setHost(validVOHost);
+    for (String voName : invalidExampleVONames) {
+      vomsaa.setVoName(voName);
+      Set<ConstraintViolation<VOMSAAProperties>> violations = validator.validate(vomsaa);
+      assertFalse(violations.isEmpty());
+    }
   }
 
   @Test
-  public void validDowncaseVoName() {
+  public void validVoName() {
     VOMSAAProperties vomsaa = new VOMSAAProperties();
-    vomsaa.setVoName("vo-name");
-    vomsaa.setHost("vo-host");
+    vomsaa.setHost(validVOHost);
+    vomsaa.setVoName(validVOName);
     Set<ConstraintViolation<VOMSAAProperties>> violations = validator.validate(vomsaa);
     assertTrue(violations.isEmpty());
-  } 
+  }
 }

--- a/iam-voms-aa/src/test/java/it/infn/mw/voms/properties/VomsPropertiesValidatorTests.java
+++ b/iam-voms-aa/src/test/java/it/infn/mw/voms/properties/VomsPropertiesValidatorTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package it.infn.mw.voms.properties;
 
 import static org.junit.Assert.assertFalse;

--- a/iam-voms-aa/src/test/java/it/infn/mw/voms/properties/VomsPropertiesValidatorTests.java
+++ b/iam-voms-aa/src/test/java/it/infn/mw/voms/properties/VomsPropertiesValidatorTests.java
@@ -1,0 +1,51 @@
+package it.infn.mw.voms.properties;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import it.infn.mw.voms.properties.VomsProperties.VOMSAAProperties;
+
+public class VomsPropertiesValidatorTests {
+  private static ValidatorFactory validatorFactory;
+  private static Validator validator;
+
+  @BeforeClass
+  public static void createValidator() {
+    validatorFactory = Validation.buildDefaultValidatorFactory();
+    validator = validatorFactory.getValidator();
+  }
+
+  @AfterClass
+  public static void close() {
+    validatorFactory.close();
+  }
+
+  @Test
+  public void invalidUppercaseVoName() {
+    VOMSAAProperties vomsaa = new VOMSAAProperties();
+    vomsaa.setHost("vo-host");
+    vomsaa.setVoName("VO-name");
+    Set<ConstraintViolation<VOMSAAProperties>> violations = validator.validate(vomsaa);
+    assertFalse(violations.isEmpty());
+  }
+
+  @Test
+  public void validDowncaseVoName() {
+    VOMSAAProperties vomsaa = new VOMSAAProperties();
+    vomsaa.setVoName("vo-name");
+    vomsaa.setHost("vo-host");
+    Set<ConstraintViolation<VOMSAAProperties>> violations = validator.validate(vomsaa);
+    assertTrue(violations.isEmpty());
+  } 
+}


### PR DESCRIPTION
This PR follows the [CERN's VO Registration Procedure](https://edms.cern.ch/ui/#!master/navigator/document?D:1517359180:1517359180:subDocs) which says that "Considering that RFC1034 section 3.5 states that both upper case and lower case letters are allowed, but no significance is to be attached to the case, but that today the software handling VO names may still be case sensitive, all VO names MUST be entirely in lower case".