### PR TITLE
Enable Redis caching of scope matchers and well-known endpoint

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/IamLoginService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/IamLoginService.java
@@ -87,6 +87,7 @@ excludeFilters = {
 public class IamLoginService {
 
   public static void main(final String[] args) {
+    System.setProperty("spring.devtools.restart.enabled", "false");
     SpringApplication iamLoginService = new SpringApplication(IamLoginService.class);
     iamLoginService.setBanner(new IamBanner(new ClassPathResource("iam-banner.txt")));
     iamLoginService.run(args);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/IamLoginService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/IamLoginService.java
@@ -27,6 +27,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.h2.H2ConsoleAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
@@ -77,7 +78,7 @@ excludeFilters = {
     @ComponentScan.Filter(type=FilterType.ASSIGNABLE_TYPE,
         value=OAuthConfirmationController.class)
 })
-
+@EnableCaching
 @EnableAutoConfiguration(
     exclude = {
         SecurityAutoConfiguration.class,

--- a/iam-login-service/src/main/java/it/infn/mw/iam/IamLoginService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/IamLoginService.java
@@ -55,7 +55,6 @@ import it.infn.mw.iam.core.util.IamBanner;
     "it.infn.mw.iam.actuator",
     "it.infn.mw.iam.rcauth",
     "it.infn.mw.iam.service.aup",
-    "it.infn.mw.iam.util",
     "org.mitre.oauth2.web",
     "org.mitre.oauth2.view", 
     "org.mitre.openid.connect.web", 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/IamLoginService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/IamLoginService.java
@@ -55,6 +55,7 @@ import it.infn.mw.iam.core.util.IamBanner;
     "it.infn.mw.iam.actuator",
     "it.infn.mw.iam.rcauth",
     "it.infn.mw.iam.service.aup",
+    "it.infn.mw.iam.util",
     "org.mitre.oauth2.web",
     "org.mitre.oauth2.view", 
     "org.mitre.openid.connect.web", 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/IamLoginService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/IamLoginService.java
@@ -17,9 +17,9 @@ package it.infn.mw.iam;
 
 import org.mitre.discovery.web.DiscoveryEndpoint;
 import org.mitre.oauth2.web.CorsFilter;
+import org.mitre.oauth2.web.OAuthConfirmationController;
 import org.mitre.openid.connect.web.DynamicClientRegistrationEndpoint;
 import org.mitre.openid.connect.web.JWKSetPublishingEndpoint;
-import org.mitre.oauth2.web.OAuthConfirmationController;
 import org.mitre.openid.connect.web.RootController;
 import org.mitre.openid.connect.web.UserInfoEndpoint;
 import org.springframework.boot.SpringApplication;
@@ -87,7 +87,6 @@ excludeFilters = {
 public class IamLoginService {
 
   public static void main(final String[] args) {
-    System.setProperty("spring.devtools.restart.enabled", "false");
     SpringApplication iamLoginService = new SpringApplication(IamLoginService.class);
     iamLoginService.setBanner(new IamBanner(new ClassPathResource("iam-banner.txt")));
     iamLoginService.run(args);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/DefaultClientService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/DefaultClientService.java
@@ -33,7 +33,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import it.infn.mw.iam.audit.events.client.ClientCreatedEvent;
-import it.infn.mw.iam.config.CacheConfig;
+import it.infn.mw.iam.core.oauth.scope.matchers.DefaultScopeMatcherRegistry;
 import it.infn.mw.iam.persistence.model.IamAccount;
 import it.infn.mw.iam.persistence.model.IamAccountClient;
 import it.infn.mw.iam.persistence.repository.client.ClientSpecs;
@@ -101,7 +101,7 @@ public class DefaultClientService implements ClientService {
   }
 
   @Override
-  @CacheEvict(allEntries = true, cacheNames = CacheConfig.SCOPE_CACHE_KEY_PREFIX)
+  @CacheEvict(allEntries = true, cacheNames = DefaultScopeMatcherRegistry.SCOPE_CACHE_KEY)
   public ClientDetailsEntity updateClient(ClientDetailsEntity client) {
 
     return clientRepo.save(client);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/DefaultClientService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/DefaultClientService.java
@@ -145,14 +145,11 @@ public class DefaultClientService implements ClientService {
     // delete all valid access tokens (exclude registration and resource tokens)
     tokenService.getAccessTokensForClient(client)
       .stream()
-      .filter(at -> isValidAccessToken(at))
-      .forEach(at -> {
-        tokenService.revokeAccessToken(at);
-      });
+      .filter(this::isValidAccessToken)
+      .forEach(at -> tokenService.revokeAccessToken(at));
     // delete all valid refresh tokens
-    tokenService.getRefreshTokensForClient(client).forEach(rt -> {
-      tokenService.revokeRefreshToken(rt);
-    });
+    tokenService.getRefreshTokensForClient(client)
+      .forEach(rt -> tokenService.revokeRefreshToken(rt));
   }
 
   @Override

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/DefaultClientService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/DefaultClientService.java
@@ -101,7 +101,7 @@ public class DefaultClientService implements ClientService {
   }
 
   @Override
-  @CacheEvict(allEntries = true, cacheNames = DefaultScopeMatcherRegistry.SCOPE_CACHE_KEY)
+  @CacheEvict(cacheNames = DefaultScopeMatcherRegistry.SCOPE_CACHE_KEY, key = "{#client?.id}")
   public ClientDetailsEntity updateClient(ClientDetailsEntity client) {
 
     return clientRepo.save(client);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/DefaultClientService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/DefaultClientService.java
@@ -32,7 +32,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import it.infn.mw.iam.audit.events.client.ClientCreatedEvent;
-import it.infn.mw.iam.core.oauth.scope.matchers.ScopeMatcherOAuthRequestValidator;
 import it.infn.mw.iam.persistence.model.IamAccount;
 import it.infn.mw.iam.persistence.model.IamAccountClient;
 import it.infn.mw.iam.persistence.repository.client.ClientSpecs;
@@ -52,8 +51,6 @@ public class DefaultClientService implements ClientService {
 
   private ApplicationEventPublisher eventPublisher;
 
-  private OAuth2RequestValidator requestValidator;
-
   private OAuth2TokenEntityService tokenService;
 
   @Autowired
@@ -64,7 +61,6 @@ public class DefaultClientService implements ClientService {
     this.clientRepo = clientRepo;
     this.accountClientRepo = accountClientRepo;
     this.eventPublisher = eventPublisher;
-    this.requestValidator = requestValidator;
     this.tokenService = tokenService;
   }
 
@@ -105,7 +101,6 @@ public class DefaultClientService implements ClientService {
   @Override
   public ClientDetailsEntity updateClient(ClientDetailsEntity client) {
 
-    ((ScopeMatcherOAuthRequestValidator) requestValidator).invalidateScope(client);
     return clientRepo.save(client);
   }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/DefaultClientService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/DefaultClientService.java
@@ -24,6 +24,7 @@ import org.mitre.oauth2.model.ClientDetailsEntity;
 import org.mitre.oauth2.model.OAuth2AccessTokenEntity;
 import org.mitre.oauth2.service.OAuth2TokenEntityService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -32,6 +33,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import it.infn.mw.iam.audit.events.client.ClientCreatedEvent;
+import it.infn.mw.iam.config.CacheConfig;
 import it.infn.mw.iam.persistence.model.IamAccount;
 import it.infn.mw.iam.persistence.model.IamAccountClient;
 import it.infn.mw.iam.persistence.repository.client.ClientSpecs;
@@ -99,6 +101,7 @@ public class DefaultClientService implements ClientService {
   }
 
   @Override
+  @CacheEvict(allEntries = true, cacheNames = CacheConfig.SCOPE_CACHE_KEY_PREFIX)
   public ClientDetailsEntity updateClient(ClientDetailsEntity client) {
 
     return clientRepo.save(client);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/CacheConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/CacheConfig.java
@@ -18,15 +18,15 @@ package it.infn.mw.iam.config;
 import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCustomizer;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cache.CacheManager;
-import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 
 import it.infn.mw.iam.core.oauth.scope.matchers.DefaultScopeMatcherRegistry;
 import it.infn.mw.iam.core.web.wellknown.IamWellKnownInfoProvider;
 
-@EnableCaching
+@Configuration
 public class CacheConfig {
 
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/CacheConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/CacheConfig.java
@@ -15,23 +15,41 @@
  */
 package it.infn.mw.iam.config;
 
-
-
+import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCustomizer;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
 
+import it.infn.mw.iam.core.oauth.scope.matchers.DefaultScopeMatcherRegistry;
 import it.infn.mw.iam.core.web.wellknown.IamWellKnownInfoProvider;
 
 @Configuration
 @EnableCaching
 public class CacheConfig {
 
+
   @Bean
   public CacheManager cacheManager() {
-    return new ConcurrentMapCacheManager(IamWellKnownInfoProvider.CACHE_KEY);
+    return new ConcurrentMapCacheManager(IamWellKnownInfoProvider.CACHE_KEY,
+        DefaultScopeMatcherRegistry.SCOPE_CACHE_KEY);
+  }
+
+
+  @Bean
+  public RedisCacheManagerBuilderCustomizer redisCacheManagerBuilderCustomizer() {
+    return (builder) -> builder.withCacheConfiguration(DefaultScopeMatcherRegistry.SCOPE_CACHE_KEY,
+        RedisCacheConfiguration.defaultCacheConfig());
+  }
+
+
+  @Bean
+  public RedisCacheConfiguration cacheConfiguration() {
+
+    return RedisCacheConfiguration.defaultCacheConfig().disableCachingNullValues();
+
   }
 
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/CacheConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/CacheConfig.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package it.infn.mw.iam.util;
+package it.infn.mw.iam.config;
 
 import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCustomizer;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/CacheConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/CacheConfig.java
@@ -43,8 +43,12 @@ public class CacheConfig {
   @Bean
   @ConditionalOnProperty(name = "redis-cache.enabled", havingValue = "true")
   public RedisCacheManagerBuilderCustomizer redisCacheManagerBuilderCustomizer() {
-    return (builder) -> builder.withCacheConfiguration(DefaultScopeMatcherRegistry.SCOPE_CACHE_KEY,
-        RedisCacheConfiguration.defaultCacheConfig());
+    return (builder) -> builder
+      .withCacheConfiguration(IamWellKnownInfoProvider.CACHE_KEY,
+          RedisCacheConfiguration.defaultCacheConfig())
+      .withCacheConfiguration(DefaultScopeMatcherRegistry.SCOPE_CACHE_KEY,
+          RedisCacheConfiguration.defaultCacheConfig());
+
   }
 
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/CacheConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/CacheConfig.java
@@ -16,6 +16,7 @@
 package it.infn.mw.iam.config;
 
 import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCustomizer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
@@ -32,6 +33,7 @@ public class CacheConfig {
 
 
   @Bean
+  @ConditionalOnProperty(name = "scope-matcher-cache.enabled", havingValue = "false")
   public CacheManager cacheManager() {
     return new ConcurrentMapCacheManager(IamWellKnownInfoProvider.CACHE_KEY,
         DefaultScopeMatcherRegistry.SCOPE_CACHE_KEY);
@@ -39,6 +41,7 @@ public class CacheConfig {
 
 
   @Bean
+  @ConditionalOnProperty(name = "scope-matcher-cache.enabled", havingValue = "true")
   public RedisCacheManagerBuilderCustomizer redisCacheManagerBuilderCustomizer() {
     return (builder) -> builder.withCacheConfiguration(DefaultScopeMatcherRegistry.SCOPE_CACHE_KEY,
         RedisCacheConfiguration.defaultCacheConfig());
@@ -46,6 +49,7 @@ public class CacheConfig {
 
 
   @Bean
+  @ConditionalOnProperty(name = "scope-matcher-cache.enabled", havingValue = "true")
   public RedisCacheConfiguration cacheConfiguration() {
 
     return RedisCacheConfiguration.defaultCacheConfig().disableCachingNullValues();

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/CacheConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/CacheConfig.java
@@ -33,15 +33,15 @@ public class CacheConfig {
 
 
   @Bean
-  @ConditionalOnProperty(name = "scope-matcher-cache.enabled", havingValue = "false")
-  public CacheManager cacheManager() {
+  @ConditionalOnProperty(name = "redis-cache.enabled", havingValue = "false")
+  public CacheManager localCacheManager() {
     return new ConcurrentMapCacheManager(IamWellKnownInfoProvider.CACHE_KEY,
         DefaultScopeMatcherRegistry.SCOPE_CACHE_KEY);
   }
 
 
   @Bean
-  @ConditionalOnProperty(name = "scope-matcher-cache.enabled", havingValue = "true")
+  @ConditionalOnProperty(name = "redis-cache.enabled", havingValue = "true")
   public RedisCacheManagerBuilderCustomizer redisCacheManagerBuilderCustomizer() {
     return (builder) -> builder.withCacheConfiguration(DefaultScopeMatcherRegistry.SCOPE_CACHE_KEY,
         RedisCacheConfiguration.defaultCacheConfig());
@@ -49,8 +49,8 @@ public class CacheConfig {
 
 
   @Bean
-  @ConditionalOnProperty(name = "scope-matcher-cache.enabled", havingValue = "true")
-  public RedisCacheConfiguration cacheConfiguration() {
+  @ConditionalOnProperty(name = "redis-cache.enabled", havingValue = "true")
+  public RedisCacheConfiguration redisCacheConfiguration() {
 
     return RedisCacheConfiguration.defaultCacheConfig().disableCachingNullValues();
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/IamConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/IamConfig.java
@@ -254,7 +254,7 @@ public class IamConfig {
   @Bean
   ScopeMatcherRegistry customScopeMatchersRegistry(ScopeMatchersProperties properties) {
     ScopeMatchersPropertiesParser parser = new ScopeMatchersPropertiesParser();
-    return new DefaultScopeMatcherRegistry(parser.parseScopeMatchersProperties(properties), 20);
+    return new DefaultScopeMatcherRegistry(parser.parseScopeMatchersProperties(properties));
   }
 
   @Bean

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/MitreServicesConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/MitreServicesConfig.java
@@ -159,7 +159,7 @@ public class MitreServicesConfig {
   @Bean
   OAuth2RequestValidator requestValidator(ScopeMatcherRegistry registry) {
 
-    return new ScopeMatcherOAuthRequestValidator(registry, 50);
+    return new ScopeMatcherOAuthRequestValidator(registry);
   }
 
   @Bean

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/RedisCacheProperties.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/RedisCacheProperties.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@ConfigurationProperties("redis-cache")
+@Configuration
+public class RedisCacheProperties {
+
+  private boolean enabled = false;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enable) {
+    this.enabled = enable;
+  }
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/matchers/DefaultScopeMatcherRegistry.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/matchers/DefaultScopeMatcherRegistry.java
@@ -15,18 +15,20 @@
  */
 package it.infn.mw.iam.core.oauth.scope.matchers;
 
-import it.infn.mw.iam.config.CacheConfig;
-
 import java.util.Set;
 
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.security.oauth2.provider.ClientDetails;
 
 import com.google.common.collect.Sets;
 
 @SuppressWarnings("deprecation")
+@EnableCaching
 public class DefaultScopeMatcherRegistry implements ScopeMatcherRegistry {
 
+  public static final String SCOPE_CACHE_KEY = "scope-matcher";
+  
   private final Set<ScopeMatcher> customMatchers;
 
   public DefaultScopeMatcherRegistry(Set<ScopeMatcher> customMatchers) {
@@ -34,7 +36,7 @@ public class DefaultScopeMatcherRegistry implements ScopeMatcherRegistry {
   }
 
   @Override
-  @Cacheable(CacheConfig.SCOPE_CACHE_KEY_PREFIX)
+  @Cacheable(value = SCOPE_CACHE_KEY, key = "{#result}")
   public Set<ScopeMatcher> findMatchersForClient(ClientDetails client) {
     Set<ScopeMatcher> result = Sets.newHashSet();
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/matchers/DefaultScopeMatcherRegistry.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/matchers/DefaultScopeMatcherRegistry.java
@@ -34,7 +34,7 @@ public class DefaultScopeMatcherRegistry implements ScopeMatcherRegistry {
   }
 
   @Override
-  @Cacheable(value = SCOPE_CACHE_KEY, key = "{#result}")
+  @Cacheable(value = SCOPE_CACHE_KEY, key = "{#client?.id}")
   public Set<ScopeMatcher> findMatchersForClient(ClientDetails client) {
     Set<ScopeMatcher> result = Sets.newHashSet();
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/matchers/DefaultScopeMatcherRegistry.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/matchers/DefaultScopeMatcherRegistry.java
@@ -18,13 +18,11 @@ package it.infn.mw.iam.core.oauth.scope.matchers;
 import java.util.Set;
 
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.security.oauth2.provider.ClientDetails;
 
 import com.google.common.collect.Sets;
 
 @SuppressWarnings("deprecation")
-@EnableCaching
 public class DefaultScopeMatcherRegistry implements ScopeMatcherRegistry {
 
   public static final String SCOPE_CACHE_KEY = "scope-matcher";

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/matchers/DefaultScopeMatcherRegistry.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/matchers/DefaultScopeMatcherRegistry.java
@@ -15,8 +15,11 @@
  */
 package it.infn.mw.iam.core.oauth.scope.matchers;
 
+import it.infn.mw.iam.config.CacheConfig;
+
 import java.util.Set;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.security.oauth2.provider.ClientDetails;
 
 import com.google.common.collect.Sets;
@@ -31,6 +34,7 @@ public class DefaultScopeMatcherRegistry implements ScopeMatcherRegistry {
   }
 
   @Override
+  @Cacheable(CacheConfig.SCOPE_CACHE_KEY_PREFIX)
   public Set<ScopeMatcher> findMatchersForClient(ClientDetails client) {
     Set<ScopeMatcher> result = Sets.newHashSet();
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/matchers/DefaultScopeMatcherRegistry.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/matchers/DefaultScopeMatcherRegistry.java
@@ -15,37 +15,18 @@
  */
 package it.infn.mw.iam.core.oauth.scope.matchers;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static java.util.Objects.nonNull;
-
 import java.util.Set;
 
 import org.springframework.security.oauth2.provider.ClientDetails;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Sets;
 
 @SuppressWarnings("deprecation")
 public class DefaultScopeMatcherRegistry implements ScopeMatcherRegistry {
 
-  public static final int DEFAULT_CACHE_SIZE = 10;
-
   private final Set<ScopeMatcher> customMatchers;
 
-  private final LoadingCache<String, ScopeMatcher> plainMatchersCache;
-
   public DefaultScopeMatcherRegistry(Set<ScopeMatcher> customMatchers) {
-    this(customMatchers, DEFAULT_CACHE_SIZE);
-  }
-
-  public DefaultScopeMatcherRegistry(Set<ScopeMatcher> customMatchers, int plainMatchersCacheSize) {
-    checkArgument(nonNull(customMatchers), "customMatchers must be non-null");
-    int cacheSize =
-        (plainMatchersCacheSize < DEFAULT_CACHE_SIZE ? DEFAULT_CACHE_SIZE : plainMatchersCacheSize);
-    plainMatchersCache =
-        CacheBuilder.newBuilder().maximumSize(cacheSize).build(CacheLoader.from(StringEqualsScopeMatcher::stringEqualsMatcher));
     this.customMatchers = customMatchers;
   }
 
@@ -55,6 +36,7 @@ public class DefaultScopeMatcherRegistry implements ScopeMatcherRegistry {
 
     for (String s : client.getScope()) {
       result.add(findMatcherForScope(s));
+
     }
 
     return result;
@@ -62,10 +44,10 @@ public class DefaultScopeMatcherRegistry implements ScopeMatcherRegistry {
 
   @Override
   public ScopeMatcher findMatcherForScope(String scope) {
+
     return customMatchers.stream()
       .filter(m -> m.matches(scope))
       .findFirst()
-      .orElse(plainMatchersCache.getUnchecked(scope));
+      .orElse(StringEqualsScopeMatcher.stringEqualsMatcher(scope));
   }
-
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/matchers/RegexpScopeMatcher.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/matchers/RegexpScopeMatcher.java
@@ -24,6 +24,7 @@ import javax.annotation.Generated;
 
 public class RegexpScopeMatcher implements ScopeMatcher {
 
+  private static final long serialVersionUID = -1419325543749683292L;
   final String regexp;
   final Pattern pattern;
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/matchers/ScopeMatcher.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/matchers/ScopeMatcher.java
@@ -15,6 +15,8 @@
  */
 package it.infn.mw.iam.core.oauth.scope.matchers;
 
-public interface ScopeMatcher {
+import java.io.Serializable;
+
+public interface ScopeMatcher extends Serializable {
   boolean matches(String scope);
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/matchers/ScopeMatcherOAuthRequestValidator.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/matchers/ScopeMatcherOAuthRequestValidator.java
@@ -23,40 +23,31 @@ import org.springframework.security.oauth2.provider.ClientDetails;
 import org.springframework.security.oauth2.provider.OAuth2RequestValidator;
 import org.springframework.security.oauth2.provider.TokenRequest;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
-
 @SuppressWarnings("deprecation")
 public class ScopeMatcherOAuthRequestValidator implements OAuth2RequestValidator {
 
-  public static final int DEFAULT_CACHE_SIZE = 10;
 
   public static final String ERROR_MSG_FMT = "Scope '%s' not allowed for client '%s'";
 
   private final ScopeMatcherRegistry registry;
-  private final LoadingCache<ClientDetails, Set<ScopeMatcher>> scopeMatchersCache;
-
-  public ScopeMatcherOAuthRequestValidator(ScopeMatcherRegistry matcherRegistry, int cacheSize) {
-    this.registry = matcherRegistry;
-    int cs = cacheSize < DEFAULT_CACHE_SIZE ? DEFAULT_CACHE_SIZE : cacheSize;
-    scopeMatchersCache = CacheBuilder.newBuilder()
-      .maximumSize(cs)
-      .build(CacheLoader.from(registry::findMatchersForClient));
-  }
 
   public ScopeMatcherOAuthRequestValidator(ScopeMatcherRegistry matcherRegistry) {
-    this(matcherRegistry, DEFAULT_CACHE_SIZE);
+    this.registry = matcherRegistry;
   }
 
   private void validateScope(Set<String> requestedScopes, ClientDetails client) {
 
-    Set<ScopeMatcher> scopeMatchers = scopeMatchersCache.getUnchecked(client);
+    Set<ScopeMatcher> scopeMatchers = registry.findMatchersForClient(client);
+    boolean isMatched = false;
     for (String s : requestedScopes) {
-      if (scopeMatchers.stream().noneMatch(m -> m.matches(s))) {
+      isMatched = scopeMatchers.stream().anyMatch(m -> m.matches(s));
+      if (isMatched) {
+        break;
+      } else {
         throw new InvalidScopeException(String.format(ERROR_MSG_FMT, s, client.getClientId()));
       }
     }
+
   }
 
   @Override
@@ -65,11 +56,9 @@ public class ScopeMatcherOAuthRequestValidator implements OAuth2RequestValidator
   }
 
   @Override
-  public void validateScope(TokenRequest tokenRequest, ClientDetails client){
+  public void validateScope(TokenRequest tokenRequest, ClientDetails client) {
     validateScope(tokenRequest.getScope(), client);
   }
 
-  public void invalidateScope(ClientDetails client) {
-    scopeMatchersCache.invalidate(client);
-  }
+
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/matchers/ScopeMatcherOAuthRequestValidator.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/matchers/ScopeMatcherOAuthRequestValidator.java
@@ -38,12 +38,8 @@ public class ScopeMatcherOAuthRequestValidator implements OAuth2RequestValidator
   private void validateScope(Set<String> requestedScopes, ClientDetails client) {
 
     Set<ScopeMatcher> scopeMatchers = registry.findMatchersForClient(client);
-    boolean isMatched = false;
     for (String s : requestedScopes) {
-      isMatched = scopeMatchers.stream().anyMatch(m -> m.matches(s));
-      if (isMatched) {
-        break;
-      } else {
+      if (scopeMatchers.stream().noneMatch(m -> m.matches(s))) {
         throw new InvalidScopeException(String.format(ERROR_MSG_FMT, s, client.getClientId()));
       }
     }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/matchers/StringEqualsScopeMatcher.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/matchers/StringEqualsScopeMatcher.java
@@ -19,6 +19,7 @@ import javax.annotation.Generated;
 
 public class StringEqualsScopeMatcher implements ScopeMatcher {
 
+  private static final long serialVersionUID = -1283075702068272727L;
   final String expectedValue;
 
   private StringEqualsScopeMatcher(String expectedValue) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/matchers/StructuredPathScopeMatcher.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/matchers/StructuredPathScopeMatcher.java
@@ -29,6 +29,8 @@ import org.slf4j.LoggerFactory;
 
 public class StructuredPathScopeMatcher implements ScopeMatcher {
 
+  private static final long serialVersionUID = 8238476071265296982L;
+
   public static final Logger LOG = LoggerFactory.getLogger(StructuredPathScopeMatcher.class);
 
   private static final Pattern POINT_DIR_MATCHER = Pattern.compile("\\.\\./?");

--- a/iam-login-service/src/main/java/it/infn/mw/iam/util/CacheConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/util/CacheConfig.java
@@ -41,7 +41,7 @@ public class CacheConfig {
   @Bean
   @ConditionalOnProperty(name = "redis-cache.enabled", havingValue = "true")
   public RedisCacheManagerBuilderCustomizer redisCacheManagerBuilderCustomizer() {
-    return (builder) -> builder
+    return builder -> builder
       .withCacheConfiguration(IamWellKnownInfoProvider.CACHE_KEY,
           RedisCacheConfiguration.defaultCacheConfig())
       .withCacheConfiguration(DefaultScopeMatcherRegistry.SCOPE_CACHE_KEY,

--- a/iam-login-service/src/main/java/it/infn/mw/iam/util/CacheConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/util/CacheConfig.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package it.infn.mw.iam.config;
+package it.infn.mw.iam.util;
 
 import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCustomizer;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -21,13 +21,11 @@ import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 
 import it.infn.mw.iam.core.oauth.scope.matchers.DefaultScopeMatcherRegistry;
 import it.infn.mw.iam.core.web.wellknown.IamWellKnownInfoProvider;
 
-@Configuration
 @EnableCaching
 public class CacheConfig {
 

--- a/iam-login-service/src/main/resources/application-redis-test.yml
+++ b/iam-login-service/src/main/resources/application-redis-test.yml
@@ -24,3 +24,6 @@ spring:
     redis:
       flush-mode: immediate
       namespace: iam:session
+
+redis-cache:
+  enabled: true

--- a/iam-login-service/src/main/resources/application.yml
+++ b/iam-login-service/src/main/resources/application.yml
@@ -182,8 +182,8 @@ iam:
   account-linking:
     enable: ${IAM_ACCOUNT_LINKING_ENABLE:true}
 
-scope-matcher-cache:
-  enabled: ${IAM_SCOPE_MATCHER_CACHE_ENABLE:false}
+redis-cache:
+  enabled: ${IAM_REDIS_CACHE_ENABLED:false}
 
 x509:
   trustAnchorsDir: ${IAM_X509_TRUST_ANCHORS_DIR:/etc/grid-security/certificates}

--- a/iam-login-service/src/main/resources/application.yml
+++ b/iam-login-service/src/main/resources/application.yml
@@ -182,6 +182,9 @@ iam:
   account-linking:
     enable: ${IAM_ACCOUNT_LINKING_ENABLE:true}
 
+scope-matcher-cache:
+  enabled: ${IAM_SCOPE_MATCHER_CACHE_ENABLE:false}
+
 x509:
   trustAnchorsDir: ${IAM_X509_TRUST_ANCHORS_DIR:/etc/grid-security/certificates}
   trustAnchorsRefreshMsec: ${IAM_X509_TRUST_ANCHORS_REFRESH:14400}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/scope/matchers/ScopeMatcherCacheTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/scope/matchers/ScopeMatcherCacheTests.java
@@ -18,6 +18,7 @@ package it.infn.mw.iam.test.oauth.scope.matchers;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertFalse;
 
 import java.text.ParseException;
 
@@ -33,6 +34,7 @@ import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTParser;
 
 import it.infn.mw.iam.api.client.service.ClientService;
+import it.infn.mw.iam.config.RedisCacheProperties;
 import it.infn.mw.iam.test.oauth.EndpointsTestUtils;
 import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
 
@@ -47,6 +49,9 @@ public class ScopeMatcherCacheTests extends EndpointsTestUtils {
   @Autowired
   private ClientService clientService;
 
+  @Autowired
+  private RedisCacheProperties cacheProperties;
+
   private String getAccessTokenForClient(String scopes) throws Exception {
 
     return new AccessTokenGetter().grantType("client_credentials")
@@ -54,6 +59,11 @@ public class ScopeMatcherCacheTests extends EndpointsTestUtils {
       .clientSecret(CLIENT_SECRET)
       .scope(scopes)
       .getAccessTokenValue();
+  }
+
+  @Test
+  public void ensureRedisCashIsDisabled() {
+    assertFalse(cacheProperties.isEnabled());
   }
 
   @Test

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/scope/matchers/ScopeMatcherCacheTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/scope/matchers/ScopeMatcherCacheTests.java
@@ -15,6 +15,7 @@
  */
 package it.infn.mw.iam.test.oauth.scope.matchers;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.not;
@@ -26,6 +27,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mitre.oauth2.model.ClientDetailsEntity;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -34,6 +36,7 @@ import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTParser;
 
 import it.infn.mw.iam.api.client.service.ClientService;
+import it.infn.mw.iam.config.CacheConfig;
 import it.infn.mw.iam.config.RedisCacheProperties;
 import it.infn.mw.iam.test.oauth.EndpointsTestUtils;
 import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
@@ -50,7 +53,10 @@ public class ScopeMatcherCacheTests extends EndpointsTestUtils {
   private ClientService clientService;
 
   @Autowired
-  private RedisCacheProperties cacheProperties;
+  private CacheConfig cacheConfig;
+  
+  @Autowired
+  private RedisCacheProperties redisCacheProperties;
 
   private String getAccessTokenForClient(String scopes) throws Exception {
 
@@ -63,7 +69,8 @@ public class ScopeMatcherCacheTests extends EndpointsTestUtils {
 
   @Test
   public void ensureRedisCashIsDisabled() {
-    assertFalse(cacheProperties.isEnabled());
+    assertFalse(redisCacheProperties.isEnabled());
+    assertThat(cacheConfig.localCacheManager(), instanceOf(CacheManager.class));
   }
 
   @Test

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/scope/matchers/ScopeMatcherExternalCacheTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/scope/matchers/ScopeMatcherExternalCacheTests.java
@@ -41,6 +41,7 @@ import com.nimbusds.jwt.JWTParser;
 
 import io.restassured.RestAssured;
 import it.infn.mw.iam.api.client.service.ClientService;
+import it.infn.mw.iam.config.RedisCacheProperties;
 import it.infn.mw.iam.test.TestUtils;
 import it.infn.mw.iam.test.oauth.EndpointsTestUtils;
 import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
@@ -60,9 +61,12 @@ public class ScopeMatcherExternalCacheTests extends EndpointsTestUtils {
   static {
     System.setProperty("spring.devtools.restart.enabled", "false");
   }
-  
+
   @Autowired
   private ClientService clientService;
+
+  @Autowired
+  private RedisCacheProperties cacheProperties;
 
   @LocalServerPort
   private Integer iamPort;
@@ -83,6 +87,7 @@ public class ScopeMatcherExternalCacheTests extends EndpointsTestUtils {
   public void setup() {
     TestUtils.initRestAssured();
     RestAssured.port = iamPort;
+    assertTrue(cacheProperties.isEnabled());
 
   }
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/scope/matchers/ScopeMatcherExternalCacheTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/scope/matchers/ScopeMatcherExternalCacheTests.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.oauth.scope.matchers;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.in;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.text.ParseException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mitre.oauth2.model.ClientDetailsEntity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Sets;
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTParser;
+
+import io.restassured.RestAssured;
+import it.infn.mw.iam.api.client.service.ClientService;
+import it.infn.mw.iam.test.TestUtils;
+import it.infn.mw.iam.test.oauth.EndpointsTestUtils;
+import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
+import it.infn.mw.iam.test.util.redis.RedisContainer;
+
+
+
+@Testcontainers
+@IamMockMvcIntegrationTest
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT,
+    properties = {"redis-cache.enabled=true", "iam.access_token.include_scope=true"})
+public class ScopeMatcherExternalCacheTests extends EndpointsTestUtils {
+
+  private static final String CLIENT_ID = "cache-client";
+  private static final String CLIENT_SECRET = "secret";
+
+  static {
+    System.setProperty("spring.devtools.restart.enabled", "false");
+  }
+  
+  @Autowired
+  private ClientService clientService;
+
+  @LocalServerPort
+  private Integer iamPort;
+
+  @Autowired
+  ObjectMapper mapper;
+
+  @Container
+  private static final RedisContainer REDIS = new RedisContainer();
+
+  @DynamicPropertySource
+  static void redisProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.redis.port", REDIS::getFirstMappedPort);
+
+  }
+
+  @BeforeEach
+  public void setup() {
+    TestUtils.initRestAssured();
+    RestAssured.port = iamPort;
+
+  }
+
+  private String getAccessTokenForClient(String scopes) throws Exception {
+
+    return new AccessTokenGetter().grantType("client_credentials")
+      .clientId(CLIENT_ID)
+      .clientSecret(CLIENT_SECRET)
+      .scope(scopes)
+      .getAccessTokenValue();
+
+  }
+
+  @Test
+  public void ensureRedisRunning() {
+    assertTrue(REDIS.isRunning());
+  }
+
+  @Test
+  public void updatingClientScopesInvalidatesExternalCache() throws ParseException, Exception {
+
+    ClientDetailsEntity client = new ClientDetailsEntity();
+    client.setClientId(CLIENT_ID);
+    client.setClientSecret(CLIENT_SECRET);
+    client.setScope(Sets.newHashSet("openid", "profile", "email"));
+    client = clientService.saveNewClient(client);
+
+    try {
+      JWT token = JWTParser.parse(getAccessTokenForClient("openid profile email"));
+      assertThat("scim:read",
+          not(in(token.getJWTClaimsSet().getClaim("scope").toString().split(" "))));
+      client.setScope(Sets.newHashSet("openid", "profile", "email", "scim:read"));
+      clientService.updateClient(client);
+      token = JWTParser.parse(getAccessTokenForClient("openid profile email scim:read"));
+      assertThat("scim:read", in(token.getJWTClaimsSet().getClaim("scope").toString().split(" ")));
+    } finally {
+      clientService.deleteClient(client);
+    }
+  }
+
+}


### PR DESCRIPTION
The scope matchers and the well-known endpoint were cashed locally.

We added a configuration property to enable scope matchers and well-known endpoint cache to an external Redis server.

In particular, when
- `redis-cache.enabled=true` the scope matchers and the well-known endpoint are cached into Redis;
- `redis-cache.enabled=false` the scope matchers and the well-known endpoint are cached locally.