### PR TITLE
Fix update of AT/RT lifetmes

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/DefaultClientDefaultsService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/DefaultClientDefaultsService.java
@@ -60,22 +60,11 @@ public class DefaultClientDefaultsService implements ClientDefaultsService {
       client.setClientId(UUID.randomUUID().toString());
     }
 
-    client.setAccessTokenValiditySeconds(
-        properties.getClientDefaults().getDefaultAccessTokenValiditySeconds());
-
     client
       .setIdTokenValiditySeconds(properties.getClientDefaults().getDefaultIdTokenValiditySeconds());
 
     client.setDeviceCodeValiditySeconds(
         properties.getClientDefaults().getDefaultDeviceCodeValiditySeconds());
-
-    final int rtSecs = properties.getClientDefaults().getDefaultRefreshTokenValiditySeconds();
-
-    if (rtSecs < 0) {
-      client.setRefreshTokenValiditySeconds(null);
-    } else {
-      client.setRefreshTokenValiditySeconds(rtSecs);
-    }
 
     if (client.getGrantTypes().contains(IMPLICIT.getGrantType()) || client.getGrantTypes()
       .contains(AuthorizationGrantType.CLIENT_CREDENTIALS.getGrantType())) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/client_registration/ClientRegistrationProperties.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/client_registration/ClientRegistrationProperties.java
@@ -19,6 +19,8 @@ import static it.infn.mw.iam.config.client_registration.ClientRegistrationProper
 
 import java.util.concurrent.TimeUnit;
 
+import javax.validation.constraints.NotNull;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
@@ -28,10 +30,14 @@ public class ClientRegistrationProperties {
 
   public static class ClientDefaultsProperties {
 
-    private int defaultAccessTokenValiditySeconds = (int) TimeUnit.HOURS.toSeconds(1);
+	@NotNull(message = "Provide a default access token lifetime")
+    private int defaultAccessTokenValiditySeconds;
+	
+	@NotNull(message = "Provide a default refresh token lifetime")
+    private int defaultRefreshTokenValiditySeconds;
+	
     private int defaultIdTokenValiditySeconds = (int) TimeUnit.MINUTES.toSeconds(10);
     private int defaultDeviceCodeValiditySeconds = (int) TimeUnit.MINUTES.toSeconds(10);
-    private int defaultRefreshTokenValiditySeconds = (int) TimeUnit.DAYS.toSeconds(30);
 
     private int defaultRegistrationAccessTokenValiditySeconds = -1;
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/web/util/IamViewInfoInterceptor.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/web/util/IamViewInfoInterceptor.java
@@ -24,6 +24,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import it.infn.mw.iam.config.IamProperties;
+import it.infn.mw.iam.config.client_registration.ClientRegistrationProperties;
+import it.infn.mw.iam.config.client_registration.ClientRegistrationProperties.ClientDefaultsProperties;
 import it.infn.mw.iam.config.saml.IamSamlProperties;
 import it.infn.mw.iam.core.web.loginpage.LoginPageConfiguration;
 import it.infn.mw.iam.rcauth.RCAuthProperties;
@@ -39,8 +41,8 @@ public class IamViewInfoInterceptor implements HandlerInterceptor {
   public static final String GIT_COMMIT_ID_KEY = "gitCommitId";
   public static final String SIMULATE_NETWORK_LATENCY_KEY = "simulateNetworkLatency";
   public static final String RCAUTH_ENABLED_KEY = "iamRcauthEnabled";
-
   public static final String RESOURCES_PATH_KEY = "resourcesPrefix";
+  public static final String CLIENT_DEFAULTS_PROPERTIES_KEY = "clientDefaultsProperties";
 
   @Value("${iam.version}")
   String iamVersion;
@@ -62,7 +64,10 @@ public class IamViewInfoInterceptor implements HandlerInterceptor {
 
   @Autowired
   IamProperties iamProperties;
-
+  
+  @Autowired
+  ClientRegistrationProperties clientRegistrationProperties;
+  
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
       throws Exception {
@@ -78,6 +83,7 @@ public class IamViewInfoInterceptor implements HandlerInterceptor {
     
     request.setAttribute(RCAUTH_ENABLED_KEY, rcAuthProperties.isEnabled());
     
+    request.setAttribute(CLIENT_DEFAULTS_PROPERTIES_KEY, clientRegistrationProperties.getClientDefaults());
 
     if (iamProperties.getVersionedStaticResources().isEnableVersioning()) {
       request.setAttribute(RESOURCES_PATH_KEY, String.format("/resources/%s", gitCommitId));

--- a/iam-login-service/src/main/resources/application.yml
+++ b/iam-login-service/src/main/resources/application.yml
@@ -210,6 +210,9 @@ task:
 client-registration:
   allow-for: ${IAM_CLIENT_REGISTRATION_ALLOW_FOR:ANYONE}
   enable: ${IAM_CLIENT_REGISTRATION_ENABLE:true}
+  client-defaults:
+    default-access-token-validity-seconds: ${DEFAULT_ACCESS_TOKEN_VALIDITY_SECONDS:3600}
+
 
 management:
   health:

--- a/iam-login-service/src/main/resources/application.yml
+++ b/iam-login-service/src/main/resources/application.yml
@@ -211,8 +211,8 @@ client-registration:
   allow-for: ${IAM_CLIENT_REGISTRATION_ALLOW_FOR:ANYONE}
   enable: ${IAM_CLIENT_REGISTRATION_ENABLE:true}
   client-defaults:
-    default-access-token-validity-seconds: ${DEFAULT_ACCESS_TOKEN_VALIDITY_SECONDS:0}
-    default-refresh-token-validity-seconds: ${DEFAULT_REFRESH_TOKEN_VALIDITY_SECONDS:20}
+    default-access-token-validity-seconds: ${DEFAULT_ACCESS_TOKEN_VALIDITY_SECONDS:3600}
+    default-refresh-token-validity-seconds: ${DEFAULT_REFRESH_TOKEN_VALIDITY_SECONDS:108000}
 
 
 management:

--- a/iam-login-service/src/main/resources/application.yml
+++ b/iam-login-service/src/main/resources/application.yml
@@ -211,7 +211,8 @@ client-registration:
   allow-for: ${IAM_CLIENT_REGISTRATION_ALLOW_FOR:ANYONE}
   enable: ${IAM_CLIENT_REGISTRATION_ENABLE:true}
   client-defaults:
-    default-access-token-validity-seconds: ${DEFAULT_ACCESS_TOKEN_VALIDITY_SECONDS:3600}
+    default-access-token-validity-seconds: ${DEFAULT_ACCESS_TOKEN_VALIDITY_SECONDS:0}
+    default-refresh-token-validity-seconds: ${DEFAULT_REFRESH_TOKEN_VALIDITY_SECONDS:20}
 
 
 management:

--- a/iam-login-service/src/main/webapp/WEB-INF/tags/iamHeader.tag
+++ b/iam-login-service/src/main/webapp/WEB-INF/tags/iamHeader.tag
@@ -88,6 +88,10 @@ function getOrganisationName() {
  return '${iamOrganisationName}'; 
 }
 
+function getAccessTokenValiditySeconds() {
+		return ${clientDefaultsProperties.defaultAccessTokenValiditySeconds};
+}
+
 function getOidcEnabled() {
   return ${loginPageConfiguration.oidcEnabled};
 }

--- a/iam-login-service/src/main/webapp/WEB-INF/tags/iamHeader.tag
+++ b/iam-login-service/src/main/webapp/WEB-INF/tags/iamHeader.tag
@@ -92,6 +92,10 @@ function getAccessTokenValiditySeconds() {
 		return ${clientDefaultsProperties.defaultAccessTokenValiditySeconds};
 }
 
+function getRefreshTokenValiditySeconds() {
+		return ${clientDefaultsProperties.defaultRefreshTokenValiditySeconds};
+}
+
 function getOidcEnabled() {
   return ${loginPageConfiguration.oidcEnabled};
 }

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.html
@@ -20,14 +20,14 @@
         <div class="form-group">
             <label for="at_timeout">Access token timeout (seconds)</label>
             <input id="at_timeout" class="form-control" type="text"
-                ng-model="$ctrl.client.access_token_validity_seconds" placeholder="3600"
+                ng-model="$ctrl.client.access_token_validity_seconds"
                 ng-disabled="$ctrl.client.access_token_validity_seconds <= 0">
         </div>
 
         <div class="checkbox">
             <label>
                 <input type="checkbox" ng-model="$ctrl.client.access_token_validity_seconds" ng-true-value="0"
-                    ng-false-value="3600">
+                    ng-false-value="{{$ctrl.client.access_token_validity_seconds}}">
                 Access tokens do not expire
             </label>
         </div>

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.html
@@ -21,7 +21,7 @@
             <label for="at_timeout">Access token timeout (seconds)</label>
             <input id="at_timeout" class="form-control" type="text"
                 ng-model="$ctrl.client.access_token_validity_seconds"
-                ng-disabled="$ctrl.isATBoxChecked">
+                ng-disabled="$ctrl.atDoNotExpire  && $ctrl.accessTokenValiditySeconds > 0">
         </div>
 
         <div class="checkbox">
@@ -67,7 +67,7 @@
 
         <input id="rt_timeout" class="form-control" type="text" ng-model="$ctrl.client.refresh_token_validity_seconds"
             ng-required ng-min="30"
-            ng-disabled="$ctrl.isRTBoxChecked && $ctrl.refreshTokenValiditySeconds > 0">
+            ng-disabled="$ctrl.rtDoNotExpire && $ctrl.refreshTokenValiditySeconds > 0">
 
         <div class="checkbox">
             <label>

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.html
@@ -21,7 +21,7 @@
             <label for="at_timeout">Access token timeout (seconds)</label>
             <input id="at_timeout" class="form-control" type="text"
                 ng-model="$ctrl.client.access_token_validity_seconds"
-                ng-disabled="$ctrl.client.access_token_validity_seconds <= 0">
+                ng-disabled="$ctrl.isATBoxChecked">
         </div>
 
         <div class="checkbox">
@@ -66,12 +66,13 @@
         <label for="rt_timeout">Refresh token timeout (seconds)</label>
 
         <input id="rt_timeout" class="form-control" type="text" ng-model="$ctrl.client.refresh_token_validity_seconds"
-            placeholder="259200" ng-required ng-min="30" ng-disabled="$ctrl.client.refresh_token_validity_seconds <= 0">
+            ng-required ng-min="30"
+            ng-disabled="$ctrl.isRTBoxChecked && $ctrl.refreshTokenValiditySeconds > 0">
 
         <div class="checkbox">
             <label>
                 <input type="checkbox" ng-model="$ctrl.client.refresh_token_validity_seconds" ng-true-value="0"
-                    ng-false-value="259200">
+                    ng-false-value="{{$ctrl.client.refresh_token_validity_seconds}}">
                 Refresh tokens do not expire
             </label>
         </div>

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.js
@@ -27,30 +27,38 @@
         self.canIssueRefreshTokens = false;
         self.hasDeviceCodeGrantType = false;
         self.accessTokenValiditySeconds = getAccessTokenValiditySeconds();
+        self.refreshTokenValiditySeconds = getRefreshTokenValiditySeconds();
+        self.isATBoxChecked = false;
+        self.isRTBoxChecked = false;
 
         self.$onInit = function () {
+
             console.debug('TokenSettingsController.self', self);
             if (!self.client.access_token_validity_seconds) {
                 self.client.access_token_validity_seconds = self.accessTokenValiditySeconds;
             }
 
-            console.log('client.access_token_validity_seconds = ' + self.client.access_token_validity_seconds);
-            console.log('accessTokenValiditySeconds = ' + self.accessTokenValiditySeconds);
-
             if (!self.client.refresh_token_validity_seconds) {
-                self.client.refresh_token_validity_seconds = 0;
+                self.client.refresh_token_validity_seconds = self.refreshTokenValiditySeconds;
             }
 
             $scope.$watch('$ctrl.client.access_token_validity_seconds', function handleChange(newVal, oldVal) {
                 if(newVal <= 0){
                     self.client.access_token_validity_seconds = 0;
+                    self.isATBoxChecked = true;
                 }
+                else self.isATBoxChecked = false;
+
+                console.log('Is AT box checked? ' + self.isATBoxChecked);
+                console.log('client.access_token_validity_seconds = ' + self.client.access_token_validity_seconds);
             });
 
             $scope.$watch('$ctrl.client.refresh_token_validity_seconds', function handleChange(newVal, oldVal) {
-                if (!self.client.refresh_token_validity_seconds) {
+                if (newVal <= 0) {
                     self.client.refresh_token_validity_seconds = 0;
+                    self.isRTBoxChecked = true;
                 }
+                else self.isRTBoxChecked = false;
             });
 
             $scope.$watch('$ctrl.client.grant_types', function handleChange(newVal, oldVal) {

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.js
@@ -28,11 +28,10 @@
         self.hasDeviceCodeGrantType = false;
         self.accessTokenValiditySeconds = getAccessTokenValiditySeconds();
         self.refreshTokenValiditySeconds = getRefreshTokenValiditySeconds();
-        self.isATBoxChecked = false;
-        self.isRTBoxChecked = false;
+        self.atDoNotExpire = false;
+        self.rtDoNotExpire = false;
 
         self.$onInit = function () {
-
             console.debug('TokenSettingsController.self', self);
             if (!self.client.access_token_validity_seconds) {
                 self.client.access_token_validity_seconds = self.accessTokenValiditySeconds;
@@ -43,22 +42,25 @@
             }
 
             $scope.$watch('$ctrl.client.access_token_validity_seconds', function handleChange(newVal, oldVal) {
-                if(newVal <= 0){
-                    self.client.access_token_validity_seconds = 0;
-                    self.isATBoxChecked = true;
-                }
-                else self.isATBoxChecked = false;
 
-                console.log('Is AT box checked? ' + self.isATBoxChecked);
-                console.log('client.access_token_validity_seconds = ' + self.client.access_token_validity_seconds);
+                if (newVal <= 0) {
+                    self.client.access_token_validity_seconds = 0;
+                    self.atDoNotExpire = true;
+                } else {
+                    self.atDoNotExpire = false;
+                }
+
             });
 
             $scope.$watch('$ctrl.client.refresh_token_validity_seconds', function handleChange(newVal, oldVal) {
+
                 if (newVal <= 0) {
                     self.client.refresh_token_validity_seconds = 0;
-                    self.isRTBoxChecked = true;
+                    self.rtDoNotExpire = true;
+                } else {
+                    self.rtDoNotExpire = false;
                 }
-                else self.isRTBoxChecked = false;
+
             });
 
             $scope.$watch('$ctrl.client.grant_types', function handleChange(newVal, oldVal) {

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.js
@@ -26,19 +26,23 @@
         self.toggleOfflineAccess = toggleOfflineAccess;
         self.canIssueRefreshTokens = false;
         self.hasDeviceCodeGrantType = false;
-
+        self.accessTokenValiditySeconds = getAccessTokenValiditySeconds();
 
         self.$onInit = function () {
             console.debug('TokenSettingsController.self', self);
             if (!self.client.access_token_validity_seconds) {
-                self.client.access_token_validity_seconds = 0;
+                self.client.access_token_validity_seconds = self.accessTokenValiditySeconds;
             }
+
+            console.log('client.access_token_validity_seconds = ' + self.client.access_token_validity_seconds);
+            console.log('accessTokenValiditySeconds = ' + self.accessTokenValiditySeconds);
+
             if (!self.client.refresh_token_validity_seconds) {
                 self.client.refresh_token_validity_seconds = 0;
             }
 
             $scope.$watch('$ctrl.client.access_token_validity_seconds', function handleChange(newVal, oldVal) {
-                if (!self.client.access_token_validity_seconds) {
+                if(newVal <= 0){
                     self.client.access_token_validity_seconds = 0;
                 }
             });


### PR DESCRIPTION
The Access Token and Refresh Token lifetimes are now shown (to IAM Admins) according with the values set by configuration.
An Admin can also modify those values via web interface.