### PR TITLE
Fix scope matching which affects device code flow

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/IamSystemScopeService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/IamSystemScopeService.java
@@ -37,7 +37,7 @@ public class IamSystemScopeService extends DefaultSystemScopeService {
   public boolean scopesMatch(Set<String> allowedScopes, Set<String> requestedScopes) {
 
     Set<ScopeMatcher> allowedScopeMatchers =
-        requestedScopes.stream().map(scopeMatcherRegistry::findMatcherForScope).collect(toSet());
+        allowedScopes.stream().map(scopeMatcherRegistry::findMatcherForScope).collect(toSet());
 
     for (String rs : requestedScopes) {
       if (allowedScopeMatchers.stream().noneMatch(m -> m.matches(rs))) {

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/devicecode/DeviceCodeTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/devicecode/DeviceCodeTests.java
@@ -34,7 +34,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 import java.io.UnsupportedEncodingException;
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -50,6 +49,7 @@ import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Sets;
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.JWTParser;
@@ -563,7 +563,7 @@ public class DeviceCodeTests extends EndpointsTestUtils implements DeviceCodeTes
   public void publicClientDeviceCodeWorks() throws Exception {
 
     Optional<ClientDetailsEntity> client = clientRepo.findByClientId(PUBLIC_DEVICE_CODE_CLIENT_ID);
-    Set<String> scopes = new HashSet<String>();
+    Set<String> scopes = Sets.newHashSet();
     scopes.add("openid");
     scopes.add("profile");
     if (client.isPresent()) {

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/devicecode/DeviceCodeTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/devicecode/DeviceCodeTests.java
@@ -34,6 +34,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 import java.io.UnsupportedEncodingException;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -433,7 +436,7 @@ public class DeviceCodeTests extends EndpointsTestUtils implements DeviceCodeTes
 
     RegisteredClientDTO registrationResponse =
         objectMapper.readValue(clientJson, RegisteredClientDTO.class);
-    
+
     ClientDetailsEntity newClient =
         clientRepo.findByClientId(registrationResponse.getClientId()).orElseThrow();
 
@@ -559,6 +562,13 @@ public class DeviceCodeTests extends EndpointsTestUtils implements DeviceCodeTes
   @Test
   public void publicClientDeviceCodeWorks() throws Exception {
 
+    Optional<ClientDetailsEntity> client = clientRepo.findByClientId(PUBLIC_DEVICE_CODE_CLIENT_ID);
+    Set<String> scopes = new HashSet<String>();
+    scopes.add("openid");
+    scopes.add("profile");
+    if (client.isPresent()) {
+      client.get().setScope(scopes);
+    }
     String deviceResponse = mvc
       .perform(post(DEVICE_CODE_ENDPOINT).contentType(APPLICATION_FORM_URLENCODED)
         .param("client_id", PUBLIC_DEVICE_CODE_CLIENT_ID)

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/scope/StructuredScopeRequestIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/scope/StructuredScopeRequestIntegrationTests.java
@@ -29,7 +29,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -49,6 +48,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Sets;
 
 import it.infn.mw.iam.IamLoginService;
 import it.infn.mw.iam.persistence.repository.client.IamClientRepository;
@@ -135,7 +135,7 @@ public class StructuredScopeRequestIntegrationTests extends EndpointsTestUtils
   public void testDeviceCodeStructuredScopeRequest() throws Exception {
 
     Optional<ClientDetailsEntity> client = clientRepo.findByClientId(DEVICE_CODE_CLIENT_ID);
-    Set<String> scopes = new HashSet<String>();
+    Set<String> scopes = Sets.newHashSet();
     scopes.add("storage.read:/");
     scopes.add("openid");
     scopes.add("profile");

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/scope/StructuredScopeRequestIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/scope/StructuredScopeRequestIntegrationTests.java
@@ -29,9 +29,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mitre.oauth2.model.ClientDetailsEntity;
 import org.mitre.oauth2.model.SystemScope;
 import org.mitre.oauth2.service.SystemScopeService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,6 +51,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import it.infn.mw.iam.IamLoginService;
+import it.infn.mw.iam.persistence.repository.client.IamClientRepository;
 import it.infn.mw.iam.test.oauth.EndpointsTestUtils;
 import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
 
@@ -66,6 +72,9 @@ public class StructuredScopeRequestIntegrationTests extends EndpointsTestUtils
 
   @Autowired
   private ObjectMapper mapper;
+
+  @Autowired
+  private IamClientRepository clientRepo;
 
   @Before
   public void setup() throws Exception {
@@ -124,6 +133,17 @@ public class StructuredScopeRequestIntegrationTests extends EndpointsTestUtils
 
   @Test
   public void testDeviceCodeStructuredScopeRequest() throws Exception {
+
+    Optional<ClientDetailsEntity> client = clientRepo.findByClientId(DEVICE_CODE_CLIENT_ID);
+    Set<String> scopes = new HashSet<String>();
+    scopes.add("storage.read:/");
+    scopes.add("openid");
+    scopes.add("profile");
+    scopes.add("offline_access");
+    if (client.isPresent()) {
+      client.get().setScope(scopes);
+    }
+
     String response = mvc
       .perform(post(DEVICE_CODE_ENDPOINT).contentType(APPLICATION_FORM_URLENCODED)
         .with(httpBasic(DEVICE_CODE_CLIENT_ID, DEVICE_CODE_CLIENT_SECRET))
@@ -243,11 +263,11 @@ public class StructuredScopeRequestIntegrationTests extends EndpointsTestUtils
   public void testRefreshTokenStructuredScopeRequest() throws Exception {
 
     DefaultOAuth2AccessToken tokenResponse = new AccessTokenGetter().grantType(PASSWORD_GRANT_TYPE)
-        .clientId(PASSWORD_CLIENT_ID)
-        .clientSecret(PASSWORD_CLIENT_SECRET)
-        .username(TEST_USERNAME)
-        .password(TEST_PASSWORD)
-        .scope("openid storage.read:/ offline_access")
+      .clientId(PASSWORD_CLIENT_ID)
+      .clientSecret(PASSWORD_CLIENT_SECRET)
+      .username(TEST_USERNAME)
+      .password(TEST_PASSWORD)
+      .scope("openid storage.read:/ offline_access")
       .getTokenResponseObject();
 
     assertThat(tokenResponse.getScope(), hasItem("storage.read:/"));
@@ -260,9 +280,8 @@ public class StructuredScopeRequestIntegrationTests extends EndpointsTestUtils
       .andExpect(status().isOk())
       .andExpect(jsonPath("$.access_token").exists())
       .andExpect(jsonPath("$.refresh_token").exists())
-      .andExpect(jsonPath("$.scope",
-          allOf(containsString("storage.read:/test "), containsString("offline_access"),
-              containsString("openid"))));
+      .andExpect(jsonPath("$.scope", allOf(containsString("storage.read:/test "),
+          containsString("offline_access"), containsString("openid"))));
 
   }
 }


### PR DESCRIPTION
The match between the requested scopes and those allowed by the client did not work correctly.
This problem was encountered when the authorization grant (code) was requested at the `/devicecode` endpoint during the device code flow.