### PR TITLE
Fix authz code flow with PKCE for IAM test client application

### DIFF
--- a/iam-test-client/src/main/java/it/infn/mw/tc/IamClientApplicationProperties.java
+++ b/iam-test-client/src/main/java/it/infn/mw/tc/IamClientApplicationProperties.java
@@ -2,6 +2,7 @@ package it.infn.mw.tc;
 
 import java.util.List;
 
+import org.mitre.oauth2.model.PKCEAlgorithm;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -14,6 +15,7 @@ public class IamClientApplicationProperties {
     String clientSecret;
     List<String> redirectUris;
     String scope;
+    PKCEAlgorithm codeChallengeMethod;
 
     public String getClientId() {
       return clientId;
@@ -45,6 +47,14 @@ public class IamClientApplicationProperties {
 
     public void setScope(String scope) {
       this.scope = scope;
+    }
+
+    public PKCEAlgorithm getCodeChallengeMethod() {
+      return codeChallengeMethod;
+    }
+
+    public void setCodeChallengeMethod(PKCEAlgorithm codeChallengeMethod) {
+      this.codeChallengeMethod = codeChallengeMethod;
     }
   }
 

--- a/iam-test-client/src/main/java/it/infn/mw/tc/IamOIDCClientFilter.java
+++ b/iam-test-client/src/main/java/it/infn/mw/tc/IamOIDCClientFilter.java
@@ -121,6 +121,11 @@ public class IamOIDCClientFilter extends OIDCAuthenticationFilter {
     form.setAll(getAuthRequestOptionsService().getTokenOptions(config.serverConfig,
         config.clientConfig, request));
 
+    String codeVerifier = getStoredCodeVerifier(request.getSession());
+    if (codeVerifier != null) {
+        form.add("code_verifier", codeVerifier);
+    }
+
     String redirectUri = getStoredSessionString(request.getSession(), REDIRECT_URI_SESION_VARIABLE);
 
     if (redirectUri != null) {

--- a/iam-test-client/src/main/java/it/infn/mw/tc/IamTestClientConfiguration.java
+++ b/iam-test-client/src/main/java/it/infn/mw/tc/IamTestClientConfiguration.java
@@ -122,6 +122,7 @@ public class IamTestClientConfiguration {
     cde.setTokenEndpointAuthMethod(AuthMethod.SECRET_BASIC);
     cde.setClientId(iamClientConfig.getClient().getClientId());
     cde.setClientSecret(iamClientConfig.getClient().getClientSecret());
+    cde.setCodeChallengeMethod(iamClientConfig.getClient().getCodeChallengeMethod());
 
     if (Strings.isNotBlank(iamClientConfig.getClient().getScope())) {
       cde.setScope(


### PR DESCRIPTION
The code challenge method is configurable by adding this property in the client application:
`iam.client.codeChallengeMethod=plain|S256`