### PR TITLE
Add OpenID Connect standard claims in ATs for WLCG JWT profile

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/wlcg/WLCGProfileAccessTokenBuilder.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/wlcg/WLCGProfileAccessTokenBuilder.java
@@ -79,6 +79,15 @@ public class WLCGProfileAccessTokenBuilder extends BaseAccessTokenBuilder {
         builder.claim(ATTR_SCOPE, attributeHelper
           .getAttributeMapFromUserInfo(((UserInfoAdapter) userInfo).getUserinfo()));
       }
+      if (properties.getAccessToken().isIncludeAuthnInfo()) {
+        if (token.getScope().contains("email")) {
+          builder.claim("email", userInfo.getEmail());
+        }
+        if (token.getScope().contains("profile")) {
+          builder.claim("preferred_username", userInfo.getPreferredUsername());
+          builder.claim("name", userInfo.getName());
+        }
+      }
     }
 
     if (!hasAudienceRequest(authentication) && !hasRefreshTokenAudienceRequest(authentication)) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/wlcg/WLCGProfileAccessTokenBuilder.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/wlcg/WLCGProfileAccessTokenBuilder.java
@@ -61,40 +61,62 @@ public class WLCGProfileAccessTokenBuilder extends BaseAccessTokenBuilder {
 
     builder.notBeforeTime(Date.from(issueTime));
 
-    if (!token.getScope().isEmpty()) {
-      builder.claim(SCOPE_CLAIM_NAME, token.getScope().stream().collect(joining(SPACE)));
-    }
-
-    builder.claim(WLCG_VER_CLAIM, PROFILE_VERSION);
+    addScopeClaim(builder, token);
+    addWlcgVerClaim(builder);
 
     if (!isNull(userInfo)) {
       Set<String> groupNames =
           groupHelper.resolveGroupNames(token, ((UserInfoAdapter) userInfo).getUserinfo());
-
-      if (!groupNames.isEmpty()) {
-        builder.claim(WLCGGroupHelper.WLCG_GROUPS_SCOPE, groupNames);
-      }
+      addWlcgGroupsScopeClaim(builder, groupNames);
 
       if (token.getScope().contains(ATTR_SCOPE)) {
-        builder.claim(ATTR_SCOPE, attributeHelper
-          .getAttributeMapFromUserInfo(((UserInfoAdapter) userInfo).getUserinfo()));
+        addAttributeScopeClaim(builder, userInfo);
       }
       if (properties.getAccessToken().isIncludeAuthnInfo()) {
-        if (token.getScope().contains("email")) {
-          builder.claim("email", userInfo.getEmail());
-        }
-        if (token.getScope().contains("profile")) {
-          builder.claim("preferred_username", userInfo.getPreferredUsername());
-          builder.claim("name", userInfo.getName());
-        }
+        addAuthnInfoClaims(builder, token.getScope(), userInfo);
       }
     }
 
+    addAudience(builder, authentication);
+
+    return builder.build();
+  }
+
+  private void addScopeClaim(Builder builder, OAuth2AccessTokenEntity token) {
+    if (!token.getScope().isEmpty()) {
+      builder.claim(SCOPE_CLAIM_NAME, token.getScope().stream().collect(joining(SPACE)));
+    }
+  }
+
+  private void addWlcgVerClaim(Builder builder) {
+    builder.claim(WLCG_VER_CLAIM, PROFILE_VERSION);
+  }
+
+  private void addWlcgGroupsScopeClaim(Builder builder, Set<String> groupNames) {
+    if (!groupNames.isEmpty()) {
+      builder.claim(WLCGGroupHelper.WLCG_GROUPS_SCOPE, groupNames);
+    }
+  }
+
+  private void addAttributeScopeClaim(Builder builder, UserInfo userInfo) {
+    builder.claim(ATTR_SCOPE,
+        attributeHelper.getAttributeMapFromUserInfo(((UserInfoAdapter) userInfo).getUserinfo()));
+  }
+
+  private void addAuthnInfoClaims(Builder builder, Set<String> scopes, UserInfo userInfo) {
+    if (scopes.contains("email")) {
+      builder.claim("email", userInfo.getEmail());
+    }
+    if (scopes.contains("profile")) {
+      builder.claim("preferred_username", userInfo.getPreferredUsername());
+      builder.claim("name", userInfo.getName());
+    }
+  }
+
+  private void addAudience(Builder builder, OAuth2Authentication authentication) {
     if (!hasAudienceRequest(authentication) && !hasRefreshTokenAudienceRequest(authentication)) {
       builder.audience(ALL_AUDIENCES_VALUE);
     }
-
-    return builder.build();
   }
 
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/WLCGProfileIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/WLCGProfileIntegrationTests.java
@@ -78,6 +78,7 @@ import it.infn.mw.iam.test.util.oauth.MockOAuth2Request;
 @TestPropertySource(properties = {
 // @formatter:off
     "iam.jwt-profile.default-profile=wlcg",
+    "iam.access_token.include_authn_info=true",
     "scope.matchers[0].name=storage.read",
     "scope.matchers[0].type=path",
     "scope.matchers[0].prefix=storage.read",
@@ -736,7 +737,7 @@ public class WLCGProfileIntegrationTests extends EndpointsTestUtils {
   }
 
   @Test
-  public void attributesAreIncludedInAccessTokenWhenNotRequested() throws Exception {
+  public void attributesAreIncludedInAccessTokenWhenRequested() throws Exception {
     IamAccount testAccount =
         repo.findByUsername(TEST_USER).orElseThrow(assertionError(EXPECTED_USER_NOT_FOUND));
 
@@ -760,6 +761,57 @@ public class WLCGProfileIntegrationTests extends EndpointsTestUtils {
 
     assertThat(claims.getJSONObjectClaim("attr"), notNullValue());
     assertThat(claims.getJSONObjectClaim("attr").get("test"), is("test"));
+  }
+
+  @Test
+  public void additionalClaimsAreIncludedInAccessTokenWhenRequested() throws Exception {
+
+    String tokenResponseJson = mvc
+      .perform(post("/token").param("grant_type", "password")
+        .param("client_id", CLIENT_ID)
+        .param("client_secret", CLIENT_SECRET)
+        .param("username", "test")
+        .param("password", "password")
+        .param("scope", "openid profile email"))
+      .andExpect(status().isOk())
+      .andReturn()
+      .getResponse()
+      .getContentAsString();
+
+    JWTClaimsSet claims =
+        JWTParser.parse(mapper.readTree(tokenResponseJson).get("access_token").asText())
+          .getJWTClaimsSet();
+
+    assertThat(claims.getClaim("email"), notNullValue());
+    assertThat(claims.getClaim("email"), is("test@iam.test"));
+    assertThat(claims.getClaim("name"), notNullValue());
+    assertThat(claims.getClaim("name"), is("Test User"));
+    assertThat(claims.getClaim("preferred_username"), notNullValue());
+    assertThat(claims.getClaim("preferred_username"), is("test"));
+  }
+
+  @Test
+  public void additionalClaimsAreNotIncludedInAccessTokenWhenRNotequested() throws Exception {
+
+    String tokenResponseJson = mvc
+      .perform(post("/token").param("grant_type", "password")
+        .param("client_id", CLIENT_ID)
+        .param("client_secret", CLIENT_SECRET)
+        .param("username", "test")
+        .param("password", "password")
+        .param("scope", "openid address"))
+      .andExpect(status().isOk())
+      .andReturn()
+      .getResponse()
+      .getContentAsString();
+
+    JWTClaimsSet claims =
+        JWTParser.parse(mapper.readTree(tokenResponseJson).get("access_token").asText())
+          .getJWTClaimsSet();
+
+    assertThat(claims.getClaim("email"), nullValue());
+    assertThat(claims.getClaim("name"), nullValue());
+    assertThat(claims.getClaim("preferred_username"), nullValue());
   }
 
 }


### PR DESCRIPTION
In particular, if `IAM_ACCESS_TOKEN_INCLUDE_AUTHN_INFO=true` and
* `email` scope is requested, the `email` claim appears in ATs
* `profile` scope is requested, the `name` and `preferred_username` claims appear in ATs