### PR TITLE
#644 Fix CERN Restore workflow

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/cern/CernHrLifecycleHandler.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/cern/CernHrLifecycleHandler.java
@@ -203,6 +203,8 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
   public void handleInvalidAccount(IamAccount account) {
     if (account.isActive()) {
       disableAccount(account);
+    } else {
+      accountService.setLabel(account, buildStatusLabel(OK));
     }
   }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/cern/CernHrLifecycleHandler.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/cern/CernHrLifecycleHandler.java
@@ -162,7 +162,7 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
 
   }
 
-  private boolean accountWasSuspendedByUs(IamAccount account) {
+  private boolean accountWasSuspendedByCernHrLifecycleJob(IamAccount account) {
     Optional<IamLabel> actionLabel =
         account.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_ACTION);
 
@@ -192,7 +192,7 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
 
   public void handleValidAccount(IamAccount account) {
     syncMembershipInformation(account);
-    if (!account.isActive() && accountWasSuspendedByUs(account)) {
+    if (!account.isActive() && accountWasSuspendedByCernHrLifecycleJob(account)) {
       restoreAccount(account);
     } else {
       accountService.setLabel(account, buildStatusLabel(OK));
@@ -203,9 +203,6 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
   public void handleInvalidAccount(IamAccount account) {
     if (account.isActive()) {
       disableAccount(account);
-    } else {
-      accountService.setLabel(account, buildStatusLabel(OK));
-      accountService.setLabel(account, buildActionLabel(NO_ACTION));
     }
   }
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/cern/CernAccountLifecycleTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/cern/CernAccountLifecycleTests.java
@@ -195,7 +195,7 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
   }
 
   @Test
-  public void testNoActionLifecycleDoesNotSetActionForInValidAccounts() {
+  public void testActionNotSetForDisabledInValidAccounts() {
 
     when(hrDb.hasValidExperimentParticipation(anyString())).thenReturn(false);
 


### PR DESCRIPTION
Fix for issue https://github.com/indigo-iam/iam/issues/644 
Invalid accounts do not have their DISABLE_ACCOUNT label overwritten on subsequent runs of the job.