### PR TITLE
to support different server port

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/HintAwareAuthenticationEntryPoint.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/HintAwareAuthenticationEntryPoint.java
@@ -29,6 +29,7 @@ public class HintAwareAuthenticationEntryPoint implements AuthenticationEntryPoi
 
   public static final String EXT_AUTHN_HINT_PARAM = "ext_authn_hint";
 
+  private int serverPort;
   private final AuthenticationEntryPoint delegate;
   private final ExternalAuthenticationHintService hintService;
 
@@ -36,6 +37,10 @@ public class HintAwareAuthenticationEntryPoint implements AuthenticationEntryPoi
       ExternalAuthenticationHintService service) {
     this.delegate = delegate;
     this.hintService = service;
+  }
+
+  public void setServerPort(int port) {
+    this.serverPort = port;
   }
 
   protected boolean isOAuthAuthorizationRequestWithHint(HttpServletRequest request) {
@@ -50,6 +55,7 @@ public class HintAwareAuthenticationEntryPoint implements AuthenticationEntryPoi
       HttpServletResponse response) throws IOException {
 
     String redirectUrl = hintService.resolve(request.getParameter(EXT_AUTHN_HINT_PARAM));
+    redirectUrl.replace("8080", (this.serverPort.toString()));
     response.sendRedirect(redirectUrl);
   }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/HintAwareAuthenticationEntryPoint.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/HintAwareAuthenticationEntryPoint.java
@@ -55,7 +55,7 @@ public class HintAwareAuthenticationEntryPoint implements AuthenticationEntryPoi
       HttpServletResponse response) throws IOException {
 
     String redirectUrl = hintService.resolve(request.getParameter(EXT_AUTHN_HINT_PARAM));
-    redirectUrl.replace("8080", (this.serverPort.toString()));
+    redirectUrl.replace("8080", Integer.toString(this.serverPort));
     response.sendRedirect(redirectUrl);
   }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamWebSecurityConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamWebSecurityConfig.java
@@ -214,7 +214,10 @@ public class IamWebSecurityConfig {
     private IamProperties iamProperties;
 
     public int getServerPort() {
-      return this.serverPort;
+      if (this.serverPort != null && this.serverPort) {
+          return this.serverPort;
+      }
+      return 8080;
     }
 
     @Autowired
@@ -322,7 +325,10 @@ public class IamWebSecurityConfig {
     private int serverPort;
 
     public int getServerPort() {
-      return this.serverPort;
+      if (this.serverPort != null && this.serverPort) {
+          return this.serverPort;
+      }
+      return 8080;
     }
 
     AccessDeniedHandler accessDeniedHandler() {
@@ -396,7 +402,10 @@ public class IamWebSecurityConfig {
     private int serverPort;
 
     public int getServerPort() {
-      return this.serverPort;
+      if (this.serverPort != null && this.serverPort) {
+          return this.serverPort;
+      }
+      return 8080;
     }
 
     @Override

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamWebSecurityConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamWebSecurityConfig.java
@@ -130,7 +130,7 @@ public class IamWebSecurityConfig {
       private PortMapper portMapper() {
         PortMapperImpl portMapper = new PortMapperImpl();
         Map<String, String> mappings = new HashMap<>();
-        mappings.put(this.serverPort, "8080");
+        mappings.put(Integer.toString(this.serverPort), "8080");
         portMapper.setPortMappings(mappings);
         return portMapper;
       }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamWebSecurityConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamWebSecurityConfig.java
@@ -80,7 +80,7 @@ import it.infn.mw.iam.service.aup.AUPSignatureCheckService;
 @EnableWebSecurity
 public class IamWebSecurityConfig {
   
-  public class IamWebSecurityConfigurerAdapter extends WebSecurityConfigurerAdapter {
+  public static class IamWebSecurityConfigurerAdapter extends WebSecurityConfigurerAdapter {
 
     public int getServerPort() {
       return 8080;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamWebSecurityConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamWebSecurityConfig.java
@@ -89,7 +89,7 @@ public class IamWebSecurityConfig {
     public PortMapper portMapper() {
         PortMapperImpl portMapper = new PortMapperImpl();
         Map<String, String> mappings = new HashMap<>();
-	mappings.put(getServerPort(), "8080");
+	mappings.put(Integer.toString(getServerPort()), "8080");
         portMapper.setPortMappings(mappings);
         return portMapper;
     }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamWebSecurityConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamWebSecurityConfig.java
@@ -172,7 +172,7 @@ public class IamWebSecurityConfig {
   @Order(100)
   public static class UserLoginConfig extends IamWebSecurityConfigurerAdapter {
 
-    @Value("${server.port}")
+    @Value("${server.port:8080}")
     private int serverPort;
 
     @Value("${iam.baseUrl}")
@@ -214,10 +214,7 @@ public class IamWebSecurityConfig {
     private IamProperties iamProperties;
 
     public int getServerPort() {
-      if (this.serverPort != null && this.serverPort) {
           return this.serverPort;
-      }
-      return 8080;
     }
 
     @Autowired
@@ -321,14 +318,11 @@ public class IamWebSecurityConfig {
     @Autowired
     IamProperties iamProperties;
 
-    @Value("${server.port}")
+    @Value("${server.port:8080}")
     private int serverPort;
 
     public int getServerPort() {
-      if (this.serverPort != null && this.serverPort) {
           return this.serverPort;
-      }
-      return 8080;
     }
 
     AccessDeniedHandler accessDeniedHandler() {
@@ -398,14 +392,11 @@ public class IamWebSecurityConfig {
     @Qualifier("OIDCAuthenticationFilter")
     private OidcClientFilter oidcFilter;
 
-    @Value("${server.port}")
+    @Value("${server.port:8080}")
     private int serverPort;
 
     public int getServerPort() {
-      if (this.serverPort != null && this.serverPort) {
           return this.serverPort;
-      }
-      return 8080;
     }
 
     @Override


### PR DESCRIPTION
When defining 'server.port = 8443', IAM will automatically redirected connections to 8080 automatically. This patch will set the redirections to be correctly to the 'server.port'.

This patch is created based on a local test version which works ok on USDF instance(https://github.com/indigo-iam/iam/compare/master...wguanicedew:iam:v1.8.1.3).