### PR TITLE
Fix management of tokens lifetime following RFC9068

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/ClientConverter.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/ClientConverter.java
@@ -231,6 +231,11 @@ public class ClientConverter {
       client.setCodeChallengeMethod(pkceAlgo);
     }
 
+    client.setAccessTokenValiditySeconds(
+        clientProperties.getClientDefaults().getDefaultAccessTokenValiditySeconds());
+    client.setRefreshTokenValiditySeconds(
+        clientProperties.getClientDefaults().getDefaultRefreshTokenValiditySeconds());
+
     return client;
   }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/ClientConverter.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/ClientConverter.java
@@ -68,14 +68,14 @@ public class ClientConverter {
 
     if (dto.getAccessTokenValiditySeconds() != null) {
       if (dto.getAccessTokenValiditySeconds() <= 0) {
-        client.setAccessTokenValiditySeconds(null);
+        client.setAccessTokenValiditySeconds(0);
       } else {
         client.setAccessTokenValiditySeconds(dto.getAccessTokenValiditySeconds());
       }
     }
     if (dto.getRefreshTokenValiditySeconds() != null) {
       if (dto.getRefreshTokenValiditySeconds() <= 0) {
-        client.setRefreshTokenValiditySeconds(null);
+        client.setRefreshTokenValiditySeconds(0);
       } else {
         client.setRefreshTokenValiditySeconds(dto.getRefreshTokenValiditySeconds());
       }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/ClientConverter.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/ClientConverter.java
@@ -38,6 +38,7 @@ import it.infn.mw.iam.api.common.client.OAuthResponseType;
 import it.infn.mw.iam.api.common.client.RegisteredClientDTO;
 import it.infn.mw.iam.api.common.client.TokenEndpointAuthenticationMethod;
 import it.infn.mw.iam.config.IamProperties;
+import it.infn.mw.iam.config.client_registration.ClientRegistrationProperties;
 
 @Component
 public class ClientConverter {
@@ -46,11 +47,14 @@ public class ClientConverter {
 
   private final String clientRegistrationBaseUrl;
 
+  private final ClientRegistrationProperties clientProperties;
+
   @Autowired
-  public ClientConverter(IamProperties properties) {
+  public ClientConverter(IamProperties properties, ClientRegistrationProperties clientProperties) {
     this.iamProperties = properties;
     clientRegistrationBaseUrl =
         String.format("%s%s", iamProperties.getBaseUrl(), ClientRegistrationApiController.ENDPOINT);
+    this.clientProperties = clientProperties;
   }
 
   private <T> Set<T> cloneSet(Set<T> stringSet) {
@@ -228,12 +232,18 @@ public class ClientConverter {
       client.setCodeChallengeMethod(pkceAlgo);
     }
 
-    if (dto.getAccessTokenValiditySeconds() != null) {
+    if (!isNull(dto.getAccessTokenValiditySeconds())) {
       client.setAccessTokenValiditySeconds(dto.getAccessTokenValiditySeconds());
+    } else {
+      client.setAccessTokenValiditySeconds(
+          clientProperties.getClientDefaults().getDefaultAccessTokenValiditySeconds());
     }
-    
-    if (dto.getRefreshTokenValiditySeconds() != null) {
+
+    if (!isNull(dto.getRefreshTokenValiditySeconds())) {
       client.setRefreshTokenValiditySeconds(dto.getRefreshTokenValiditySeconds());
+    } else {
+      client.setRefreshTokenValiditySeconds(
+          clientProperties.getClientDefaults().getDefaultRefreshTokenValiditySeconds());
     }
 
     return client;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/ClientConverter.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/ClientConverter.java
@@ -193,19 +193,16 @@ public class ClientConverter {
 
     client.setLogoUri(dto.getLogoUri());
     client.setPolicyUri(dto.getPolicyUri());
-    
+
     client.setRedirectUris(cloneSet(dto.getRedirectUris()));
 
     client.setScope(cloneSet(dto.getScope()));
-    
-    client.setGrantTypes(new HashSet<>());   
+
+    client.setGrantTypes(new HashSet<>());
 
     if (!isNull(dto.getGrantTypes())) {
       client.setGrantTypes(
-          dto.getGrantTypes()
-          .stream()
-          .map(AuthorizationGrantType::getGrantType)
-          .collect(toSet()));
+          dto.getGrantTypes().stream().map(AuthorizationGrantType::getGrantType).collect(toSet()));
     }
 
     if (dto.getScope().contains("offline_access")) {
@@ -229,6 +226,14 @@ public class ClientConverter {
     if (dto.getCodeChallengeMethod() != null) {
       PKCEAlgorithm pkceAlgo = PKCEAlgorithm.parse(dto.getCodeChallengeMethod());
       client.setCodeChallengeMethod(pkceAlgo);
+    }
+
+    if (dto.getAccessTokenValiditySeconds() != null) {
+      client.setAccessTokenValiditySeconds(dto.getAccessTokenValiditySeconds());
+    }
+    
+    if (dto.getRefreshTokenValiditySeconds() != null) {
+      client.setRefreshTokenValiditySeconds(dto.getRefreshTokenValiditySeconds());
     }
 
     return client;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/ClientConverter.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/ClientConverter.java
@@ -71,18 +71,17 @@ public class ClientConverter {
     ClientDetailsEntity client = entityFromRegistrationRequest(dto);
 
     if (dto.getAccessTokenValiditySeconds() != null) {
-      if (dto.getAccessTokenValiditySeconds() <= 0) {
-        client.setAccessTokenValiditySeconds(0);
-      } else {
-        client.setAccessTokenValiditySeconds(dto.getAccessTokenValiditySeconds());
-      }
+      client.setAccessTokenValiditySeconds(dto.getAccessTokenValiditySeconds());
+    } else {
+      client.setAccessTokenValiditySeconds(
+          clientProperties.getClientDefaults().getDefaultAccessTokenValiditySeconds());
     }
+
     if (dto.getRefreshTokenValiditySeconds() != null) {
-      if (dto.getRefreshTokenValiditySeconds() <= 0) {
-        client.setRefreshTokenValiditySeconds(0);
-      } else {
-        client.setRefreshTokenValiditySeconds(dto.getRefreshTokenValiditySeconds());
-      }
+      client.setRefreshTokenValiditySeconds(dto.getRefreshTokenValiditySeconds());
+    } else {
+      client.setRefreshTokenValiditySeconds(
+          clientProperties.getClientDefaults().getDefaultRefreshTokenValiditySeconds());
     }
 
     if (dto.getIdTokenValiditySeconds() != null) {
@@ -230,20 +229,6 @@ public class ClientConverter {
     if (dto.getCodeChallengeMethod() != null) {
       PKCEAlgorithm pkceAlgo = PKCEAlgorithm.parse(dto.getCodeChallengeMethod());
       client.setCodeChallengeMethod(pkceAlgo);
-    }
-
-    if (!isNull(dto.getAccessTokenValiditySeconds())) {
-      client.setAccessTokenValiditySeconds(dto.getAccessTokenValiditySeconds());
-    } else {
-      client.setAccessTokenValiditySeconds(
-          clientProperties.getClientDefaults().getDefaultAccessTokenValiditySeconds());
-    }
-
-    if (!isNull(dto.getRefreshTokenValiditySeconds())) {
-      client.setRefreshTokenValiditySeconds(dto.getRefreshTokenValiditySeconds());
-    } else {
-      client.setRefreshTokenValiditySeconds(
-          clientProperties.getClientDefaults().getDefaultRefreshTokenValiditySeconds());
     }
 
     return client;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/DefaultClientDefaultsService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/DefaultClientDefaultsService.java
@@ -15,6 +15,7 @@
  */
 package it.infn.mw.iam.api.client.service;
 
+import static it.infn.mw.iam.api.common.client.AuthorizationGrantType.IMPLICIT;
 import static java.util.Objects.isNull;
 
 import java.math.BigInteger;
@@ -32,6 +33,7 @@ import org.springframework.stereotype.Service;
 
 import com.google.common.collect.Sets;
 
+import it.infn.mw.iam.api.common.client.AuthorizationGrantType;
 import it.infn.mw.iam.authn.util.Authorities;
 import it.infn.mw.iam.config.client_registration.ClientRegistrationProperties;
 
@@ -58,31 +60,21 @@ public class DefaultClientDefaultsService implements ClientDefaultsService {
       client.setClientId(UUID.randomUUID().toString());
     }
 
-    client.setAccessTokenValiditySeconds(
-        properties.getClientDefaults().getDefaultAccessTokenValiditySeconds());
-
     client
       .setIdTokenValiditySeconds(properties.getClientDefaults().getDefaultIdTokenValiditySeconds());
 
     client.setDeviceCodeValiditySeconds(
         properties.getClientDefaults().getDefaultDeviceCodeValiditySeconds());
 
-    final int rtSecs = properties.getClientDefaults().getDefaultRefreshTokenValiditySeconds();
-
-    if (rtSecs < 0) {
-      client.setRefreshTokenValiditySeconds(null);
-    } else {
-      client.setRefreshTokenValiditySeconds(rtSecs);
+    if (client.getGrantTypes().contains(IMPLICIT.getGrantType()) || client.getGrantTypes()
+      .contains(AuthorizationGrantType.CLIENT_CREDENTIALS.getGrantType())) {
+      client.setRefreshTokenValiditySeconds(0);
     }
 
     client.setAllowIntrospection(true);
 
     if (isNull(client.getContacts())) {
       client.setContacts(new HashSet<>());
-    }
-
-    if (isNull(client.getClientId())) {
-      client.setClientId(UUID.randomUUID().toString());
     }
 
     if (AUTH_METHODS_REQUIRING_SECRET.contains(client.getTokenEndpointAuthMethod())) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/DefaultClientDefaultsService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/DefaultClientDefaultsService.java
@@ -15,7 +15,6 @@
  */
 package it.infn.mw.iam.api.client.service;
 
-import static it.infn.mw.iam.api.common.client.AuthorizationGrantType.IMPLICIT;
 import static java.util.Objects.isNull;
 
 import java.math.BigInteger;
@@ -33,7 +32,6 @@ import org.springframework.stereotype.Service;
 
 import com.google.common.collect.Sets;
 
-import it.infn.mw.iam.api.common.client.AuthorizationGrantType;
 import it.infn.mw.iam.authn.util.Authorities;
 import it.infn.mw.iam.config.client_registration.ClientRegistrationProperties;
 
@@ -65,11 +63,6 @@ public class DefaultClientDefaultsService implements ClientDefaultsService {
 
     client.setDeviceCodeValiditySeconds(
         properties.getClientDefaults().getDefaultDeviceCodeValiditySeconds());
-
-    if (client.getGrantTypes().contains(IMPLICIT.getGrantType()) || client.getGrantTypes()
-      .contains(AuthorizationGrantType.CLIENT_CREDENTIALS.getGrantType())) {
-      client.setRefreshTokenValiditySeconds(0);
-    }
 
     client.setAllowIntrospection(true);
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/client_registration/ClientRegistrationProperties.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/client_registration/ClientRegistrationProperties.java
@@ -19,6 +19,8 @@ import static it.infn.mw.iam.config.client_registration.ClientRegistrationProper
 
 import java.util.concurrent.TimeUnit;
 
+import javax.validation.constraints.NotNull;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
@@ -28,10 +30,14 @@ public class ClientRegistrationProperties {
 
   public static class ClientDefaultsProperties {
 
-    private int defaultAccessTokenValiditySeconds = (int) TimeUnit.HOURS.toSeconds(1);
+	@NotNull(message = "Provide a default access token lifetime")
+    private int defaultAccessTokenValiditySeconds;
+	
+	@NotNull(message = "Provide a default refresh token lifetime")
+    private int defaultRefreshTokenValiditySeconds;
+	
     private int defaultIdTokenValiditySeconds = (int) TimeUnit.MINUTES.toSeconds(10);
     private int defaultDeviceCodeValiditySeconds = (int) TimeUnit.MINUTES.toSeconds(10);
-    private int defaultRefreshTokenValiditySeconds = (int) TimeUnit.DAYS.toSeconds(30);
 
     private int defaultRegistrationAccessTokenValiditySeconds = -1;
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/web/util/IamViewInfoInterceptor.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/web/util/IamViewInfoInterceptor.java
@@ -25,7 +25,6 @@ import org.springframework.web.servlet.HandlerInterceptor;
 
 import it.infn.mw.iam.config.IamProperties;
 import it.infn.mw.iam.config.client_registration.ClientRegistrationProperties;
-import it.infn.mw.iam.config.client_registration.ClientRegistrationProperties.ClientDefaultsProperties;
 import it.infn.mw.iam.config.saml.IamSamlProperties;
 import it.infn.mw.iam.core.web.loginpage.LoginPageConfiguration;
 import it.infn.mw.iam.rcauth.RCAuthProperties;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/web/util/IamViewInfoInterceptor.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/web/util/IamViewInfoInterceptor.java
@@ -24,6 +24,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import it.infn.mw.iam.config.IamProperties;
+import it.infn.mw.iam.config.client_registration.ClientRegistrationProperties;
+import it.infn.mw.iam.config.client_registration.ClientRegistrationProperties.ClientDefaultsProperties;
 import it.infn.mw.iam.config.saml.IamSamlProperties;
 import it.infn.mw.iam.core.web.loginpage.LoginPageConfiguration;
 import it.infn.mw.iam.rcauth.RCAuthProperties;
@@ -39,8 +41,8 @@ public class IamViewInfoInterceptor implements HandlerInterceptor {
   public static final String GIT_COMMIT_ID_KEY = "gitCommitId";
   public static final String SIMULATE_NETWORK_LATENCY_KEY = "simulateNetworkLatency";
   public static final String RCAUTH_ENABLED_KEY = "iamRcauthEnabled";
-
   public static final String RESOURCES_PATH_KEY = "resourcesPrefix";
+  public static final String CLIENT_DEFAULTS_PROPERTIES_KEY = "clientDefaultsProperties";
 
   @Value("${iam.version}")
   String iamVersion;
@@ -62,7 +64,10 @@ public class IamViewInfoInterceptor implements HandlerInterceptor {
 
   @Autowired
   IamProperties iamProperties;
-
+  
+  @Autowired
+  ClientRegistrationProperties clientRegistrationProperties;
+  
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
       throws Exception {
@@ -78,6 +83,7 @@ public class IamViewInfoInterceptor implements HandlerInterceptor {
     
     request.setAttribute(RCAUTH_ENABLED_KEY, rcAuthProperties.isEnabled());
     
+    request.setAttribute(CLIENT_DEFAULTS_PROPERTIES_KEY, clientRegistrationProperties.getClientDefaults());
 
     if (iamProperties.getVersionedStaticResources().isEnableVersioning()) {
       request.setAttribute(RESOURCES_PATH_KEY, String.format("/resources/%s", gitCommitId));

--- a/iam-login-service/src/main/resources/application.yml
+++ b/iam-login-service/src/main/resources/application.yml
@@ -213,6 +213,9 @@ task:
 client-registration:
   allow-for: ${IAM_CLIENT_REGISTRATION_ALLOW_FOR:ANYONE}
   enable: ${IAM_CLIENT_REGISTRATION_ENABLE:true}
+  client-defaults:
+    default-access-token-validity-seconds: ${DEFAULT_ACCESS_TOKEN_VALIDITY_SECONDS:3600}
+
 
 management:
   health:

--- a/iam-login-service/src/main/resources/application.yml
+++ b/iam-login-service/src/main/resources/application.yml
@@ -214,7 +214,8 @@ client-registration:
   allow-for: ${IAM_CLIENT_REGISTRATION_ALLOW_FOR:ANYONE}
   enable: ${IAM_CLIENT_REGISTRATION_ENABLE:true}
   client-defaults:
-    default-access-token-validity-seconds: ${DEFAULT_ACCESS_TOKEN_VALIDITY_SECONDS:3600}
+    default-access-token-validity-seconds: ${DEFAULT_ACCESS_TOKEN_VALIDITY_SECONDS:0}
+    default-refresh-token-validity-seconds: ${DEFAULT_REFRESH_TOKEN_VALIDITY_SECONDS:20}
 
 
 management:

--- a/iam-login-service/src/main/resources/application.yml
+++ b/iam-login-service/src/main/resources/application.yml
@@ -214,8 +214,8 @@ client-registration:
   allow-for: ${IAM_CLIENT_REGISTRATION_ALLOW_FOR:ANYONE}
   enable: ${IAM_CLIENT_REGISTRATION_ENABLE:true}
   client-defaults:
-    default-access-token-validity-seconds: ${DEFAULT_ACCESS_TOKEN_VALIDITY_SECONDS:0}
-    default-refresh-token-validity-seconds: ${DEFAULT_REFRESH_TOKEN_VALIDITY_SECONDS:20}
+    default-access-token-validity-seconds: ${DEFAULT_ACCESS_TOKEN_VALIDITY_SECONDS:3600}
+    default-refresh-token-validity-seconds: ${DEFAULT_REFRESH_TOKEN_VALIDITY_SECONDS:108000}
 
 
 management:

--- a/iam-login-service/src/main/webapp/WEB-INF/tags/iamHeader.tag
+++ b/iam-login-service/src/main/webapp/WEB-INF/tags/iamHeader.tag
@@ -88,6 +88,10 @@ function getOrganisationName() {
  return '${iamOrganisationName}'; 
 }
 
+function getAccessTokenValiditySeconds() {
+		return ${clientDefaultsProperties.defaultAccessTokenValiditySeconds};
+}
+
 function getOidcEnabled() {
   return ${loginPageConfiguration.oidcEnabled};
 }

--- a/iam-login-service/src/main/webapp/WEB-INF/tags/iamHeader.tag
+++ b/iam-login-service/src/main/webapp/WEB-INF/tags/iamHeader.tag
@@ -92,6 +92,10 @@ function getAccessTokenValiditySeconds() {
 		return ${clientDefaultsProperties.defaultAccessTokenValiditySeconds};
 }
 
+function getRefreshTokenValiditySeconds() {
+		return ${clientDefaultsProperties.defaultRefreshTokenValiditySeconds};
+}
+
 function getOidcEnabled() {
   return ${loginPageConfiguration.oidcEnabled};
 }

--- a/iam-login-service/src/main/webapp/WEB-INF/tags/iamHeader.tag
+++ b/iam-login-service/src/main/webapp/WEB-INF/tags/iamHeader.tag
@@ -89,11 +89,11 @@ function getOrganisationName() {
 }
 
 function getAccessTokenValiditySeconds() {
-		return ${clientDefaultsProperties.defaultAccessTokenValiditySeconds};
+  return ${clientDefaultsProperties.defaultAccessTokenValiditySeconds};
 }
 
 function getRefreshTokenValiditySeconds() {
-		return ${clientDefaultsProperties.defaultRefreshTokenValiditySeconds};
+  return ${clientDefaultsProperties.defaultRefreshTokenValiditySeconds};
 }
 
 function getOidcEnabled() {

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.html
@@ -54,19 +54,10 @@
     </div>
 
     <div class="form-group">
-        <label for="rt_timeout">Refresh token timeout (seconds)</label>
+        <label for="rt_timeout">Refresh token timeout (seconds), type 0 if the refresh token does not expire</label>
 
         <input id="rt_timeout" class="form-control" type="text" ng-model="$ctrl.client.refresh_token_validity_seconds"
-            ng-required ng-min="30"
-            ng-disabled="$ctrl.rtDoNotExpire && $ctrl.refreshTokenValiditySeconds > 0">
-
-        <div class="checkbox">
-            <label>
-                <input type="checkbox" ng-model="$ctrl.client.refresh_token_validity_seconds" ng-true-value="0"
-                    ng-false-value="{{$ctrl.client.refresh_token_validity_seconds}}">
-                Refresh tokens do not expire
-            </label>
-        </div>
+            ng-required ng-min="30">
 
     </div>
     <div class="form-group">

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.html
@@ -20,14 +20,14 @@
         <div class="form-group">
             <label for="at_timeout">Access token timeout (seconds)</label>
             <input id="at_timeout" class="form-control" type="text"
-                ng-model="$ctrl.client.access_token_validity_seconds" placeholder="3600"
+                ng-model="$ctrl.client.access_token_validity_seconds"
                 ng-disabled="$ctrl.client.access_token_validity_seconds <= 0">
         </div>
 
         <div class="checkbox">
             <label>
                 <input type="checkbox" ng-model="$ctrl.client.access_token_validity_seconds" ng-true-value="0"
-                    ng-false-value="3600">
+                    ng-false-value="{{$ctrl.client.access_token_validity_seconds}}">
                 Access tokens do not expire
             </label>
         </div>

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.html
@@ -21,7 +21,7 @@
             <label for="at_timeout">Access token timeout (seconds)</label>
             <input id="at_timeout" class="form-control" type="text"
                 ng-model="$ctrl.client.access_token_validity_seconds"
-                ng-disabled="$ctrl.isATBoxChecked">
+                ng-disabled="$ctrl.atDoNotExpire  && $ctrl.accessTokenValiditySeconds > 0">
         </div>
 
         <div class="checkbox">
@@ -67,7 +67,7 @@
 
         <input id="rt_timeout" class="form-control" type="text" ng-model="$ctrl.client.refresh_token_validity_seconds"
             ng-required ng-min="30"
-            ng-disabled="$ctrl.isRTBoxChecked && $ctrl.refreshTokenValiditySeconds > 0">
+            ng-disabled="$ctrl.rtDoNotExpire && $ctrl.refreshTokenValiditySeconds > 0">
 
         <div class="checkbox">
             <label>

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.html
@@ -20,16 +20,7 @@
         <div class="form-group">
             <label for="at_timeout">Access token timeout (seconds)</label>
             <input id="at_timeout" class="form-control" type="text"
-                ng-model="$ctrl.client.access_token_validity_seconds"
-                ng-disabled="$ctrl.atDoNotExpire  && $ctrl.accessTokenValiditySeconds > 0">
-        </div>
-
-        <div class="checkbox">
-            <label>
-                <input type="checkbox" ng-model="$ctrl.client.access_token_validity_seconds" ng-true-value="0"
-                    ng-false-value="{{$ctrl.client.access_token_validity_seconds}}">
-                Access tokens do not expire
-            </label>
+                ng-model="$ctrl.client.access_token_validity_seconds">
         </div>
 
     </div>

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.html
@@ -21,7 +21,7 @@
             <label for="at_timeout">Access token timeout (seconds)</label>
             <input id="at_timeout" class="form-control" type="text"
                 ng-model="$ctrl.client.access_token_validity_seconds"
-                ng-disabled="$ctrl.client.access_token_validity_seconds <= 0">
+                ng-disabled="$ctrl.isATBoxChecked">
         </div>
 
         <div class="checkbox">
@@ -66,12 +66,13 @@
         <label for="rt_timeout">Refresh token timeout (seconds)</label>
 
         <input id="rt_timeout" class="form-control" type="text" ng-model="$ctrl.client.refresh_token_validity_seconds"
-            placeholder="259200" ng-required ng-min="30" ng-disabled="$ctrl.client.refresh_token_validity_seconds <= 0">
+            ng-required ng-min="30"
+            ng-disabled="$ctrl.isRTBoxChecked && $ctrl.refreshTokenValiditySeconds > 0">
 
         <div class="checkbox">
             <label>
                 <input type="checkbox" ng-model="$ctrl.client.refresh_token_validity_seconds" ng-true-value="0"
-                    ng-false-value="259200">
+                    ng-false-value="{{$ctrl.client.refresh_token_validity_seconds}}">
                 Refresh tokens do not expire
             </label>
         </div>

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.html
@@ -54,10 +54,14 @@
     </div>
 
     <div class="form-group">
-        <label for="rt_timeout">Refresh token timeout (seconds), type 0 if the refresh token does not expire</label>
+        <label for="rt_timeout">Refresh token timeout (seconds)</label>
 
         <input id="rt_timeout" class="form-control" type="text" ng-model="$ctrl.client.refresh_token_validity_seconds"
             ng-required ng-min="30">
+            <p class="help-block">
+                This will setup after how many seconds the refresh token
+                expires. Type 0 to set an infinite lifetime.
+            </p>
 
     </div>
     <div class="form-group">

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.js
@@ -27,30 +27,38 @@
         self.canIssueRefreshTokens = false;
         self.hasDeviceCodeGrantType = false;
         self.accessTokenValiditySeconds = getAccessTokenValiditySeconds();
+        self.refreshTokenValiditySeconds = getRefreshTokenValiditySeconds();
+        self.isATBoxChecked = false;
+        self.isRTBoxChecked = false;
 
         self.$onInit = function () {
+
             console.debug('TokenSettingsController.self', self);
             if (!self.client.access_token_validity_seconds) {
                 self.client.access_token_validity_seconds = self.accessTokenValiditySeconds;
             }
 
-            console.log('client.access_token_validity_seconds = ' + self.client.access_token_validity_seconds);
-            console.log('accessTokenValiditySeconds = ' + self.accessTokenValiditySeconds);
-
             if (!self.client.refresh_token_validity_seconds) {
-                self.client.refresh_token_validity_seconds = 0;
+                self.client.refresh_token_validity_seconds = self.refreshTokenValiditySeconds;
             }
 
             $scope.$watch('$ctrl.client.access_token_validity_seconds', function handleChange(newVal, oldVal) {
                 if(newVal <= 0){
                     self.client.access_token_validity_seconds = 0;
+                    self.isATBoxChecked = true;
                 }
+                else self.isATBoxChecked = false;
+
+                console.log('Is AT box checked? ' + self.isATBoxChecked);
+                console.log('client.access_token_validity_seconds = ' + self.client.access_token_validity_seconds);
             });
 
             $scope.$watch('$ctrl.client.refresh_token_validity_seconds', function handleChange(newVal, oldVal) {
-                if (!self.client.refresh_token_validity_seconds) {
+                if (newVal <= 0) {
                     self.client.refresh_token_validity_seconds = 0;
+                    self.isRTBoxChecked = true;
                 }
+                else self.isRTBoxChecked = false;
             });
 
             $scope.$watch('$ctrl.client.grant_types', function handleChange(newVal, oldVal) {

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.js
@@ -28,11 +28,10 @@
         self.hasDeviceCodeGrantType = false;
         self.accessTokenValiditySeconds = getAccessTokenValiditySeconds();
         self.refreshTokenValiditySeconds = getRefreshTokenValiditySeconds();
-        self.isATBoxChecked = false;
-        self.isRTBoxChecked = false;
+        self.atDoNotExpire = false;
+        self.rtDoNotExpire = false;
 
         self.$onInit = function () {
-
             console.debug('TokenSettingsController.self', self);
             if (!self.client.access_token_validity_seconds) {
                 self.client.access_token_validity_seconds = self.accessTokenValiditySeconds;
@@ -43,22 +42,25 @@
             }
 
             $scope.$watch('$ctrl.client.access_token_validity_seconds', function handleChange(newVal, oldVal) {
-                if(newVal <= 0){
-                    self.client.access_token_validity_seconds = 0;
-                    self.isATBoxChecked = true;
-                }
-                else self.isATBoxChecked = false;
 
-                console.log('Is AT box checked? ' + self.isATBoxChecked);
-                console.log('client.access_token_validity_seconds = ' + self.client.access_token_validity_seconds);
+                if (newVal <= 0) {
+                    self.client.access_token_validity_seconds = 0;
+                    self.atDoNotExpire = true;
+                } else {
+                    self.atDoNotExpire = false;
+                }
+
             });
 
             $scope.$watch('$ctrl.client.refresh_token_validity_seconds', function handleChange(newVal, oldVal) {
+
                 if (newVal <= 0) {
                     self.client.refresh_token_validity_seconds = 0;
-                    self.isRTBoxChecked = true;
+                    self.rtDoNotExpire = true;
+                } else {
+                    self.rtDoNotExpire = false;
                 }
-                else self.isRTBoxChecked = false;
+
             });
 
             $scope.$watch('$ctrl.client.grant_types', function handleChange(newVal, oldVal) {

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.js
@@ -28,15 +28,14 @@
         self.hasDeviceCodeGrantType = false;
         self.accessTokenValiditySeconds = getAccessTokenValiditySeconds();
         self.refreshTokenValiditySeconds = getRefreshTokenValiditySeconds();
-        self.rtDoNotExpire = false;
 
         self.$onInit = function () {
             console.debug('TokenSettingsController.self', self);
-            if (!self.client.access_token_validity_seconds) {
+            if (self.client.access_token_validity_seconds == null) {
                 self.client.access_token_validity_seconds = self.accessTokenValiditySeconds;
             }
 
-            if (!self.client.refresh_token_validity_seconds) {
+            if (self.client.refresh_token_validity_seconds == null) {
                 self.client.refresh_token_validity_seconds = self.refreshTokenValiditySeconds;
             }
 
@@ -47,14 +46,9 @@
             });
 
             $scope.$watch('$ctrl.client.refresh_token_validity_seconds', function handleChange(newVal, oldVal) {
-
                 if (newVal <= 0) {
                     self.client.refresh_token_validity_seconds = 0;
-                    self.rtDoNotExpire = true;
-                } else {
-                    self.rtDoNotExpire = false;
                 }
-
             });
 
             $scope.$watch('$ctrl.client.grant_types', function handleChange(newVal, oldVal) {

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.js
@@ -26,19 +26,23 @@
         self.toggleOfflineAccess = toggleOfflineAccess;
         self.canIssueRefreshTokens = false;
         self.hasDeviceCodeGrantType = false;
-
+        self.accessTokenValiditySeconds = getAccessTokenValiditySeconds();
 
         self.$onInit = function () {
             console.debug('TokenSettingsController.self', self);
             if (!self.client.access_token_validity_seconds) {
-                self.client.access_token_validity_seconds = 0;
+                self.client.access_token_validity_seconds = self.accessTokenValiditySeconds;
             }
+
+            console.log('client.access_token_validity_seconds = ' + self.client.access_token_validity_seconds);
+            console.log('accessTokenValiditySeconds = ' + self.accessTokenValiditySeconds);
+
             if (!self.client.refresh_token_validity_seconds) {
                 self.client.refresh_token_validity_seconds = 0;
             }
 
             $scope.$watch('$ctrl.client.access_token_validity_seconds', function handleChange(newVal, oldVal) {
-                if (!self.client.access_token_validity_seconds) {
+                if(newVal <= 0){
                     self.client.access_token_validity_seconds = 0;
                 }
             });

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.js
@@ -28,7 +28,6 @@
         self.hasDeviceCodeGrantType = false;
         self.accessTokenValiditySeconds = getAccessTokenValiditySeconds();
         self.refreshTokenValiditySeconds = getRefreshTokenValiditySeconds();
-        self.atDoNotExpire = false;
         self.rtDoNotExpire = false;
 
         self.$onInit = function () {
@@ -42,14 +41,9 @@
             }
 
             $scope.$watch('$ctrl.client.access_token_validity_seconds', function handleChange(newVal, oldVal) {
-
                 if (newVal <= 0) {
                     self.client.access_token_validity_seconds = 0;
-                    self.atDoNotExpire = true;
-                } else {
-                    self.atDoNotExpire = false;
                 }
-
             });
 
             $scope.$watch('$ctrl.client.refresh_token_validity_seconds', function handleChange(newVal, oldVal) {

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/client/ClientRegistrationAPIIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/client/ClientRegistrationAPIIntegrationTests.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.api.client;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import it.infn.mw.iam.IamLoginService;
+import it.infn.mw.iam.api.client.registration.ClientRegistrationApiController;
+import it.infn.mw.iam.api.common.client.RegisteredClientDTO;
+import it.infn.mw.iam.test.api.TestSupport;
+import it.infn.mw.iam.test.oauth.client_registration.ClientRegistrationTestSupport.ClientJsonStringBuilder;
+import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
+
+@IamMockMvcIntegrationTest
+@WithMockUser(username = "test", roles = "USER")
+@SpringBootTest(classes = {IamLoginService.class})
+public class ClientRegistrationAPIIntegrationTests extends TestSupport {
+
+  @Autowired
+  private MockMvc mvc;
+
+  @Autowired
+  private ObjectMapper mapper;
+
+  @Test
+  @WithAnonymousUser
+  public void dynamicRegistrationWorksForAnonymousUser() throws Exception {
+
+    String clientJson = ClientJsonStringBuilder.builder().scopes("openid").build();
+
+    mvc
+      .perform(post(ClientRegistrationApiController.ENDPOINT).contentType(APPLICATION_JSON)
+        .content(clientJson))
+      .andExpect(CREATED)
+      .andExpect(jsonPath("$.client_id").exists())
+      .andExpect(jsonPath("$.client_secret").exists())
+      .andExpect(jsonPath("$.client_name").exists())
+      .andExpect(jsonPath("$.grant_types").exists())
+      .andExpect(jsonPath("$.scope").exists())
+      .andExpect(jsonPath("$.dynamically_registered").value(true))
+      .andExpect(jsonPath("$.registration_access_token").exists());
+
+  }
+
+  @Test
+  public void clientDetailsVisibleWithAuthentication() throws Exception {
+
+    String clientJson = ClientJsonStringBuilder.builder().scopes("openid").build();
+
+    String responseJson = mvc
+      .perform(post(ClientRegistrationApiController.ENDPOINT).contentType(APPLICATION_JSON)
+        .content(clientJson))
+      .andExpect(CREATED)
+      .andReturn()
+      .getResponse()
+      .getContentAsString();
+
+    RegisteredClientDTO client = mapper.readValue(responseJson, RegisteredClientDTO.class);
+
+    final String url =
+        String.format("%s/%s", ClientRegistrationApiController.ENDPOINT, client.getClientId());
+
+    mvc.perform(get(url))
+      .andExpect(OK)
+      .andExpect(jsonPath("$.client_id").value(client.getClientId()))
+      .andExpect(jsonPath("$.client_name").value(client.getClientName()));
+
+  }
+
+  @Test
+  public void clientRemovalWorksWithAuthentication() throws Exception {
+
+    String clientJson = ClientJsonStringBuilder.builder().scopes("openid").build();
+
+    String responseJson = mvc
+      .perform(post(ClientRegistrationApiController.ENDPOINT).contentType(APPLICATION_JSON)
+        .content(clientJson))
+      .andExpect(CREATED)
+      .andReturn()
+      .getResponse()
+      .getContentAsString();
+
+    RegisteredClientDTO client = mapper.readValue(responseJson, RegisteredClientDTO.class);
+
+    final String url =
+        String.format("%s/%s", ClientRegistrationApiController.ENDPOINT, client.getClientId());
+
+    mvc.perform(delete(url)).andExpect(NO_CONTENT);
+
+    mvc.perform(get(url))
+      .andExpect(NOT_FOUND)
+      .andExpect(jsonPath("$.error", containsString("Client not found")));
+  }
+
+  @Test
+  public void tokenLifetimesAreNotEditable() throws Exception {
+
+    String clientJson = ClientJsonStringBuilder.builder()
+      .scopes("openid")
+      .accessTokenValiditySeconds(10)
+      .refreshTokenValiditySeconds(10)
+      .build();
+
+    mvc
+      .perform(post(ClientRegistrationApiController.ENDPOINT).contentType(APPLICATION_JSON)
+        .content(clientJson))
+      .andExpect(CREATED)
+      .andExpect(jsonPath("$.access_token_validity_seconds").doesNotExist())
+      .andExpect(jsonPath("$.refresh_token_validity_seconds").doesNotExist());
+
+  }
+
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/client_registration/ClientRegistrationTestSupport.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/client_registration/ClientRegistrationTestSupport.java
@@ -42,47 +42,52 @@ public class ClientRegistrationTestSupport {
   public static final String LEGACY_REGISTER_ENDPOINT = "/register";
 
   public static class ClientJsonStringBuilder {
-    
+
     static final Joiner JOINER = Joiner.on(RegisteredClientFields.SCOPE_SEPARATOR);
-    
+
     String name = "test_client";
     Set<String> redirectUris = Sets.newHashSet("http://localhost:9090");
     Set<String> grantTypes = Sets.newHashSet("client_credentials");
     Set<String> scopes = Sets.newHashSet();
     Set<String> responseTypes = Sets.newHashSet();
-    
-    private ClientJsonStringBuilder() {
-    }
-    
+    int accessTokenValiditySeconds = 3600;
+
+    private ClientJsonStringBuilder() {}
+
     public static ClientJsonStringBuilder builder() {
       return new ClientJsonStringBuilder();
     }
-    
+
     public ClientJsonStringBuilder name(String name) {
       this.name = name;
       return this;
     }
-    
-    public ClientJsonStringBuilder redirectUris(String...uris) {
+
+    public ClientJsonStringBuilder redirectUris(String... uris) {
       this.redirectUris = Sets.newHashSet(uris);
       return this;
     }
-    
-    public ClientJsonStringBuilder grantTypes(String...grantTypes) {
+
+    public ClientJsonStringBuilder grantTypes(String... grantTypes) {
       this.grantTypes = Sets.newHashSet(grantTypes);
       return this;
     }
-    
-    public ClientJsonStringBuilder scopes(String...scopes) {
+
+    public ClientJsonStringBuilder scopes(String... scopes) {
       this.scopes = Sets.newHashSet(scopes);
       return this;
     }
-    
-    public ClientJsonStringBuilder responseTypes(String...responseTypes) {
+
+    public ClientJsonStringBuilder responseTypes(String... responseTypes) {
       this.responseTypes = Sets.newHashSet(responseTypes);
       return this;
     }
-    
+
+    public ClientJsonStringBuilder accessTokenValiditySeconds(int accessTokenValiditySeconds) {
+      this.accessTokenValiditySeconds = accessTokenValiditySeconds;
+      return this;
+    }
+
     public String build() {
       JsonObject json = new JsonObject();
       json.addProperty(CLIENT_NAME, name);
@@ -93,12 +98,12 @@ public class ClientRegistrationTestSupport {
       json.add(CLAIMS_REDIRECT_URIS, getAsArray(newHashSet(), true));
       json.add(REQUEST_URIS, getAsArray(newHashSet(), true));
       json.add(CONTACTS, getAsArray(newHashSet("test@iam.test")));
-     
+      json.addProperty("access_token_validity_seconds", accessTokenValiditySeconds);
       return json.toString();
     }
-    
-    
-    
+
+
+
   }
 
   protected String setToString(Set<String> scopes) {

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/client_registration/ClientRegistrationTestSupport.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/client_registration/ClientRegistrationTestSupport.java
@@ -95,10 +95,6 @@ public class ClientRegistrationTestSupport {
       return this;
     }
 
-    public Integer getAccessTokenValiditySeconds() {
-      return accessTokenValiditySeconds;
-    }
-
     public String build() {
       JsonObject json = new JsonObject();
       json.addProperty(CLIENT_NAME, name);

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/client_registration/ClientRegistrationTestSupport.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/client_registration/ClientRegistrationTestSupport.java
@@ -50,7 +50,8 @@ public class ClientRegistrationTestSupport {
     Set<String> grantTypes = Sets.newHashSet("client_credentials");
     Set<String> scopes = Sets.newHashSet();
     Set<String> responseTypes = Sets.newHashSet();
-    int accessTokenValiditySeconds = 3600;
+    Integer accessTokenValiditySeconds;
+    Integer refreshTokenValiditySeconds;
 
     private ClientJsonStringBuilder() {}
 
@@ -83,9 +84,19 @@ public class ClientRegistrationTestSupport {
       return this;
     }
 
-    public ClientJsonStringBuilder accessTokenValiditySeconds(int accessTokenValiditySeconds) {
+    public ClientJsonStringBuilder accessTokenValiditySeconds(Integer accessTokenValiditySeconds) {
       this.accessTokenValiditySeconds = accessTokenValiditySeconds;
       return this;
+    }
+
+    public ClientJsonStringBuilder refreshTokenValiditySeconds(
+        Integer refreshTokenValiditySeconds) {
+      this.refreshTokenValiditySeconds = refreshTokenValiditySeconds;
+      return this;
+    }
+
+    public Integer getAccessTokenValiditySeconds() {
+      return accessTokenValiditySeconds;
     }
 
     public String build() {
@@ -99,6 +110,7 @@ public class ClientRegistrationTestSupport {
       json.add(REQUEST_URIS, getAsArray(newHashSet(), true));
       json.add(CONTACTS, getAsArray(newHashSet("test@iam.test")));
       json.addProperty("access_token_validity_seconds", accessTokenValiditySeconds);
+      json.addProperty("refresh_token_validity_seconds", refreshTokenValiditySeconds);
       return json.toString();
     }
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/devicecode/DeviceCodeTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/devicecode/DeviceCodeTests.java
@@ -419,7 +419,6 @@ public class DeviceCodeTests extends EndpointsTestUtils implements DeviceCodeTes
     String jsonInString = ClientJsonStringBuilder.builder()
       .grantTypes("urn:ietf:params:oauth:grant-type:device_code")
       .scopes("openid", "profile", "offline_access")
-      .accessTokenValiditySeconds(3600)
       .build();
 
     String clientJson =

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/devicecode/DeviceCodeTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/devicecode/DeviceCodeTests.java
@@ -419,6 +419,7 @@ public class DeviceCodeTests extends EndpointsTestUtils implements DeviceCodeTes
     String jsonInString = ClientJsonStringBuilder.builder()
       .grantTypes("urn:ietf:params:oauth:grant-type:device_code")
       .scopes("openid", "profile", "offline_access")
+      .accessTokenValiditySeconds(3600)
       .build();
 
     String clientJson =

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 
     <testcontainers.version>1.16.2</testcontainers.version>
 
-    <mitreid.version>1.3.6.cnaf-20230913</mitreid.version>
+    <mitreid.version>1.3.6.cnaf-20230914</mitreid.version>
     <spring-security-oauth2.version>2.5.2.RELEASE</spring-security-oauth2.version>
 
     <voms.version>3.3.2</voms.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 
     <testcontainers.version>1.16.2</testcontainers.version>
 
-    <mitreid.version>1.3.6.cnaf-20230726</mitreid.version>
+    <mitreid.version>1.3.6.cnaf-20230907</mitreid.version>
     <spring-security-oauth2.version>2.5.2.RELEASE</spring-security-oauth2.version>
 
     <voms.version>3.3.2</voms.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 
     <testcontainers.version>1.16.2</testcontainers.version>
 
-    <mitreid.version>1.3.6.cnaf-20230907</mitreid.version>
+    <mitreid.version>1.3.6.cnaf-20230913</mitreid.version>
     <spring-security-oauth2.version>2.5.2.RELEASE</spring-security-oauth2.version>
 
     <voms.version>3.3.2</voms.version>


### PR DESCRIPTION
The Access Token and Refresh Token lifetimes are configurable by admins via web interface. #545 
The exp claim will always appear into access tokens (following RFC9068). #648 
