### PR TITLE
Replace #oauth.hasScope annotation with proper #iam.hasScope

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/attributes/AccountAttributesController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/attributes/AccountAttributesController.java
@@ -72,7 +72,7 @@ public class AccountAttributesController {
   }
 
   @RequestMapping(value = "/iam/account/{id}/attributes", method = RequestMethod.GET)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.isUser(#id) or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM')")
+  @PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.isUser(#id) or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM')")
   public List<AttributeDTO> getAttributes(@PathVariable String id) {
 
     IamAccount account =
@@ -85,7 +85,7 @@ public class AccountAttributesController {
   }
 
   @RequestMapping(value = "/iam/account/{id}/attributes", method = PUT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void setAttribute(@PathVariable String id, @RequestBody @Validated AttributeDTO attribute,
       final BindingResult validationResult) {
 
@@ -99,7 +99,7 @@ public class AccountAttributesController {
   }
 
   @RequestMapping(value = "/iam/account/{id}/attributes", method = DELETE)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @ResponseStatus(value = NO_CONTENT)
   public void deleteAttribute(@PathVariable String id, @Validated AttributeDTO attribute,
       final BindingResult validationResult) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/authority/AccountAuthorityController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/authority/AccountAuthorityController.java
@@ -68,14 +68,14 @@ public class AccountAuthorityController {
       .orElseThrow(() -> new NoSuchAccountError(format("No account found for name '%s'", name)));
   }
 
-  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_USER')")
+  @PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_USER')")
   @RequestMapping(value = "/me/authorities", method = RequestMethod.GET)
   public AuthoritySetDTO getAuthoritiesForMe(Authentication authn) {
     return AuthoritySetDTO
       .fromAuthorities(authorityService.getAccountAuthorities(findAccountByName(authn.getName())));
   }
 
-  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM')")
+  @PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM')")
   @RequestMapping(value = "/account/{id}/authorities", method = RequestMethod.GET)
   @ResponseBody
   public AuthoritySetDTO getAuthoritiesForAccount(@PathVariable("id") String id) {
@@ -83,7 +83,7 @@ public class AccountAuthorityController {
       .fromAuthorities(authorityService.getAccountAuthorities(findAccountById(id)));
   }
 
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @RequestMapping(value = "/account/{id}/authorities", method = RequestMethod.POST)
   public void addAuthorityToAccount(@PathVariable("id") String id, @Valid AuthorityDTO authority,
       BindingResult validationResult) {
@@ -96,7 +96,7 @@ public class AccountAuthorityController {
 
   }
 
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @RequestMapping(value = "/account/{id}/authorities", method = RequestMethod.DELETE)
   public void removeAuthorityFromAccount(@PathVariable("id") String id,
       @Valid AuthorityDTO authority, BindingResult validationResult) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/find/FindAccountController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/find/FindAccountController.java
@@ -36,7 +36,7 @@ import it.infn.mw.iam.api.scim.model.ScimConstants;
 import it.infn.mw.iam.api.scim.model.ScimUser;
 
 @RestController
-@PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+@PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
 public class FindAccountController {
 
   public static final String INVALID_FIND_ACCOUNT_REQUEST = "Invalid find account request";

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/group/AccountGroupController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/group/AccountGroupController.java
@@ -57,7 +57,7 @@ public class AccountGroupController {
 
   @RequestMapping(value = "/iam/account/{accountUuid}/groups/{groupUuid}", method = POST)
   @ResponseStatus(value = HttpStatus.CREATED)
-  @PreAuthorize("#iam.hasAdminOrGMDashboardRoleOfGroup(#groupUuid) or #oauth2.hasScope('iam:admin.write')")
+  @PreAuthorize("#iam.hasAdminOrGMDashboardRoleOfGroup(#groupUuid) or #iam.hasScope('iam:admin.write')")
   public void addAccountToGroup(@PathVariable String accountUuid, @PathVariable String groupUuid) {
     IamGroup group = groupService.findByUuid(groupUuid).orElseThrow(noSuchGroup(groupUuid));
 
@@ -75,7 +75,7 @@ public class AccountGroupController {
 
   @RequestMapping(value = "/iam/account/{accountUuid}/groups/{groupUuid}", method = DELETE)
   @ResponseStatus(value = HttpStatus.NO_CONTENT)
-  @PreAuthorize("#iam.hasAdminOrGMDashboardRoleOfGroup(#groupUuid) or #oauth2.hasScope('iam:admin.write')")
+  @PreAuthorize("#iam.hasAdminOrGMDashboardRoleOfGroup(#groupUuid) or #iam.hasScope('iam:admin.write')")
   public void removeAccountFromGroup(@PathVariable String accountUuid,
       @PathVariable String groupUuid) {
     IamGroup group = groupService.findByUuid(groupUuid).orElseThrow(noSuchGroup(groupUuid));

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/group_manager/AccountGroupManagerController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/group_manager/AccountGroupManagerController.java
@@ -63,7 +63,7 @@ public class AccountGroupManagerController {
 
 
   @RequestMapping(value = "/iam/account/{accountId}/managed-groups", method = RequestMethod.GET)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isUser(#accountId)")
+  @PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isUser(#accountId)")
   public AccountManagedGroupsDTO getAccountManagedGroupsInformation(
       @PathVariable String accountId) {
     IamAccount account = accountRepository.findByUuid(accountId)
@@ -74,7 +74,7 @@ public class AccountGroupManagerController {
 
   @RequestMapping(value = "/iam/account/{accountId}/managed-groups/{groupId}",
       method = RequestMethod.POST)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @ResponseStatus(value = HttpStatus.CREATED)
   public void addManagedGroupToAccount(@PathVariable String accountId,
       @PathVariable String groupId) {
@@ -90,7 +90,7 @@ public class AccountGroupManagerController {
 
   @RequestMapping(value = "/iam/account/{accountId}/managed-groups/{groupId}",
       method = RequestMethod.DELETE)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @ResponseStatus(value = HttpStatus.NO_CONTENT)
   public void removeManagedGroupFromAccount(@PathVariable String accountId,
       @PathVariable String groupId) {
@@ -105,7 +105,7 @@ public class AccountGroupManagerController {
   }
 
   @RequestMapping(value = "/iam/group/{groupId}/group-managers", method=RequestMethod.GET)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isGroupManager(#groupId)")
+  @PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isGroupManager(#groupId)")
   public List<ScimUser> getGroupManagersForGroup(@PathVariable String groupId) {
     IamGroup group = groupRepository.findByUuid(groupId)
       .orElseThrow(() -> InvalidManagedGroupError.groupNotFoundException(groupId));

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/labels/AccountLabelsController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/labels/AccountLabelsController.java
@@ -75,7 +75,7 @@ public class AccountLabelsController {
   }
 
   @RequestMapping(method = GET)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM') or #iam.isUser(#id)")
+  @PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM') or #iam.isUser(#id)")
   public List<LabelDTO> getLabels(@PathVariable String id) {
 
     IamAccount account = service.findByUuid(id).orElseThrow(noSuchAccountError(id));
@@ -88,7 +88,7 @@ public class AccountLabelsController {
   }
 
   @RequestMapping(method = PUT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void setLabel(@PathVariable String id, @RequestBody @Validated LabelDTO label,
       BindingResult validationResult) {
     handleValidationError(validationResult);
@@ -98,7 +98,7 @@ public class AccountLabelsController {
   }
 
   @RequestMapping(method = DELETE)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @ResponseStatus(NO_CONTENT)
   public void deleteLabel(@PathVariable String id, @Validated LabelDTO label,
       BindingResult validationResult) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/lifecycle/AccountLifecycleController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/lifecycle/AccountLifecycleController.java
@@ -42,7 +42,7 @@ import it.infn.mw.iam.persistence.model.IamAccount;
 
 @RestController
 @RequestMapping(value = AccountLifecycleController.BASE_RESOURCE)
-@PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+@PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
 public class AccountLifecycleController {
 
   public static final String BASE_RESOURCE = "/iam/account/{id}/endTime";

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/proxy_certificate/AccountProxyCertificatesController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/proxy_certificate/AccountProxyCertificatesController.java
@@ -77,7 +77,7 @@ public class AccountProxyCertificatesController {
   }
 
   @RequestMapping(value = "/iam/account/me/proxycert", method = PUT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_USER')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_USER')")
   public void addProxyCertificate(
       @RequestBody @Validated(
           value = ProxyCertificateDTO.AddProxyCertValidation.class) ProxyCertificateDTO proxyCert,

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/search/AccountSearchController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/search/AccountSearchController.java
@@ -38,7 +38,7 @@ import it.infn.mw.iam.persistence.model.IamAccount;
 
 @RestController
 @Transactional
-@PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM')")
+@PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM')")
 @RequestMapping(AccountSearchController.ACCOUNT_SEARCH_ENDPOINT)
 public class AccountSearchController extends AbstractSearchController<ScimUser, IamAccount> {
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/search/GroupSearchController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/search/GroupSearchController.java
@@ -42,7 +42,7 @@ import it.infn.mw.iam.persistence.model.IamGroup;
 
 @RestController
 @Transactional
-@PreAuthorize("hasAnyRole('ADMIN', 'USER') or #oauth2.hasScope('iam:admin.read')")
+@PreAuthorize("hasAnyRole('ADMIN', 'USER') or #iam.hasScope('iam:admin.read')")
 @RequestMapping(GroupSearchController.GROUP_SEARCH_ENDPOINT)
 public class GroupSearchController extends AbstractSearchController<ScimGroup, IamGroup> {
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/aup/AupSignatureController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/aup/AupSignatureController.java
@@ -101,7 +101,7 @@ public class AupSignatureController {
   }
 
   @RequestMapping(value = "/iam/aup/signature/{accountId}", method = RequestMethod.GET)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM') or #iam.isUser(#accountId)")
+  @PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM') or #iam.isUser(#accountId)")
   public AupSignatureDTO getSignatureForAccount(@PathVariable String accountId) throws AccountNotFoundException {
     IamAccount account = accountUtils.getByAccountId(accountId)
       .orElseThrow(accountNotFoundException("Account not found for id: " + accountId));
@@ -113,7 +113,7 @@ public class AupSignatureController {
   }
 
   @RequestMapping(value = "/iam/aup/signature/{accountId}", method = RequestMethod.PATCH)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write')")
   public void setSignatureForAccount(@PathVariable String accountId,
       @RequestBody @Validated AupSignatureDTO dto) throws AccountNotFoundException {
     IamAccount account = accountUtils.getByAccountId(accountId)

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/management/ClientManagementAPIController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/management/ClientManagementAPIController.java
@@ -68,7 +68,7 @@ public class ClientManagementAPIController {
 
   @PostMapping
   @ResponseStatus(CREATED)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public RegisteredClientDTO saveNewClient(@RequestBody RegisteredClientDTO client)
       throws ParseException {
     return managementService.saveNewClient(client);
@@ -76,7 +76,7 @@ public class ClientManagementAPIController {
 
   @JsonView({ClientViews.ClientManagement.class})
   @GetMapping
-  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public ListResponseDTO<RegisteredClientDTO> retrieveClients(
       @RequestParam final Optional<Integer> count,
       @RequestParam final Optional<Integer> startIndex,
@@ -94,14 +94,14 @@ public class ClientManagementAPIController {
 
   @JsonView({ClientViews.ClientManagement.class})
   @GetMapping("/{clientId}")
-  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public RegisteredClientDTO retrieveClient(@PathVariable String clientId) {
     return managementService.retrieveClientByClientId(clientId)
       .orElseThrow(clientNotFound(clientId));
   }
 
   @GetMapping("/{clientId}/owners")
-  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public ListResponseDTO<ScimUser> retrieveClientOwners(@PathVariable String clientId,
       @RequestParam final Optional<Integer> count,
       @RequestParam final Optional<Integer> startIndex) {
@@ -111,7 +111,7 @@ public class ClientManagementAPIController {
 
   @PostMapping("/{clientId}/owners/{accountId}")
   @ResponseStatus(CREATED)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void assignClientOwner(@PathVariable String clientId,
       @PathVariable final String accountId) {
     managementService.assignClientOwner(clientId, accountId);
@@ -119,21 +119,21 @@ public class ClientManagementAPIController {
 
   @PostMapping("/{clientId}/rat")
   @ResponseStatus(CREATED)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public RegisteredClientDTO rotateRegistrationAccessToken(@PathVariable String clientId) {
     return managementService.rotateRegistrationAccessToken(clientId);
   }
 
   @DeleteMapping("/{clientId}/owners/{accountId}")
   @ResponseStatus(NO_CONTENT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void removeClientOwner(@PathVariable String clientId,
       @PathVariable final String accountId) {
     managementService.removeClientOwner(clientId, accountId);
   }
 
   @PutMapping("/{clientId}")
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public RegisteredClientDTO updateClient(@PathVariable String clientId,
       @RequestBody RegisteredClientDTO client)
       throws ParseException {
@@ -142,14 +142,14 @@ public class ClientManagementAPIController {
 
   @PostMapping("/{clientId}/secret")
   @ResponseStatus(CREATED)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public RegisteredClientDTO rotateClientSecret(@PathVariable String clientId) {
     return managementService.generateNewClientSecret(clientId);
   }
 
   @DeleteMapping("/{clientId}")
   @ResponseStatus(NO_CONTENT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void deleteClient(@PathVariable String clientId) {
     managementService.deleteClientByClientId(clientId);
   }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/search/SearchClientController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/search/SearchClientController.java
@@ -36,7 +36,7 @@ import it.infn.mw.iam.api.common.client.RegisteredClientDTO;
 
 @RestController
 @RequestMapping(SearchClientController.ENDPOINT)
-@PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+@PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
 public class SearchClientController {
 
   public static final int MAX_PAGE_SIZE = 100;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/exchange_policy/ExchangePolicyController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/exchange_policy/ExchangePolicyController.java
@@ -62,7 +62,7 @@ public class ExchangePolicyController {
   }
 
   @RequestMapping(value = "/policies", method = RequestMethod.GET)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public List<ExchangePolicyDTO> getExchangePolicies() {
     Page<ExchangePolicyDTO> resultsPage = service.getTokenExchangePolicies(UNPAGED);
     if (resultsPage.hasNext()) {
@@ -74,14 +74,14 @@ public class ExchangePolicyController {
 
   @RequestMapping(value = "/policies/{id}", method = RequestMethod.DELETE)
   @ResponseStatus(code = HttpStatus.NO_CONTENT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void deleteExchangePolicy(@PathVariable Long id) {
     service.deleteTokenExchangePolicyById(id);
   }
 
   @RequestMapping(value = "/policies", method = RequestMethod.POST)
   @ResponseStatus(code = HttpStatus.CREATED)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void createExchangePolicy(@Valid @RequestBody ExchangePolicyDTO dto,
       BindingResult validationResult) {
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/group/GroupController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/group/GroupController.java
@@ -86,7 +86,7 @@ public class GroupController {
   
   @RequestMapping(value = "/iam/group", method = POST)
   @ResponseStatus(value = HttpStatus.CREATED)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public GroupDTO createGroup(@RequestBody @Validated(CreateGroup.class) GroupDTO group, final BindingResult validationResult) {
     
     handleValidationError(INVALID_GROUP,validationResult);
@@ -97,7 +97,7 @@ public class GroupController {
   }
   
   @RequestMapping(value = "/iam/group/{id}", method = PUT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isGroupManager(#id)")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isGroupManager(#id)")
   public GroupDTO updateGroup(@PathVariable String id, @RequestBody @Validated(UpdateGroup.class) GroupDTO group, final BindingResult validationResult) {
     handleValidationError(INVALID_GROUP, validationResult);
     
@@ -107,7 +107,7 @@ public class GroupController {
   }
   
   @RequestMapping(value = "/iam/group/{id}/attributes", method=RequestMethod.GET)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isGroupManager(#id)")
+  @PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isGroupManager(#id)")
   public List<AttributeDTO> getAttributes(@PathVariable String id){
     
     IamGroup entity = groupService.findByUuid(id).orElseThrow(()->NoSuchGroupError.forUuid(id));
@@ -119,7 +119,7 @@ public class GroupController {
   }
   
   @RequestMapping(value = "/iam/group/{id}/attributes", method= PUT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void setAttribute(@PathVariable String id, @RequestBody @Validated AttributeDTO attribute, final BindingResult validationResult) {
     handleValidationError(INVALID_ATTRIBUTE,validationResult);
     IamGroup entity = groupService.findByUuid(id).orElseThrow(()->NoSuchGroupError.forUuid(id));
@@ -130,7 +130,7 @@ public class GroupController {
   }
   
   @RequestMapping(value = "/iam/group/{id}/attributes", method=DELETE)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @ResponseStatus(value = HttpStatus.NO_CONTENT)
   public void deleteAttribute(@PathVariable String id, @Validated AttributeDTO attribute, final BindingResult validationResult) {
     handleValidationError(INVALID_ATTRIBUTE, validationResult);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/controller/ScimGroupController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/controller/ScimGroupController.java
@@ -73,7 +73,7 @@ public class ScimGroupController extends ScimControllerSupport {
   @Autowired
   ScimGroupProvisioning groupProvisioningService;
 
-  @PreAuthorize("#oauth2.hasScope('scim:read') or #iam.hasAdminOrGMDashboardRoleOfGroup(#id)")
+  @PreAuthorize("#iam.hasScope('scim:read') or #iam.hasAdminOrGMDashboardRoleOfGroup(#id)")
   @RequestMapping(value = "/{id}", method = RequestMethod.GET,
       produces = ScimConstants.SCIM_CONTENT_TYPE)
   public ScimGroup getGroup(@PathVariable final String id) {
@@ -81,7 +81,7 @@ public class ScimGroupController extends ScimControllerSupport {
     return groupProvisioningService.getById(id);
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('scim:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @RequestMapping(method = RequestMethod.GET, produces = ScimConstants.SCIM_CONTENT_TYPE)
   public MappingJacksonValue listGroups(@RequestParam(required = false) final Integer count,
       @RequestParam(required = false) final Integer startIndex,
@@ -104,7 +104,7 @@ public class ScimGroupController extends ScimControllerSupport {
     return wrapper;
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('scim:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @RequestMapping(method = RequestMethod.POST, consumes = ScimConstants.SCIM_CONTENT_TYPE,
       produces = ScimConstants.SCIM_CONTENT_TYPE)
   @ResponseStatus(HttpStatus.CREATED)
@@ -115,7 +115,7 @@ public class ScimGroupController extends ScimControllerSupport {
     return groupProvisioningService.create(group);
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('scim:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @RequestMapping(value = "/{id}", method = RequestMethod.PUT,
       consumes = ScimConstants.SCIM_CONTENT_TYPE, produces = ScimConstants.SCIM_CONTENT_TYPE)
   @ResponseStatus(HttpStatus.OK)
@@ -128,7 +128,7 @@ public class ScimGroupController extends ScimControllerSupport {
 
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.hasAdminOrGMDashboardRoleOfGroup(#id)")
+  @PreAuthorize("#iam.hasScope('scim:write') or #iam.hasAdminOrGMDashboardRoleOfGroup(#id)")
   @RequestMapping(value = "/{id}", method = RequestMethod.PATCH,
       consumes = ScimConstants.SCIM_CONTENT_TYPE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
@@ -141,7 +141,7 @@ public class ScimGroupController extends ScimControllerSupport {
     groupProvisioningService.update(id, groupPatchRequest.getOperations());
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.hasAdminOrGMDashboardRoleOfGroup(#id)")
+  @PreAuthorize("#iam.hasScope('scim:write') or #iam.hasAdminOrGMDashboardRoleOfGroup(#id)")
   @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
   public void deleteGroup(@PathVariable final String id) {
@@ -150,7 +150,7 @@ public class ScimGroupController extends ScimControllerSupport {
   }
 
 
-  @PreAuthorize("#oauth2.hasScope('scim:read') or #iam.hasAdminOrGMDashboardRoleOfGroup(#id)")
+  @PreAuthorize("#iam.hasScope('scim:read') or #iam.hasAdminOrGMDashboardRoleOfGroup(#id)")
   @RequestMapping(value = "/{id}/members", method = RequestMethod.GET,
       produces = ScimConstants.SCIM_CONTENT_TYPE)
   public ScimListResponse<ScimMemberRef> listMembers(@PathVariable final String id,
@@ -161,7 +161,7 @@ public class ScimGroupController extends ScimControllerSupport {
         buildPageRequest(count, startIndex, SCIM_MEMBERS_MAX_PAGE_SIZE));
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:read') or #iam.hasAdminOrGMDashboardRoleOfGroup(#id)")
+  @PreAuthorize("#iam.hasScope('scim:read') or #iam.hasAdminOrGMDashboardRoleOfGroup(#id)")
   @RequestMapping(value = "/{id}/subgroups", method = RequestMethod.GET,
       produces = ScimConstants.SCIM_CONTENT_TYPE)
   public ScimListResponse<ScimMemberRef> listSubgroups(@PathVariable final String id,

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/controller/ScimMeController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/controller/ScimMeController.java
@@ -126,7 +126,7 @@ public class ScimMeController implements ApplicationEventPublisherAware {
     this.eventPublisher = publisher;
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:read') or hasRole('USER')")
+  @PreAuthorize("#iam.hasScope('scim:read') or hasRole('USER')")
   @RequestMapping(method = RequestMethod.GET, produces = ScimConstants.SCIM_CONTENT_TYPE)
   public ScimUser whoami() {
 
@@ -135,7 +135,7 @@ public class ScimMeController implements ApplicationEventPublisherAware {
 
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or hasRole('USER')")
+  @PreAuthorize("#iam.hasScope('scim:write') or hasRole('USER')")
   @RequestMapping(method = RequestMethod.PATCH, consumes = ScimConstants.SCIM_CONTENT_TYPE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
   public void updateUser(

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/controller/ScimUserController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/controller/ScimUserController.java
@@ -75,7 +75,7 @@ public class ScimUserController extends ScimControllerSupport {
     return result;
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('scim:read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @RequestMapping(method = RequestMethod.GET, produces = ScimConstants.SCIM_CONTENT_TYPE)
   public MappingJacksonValue listUsers(@RequestParam(required = false) final Integer count,
       @RequestParam(required = false) final Integer startIndex,
@@ -98,7 +98,7 @@ public class ScimUserController extends ScimControllerSupport {
     return wrapper;
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM')")
+  @PreAuthorize("#iam.hasScope('scim:read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM')")
   @RequestMapping(value = "/{id}", method = RequestMethod.GET,
       produces = ScimConstants.SCIM_CONTENT_TYPE)
   public ScimUser getUser(@PathVariable final String id) {
@@ -106,7 +106,7 @@ public class ScimUserController extends ScimControllerSupport {
     return userProvisioningService.getById(id);
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('scim:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @RequestMapping(method = RequestMethod.POST, consumes = ScimConstants.SCIM_CONTENT_TYPE,
       produces = ScimConstants.SCIM_CONTENT_TYPE)
   @ResponseStatus(HttpStatus.CREATED)
@@ -120,7 +120,7 @@ public class ScimUserController extends ScimControllerSupport {
     return new MappingJacksonValue(result);
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('scim:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @RequestMapping(value = "/{id}", method = RequestMethod.PUT,
       consumes = ScimConstants.SCIM_CONTENT_TYPE, produces = ScimConstants.SCIM_CONTENT_TYPE)
   @ResponseStatus(HttpStatus.OK)
@@ -134,7 +134,7 @@ public class ScimUserController extends ScimControllerSupport {
 
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('scim:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @RequestMapping(value = "/{id}", method = RequestMethod.PATCH,
       consumes = ScimConstants.SCIM_CONTENT_TYPE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
@@ -148,7 +148,7 @@ public class ScimUserController extends ScimControllerSupport {
 
   }
 
-  @PreAuthorize("#oauth2.hasScope('scim:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('scim:write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
   public void deleteUser(@PathVariable final String id) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scope_policy/ScopePolicyController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scope_policy/ScopePolicyController.java
@@ -55,7 +55,7 @@ public class ScopePolicyController {
   }
 
   @RequestMapping(value = "/iam/scope_policies", method = RequestMethod.GET)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public List<ScopePolicyDTO> listScopePolicies() {
 
     Iterable<IamScopePolicy> policies = policyService.findAllScopePolicies();
@@ -70,7 +70,7 @@ public class ScopePolicyController {
 
   @RequestMapping(value = "/iam/scope_policies", method = RequestMethod.POST)
   @ResponseStatus(code = HttpStatus.CREATED)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void addScopePolicy(@Valid @RequestBody ScopePolicyDTO policy,
       BindingResult validationResult) {
 
@@ -83,7 +83,7 @@ public class ScopePolicyController {
 
 
   @RequestMapping(value = "/iam/scope_policies/{id}", method = RequestMethod.GET)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public ScopePolicyDTO getScopePolicy(@PathVariable Long id) {
 
     IamScopePolicy p = policyService.findScopePolicyById(id)
@@ -95,7 +95,7 @@ public class ScopePolicyController {
 
   @RequestMapping(value = "/iam/scope_policies/{id}", method = RequestMethod.PUT)
   @ResponseStatus(code = HttpStatus.NO_CONTENT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void updateScopePolicy(@PathVariable Long id,
       @Valid @RequestBody ScopePolicyDTO policy, BindingResult validationResult) {
 
@@ -110,7 +110,7 @@ public class ScopePolicyController {
 
   @RequestMapping(value = "/iam/scope_policies/{id}", method = RequestMethod.DELETE)
   @ResponseStatus(code = HttpStatus.NO_CONTENT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void deleteScopePolicy(@PathVariable Long id) {
 
     policyService.deleteScopePolicyById(id);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/tokens/AccessTokensController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/tokens/AccessTokensController.java
@@ -49,7 +49,7 @@ public class AccessTokensController extends TokensControllerSupport {
   private TokenService<AccessToken> tokenService;
 
   @RequestMapping(method = RequestMethod.GET, produces = APPLICATION_JSON_CONTENT_TYPE)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public MappingJacksonValue listAccessTokens(@RequestParam(required = false) Integer count,
       @RequestParam(required = false) Integer startIndex,
       @RequestParam(required = false) String userId,
@@ -63,7 +63,7 @@ public class AccessTokensController extends TokensControllerSupport {
   
   @RequestMapping(method = RequestMethod.DELETE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void deleteAllTokens() {
     tokenService.deleteAllTokens();
   }
@@ -87,7 +87,7 @@ public class AccessTokensController extends TokensControllerSupport {
   }
 
   @RequestMapping(method = RequestMethod.GET, value = "/{id}", produces = APPLICATION_JSON_CONTENT_TYPE)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public AccessToken getAccessToken(@PathVariable("id") Long id) {
 
     return tokenService.getTokenById(id);
@@ -95,7 +95,7 @@ public class AccessTokensController extends TokensControllerSupport {
 
   @RequestMapping(method = RequestMethod.DELETE, value = "/{id}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void revokeAccessToken(@PathVariable("id") Long id) {
 
     tokenService.revokeTokenById(id);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/tokens/RefreshTokensController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/tokens/RefreshTokensController.java
@@ -49,7 +49,7 @@ public class RefreshTokensController extends TokensControllerSupport {
   private TokenService<RefreshToken> tokenService;
 
   @RequestMapping(method = RequestMethod.GET, produces = APPLICATION_JSON_CONTENT_TYPE)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public MappingJacksonValue lisRefreshTokens(@RequestParam(required = false) Integer count,
       @RequestParam(required = false) Integer startIndex,
       @RequestParam(required = false) String userId,
@@ -63,7 +63,7 @@ public class RefreshTokensController extends TokensControllerSupport {
   
   @RequestMapping(method = RequestMethod.DELETE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void deleteAllTokens() {
     tokenService.deleteAllTokens();
   }
@@ -87,7 +87,7 @@ public class RefreshTokensController extends TokensControllerSupport {
   }
 
   @RequestMapping(method = RequestMethod.GET, value = "/{id}", produces = APPLICATION_JSON_CONTENT_TYPE)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public RefreshToken getRefreshToken(@PathVariable("id") Long id) {
 
     return tokenService.getTokenById(id);
@@ -95,7 +95,7 @@ public class RefreshTokensController extends TokensControllerSupport {
 
   @RequestMapping(method = RequestMethod.DELETE, value = "/{id}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
-  @PreAuthorize("#oauth2.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public void revokeRefreshToken(@PathVariable("id") Long id) {
 
     tokenService.revokeTokenById(id);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/userinfo/IamUserInfoEndpoint.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/userinfo/IamUserInfoEndpoint.java
@@ -57,7 +57,7 @@ public class IamUserInfoEndpoint {
     this.scopeResolver = scopeResolver;
   }
 
-  @PreAuthorize("hasRole('ROLE_USER') and #oauth2.hasScope('" + SystemScopeService.OPENID_SCOPE
+  @PreAuthorize("hasRole('ROLE_USER') and #iam.hasScope('" + SystemScopeService.OPENID_SCOPE
       + "')")
   @RequestMapping(method = RequestMethod.GET, produces = {MediaType.APPLICATION_JSON_VALUE})
   public String getInfo(

--- a/iam-login-service/src/main/java/it/infn/mw/iam/registration/RegistrationApiController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/registration/RegistrationApiController.java
@@ -95,7 +95,7 @@ public class RegistrationApiController {
 
 
 
-  @PreAuthorize("#oauth2.hasScope('registration:read') or hasRole('ADMIN')")
+  @PreAuthorize("#iam.hasScope('registration:read') or hasRole('ADMIN')")
   @RequestMapping(value = "/registration/list", method = RequestMethod.GET)
   @ResponseBody
   public List<RegistrationRequestDto> listRequests(
@@ -104,7 +104,7 @@ public class RegistrationApiController {
     return service.listRequests(status);
   }
 
-  @PreAuthorize("#oauth2.hasScope('registration:read') or hasRole('ADMIN')")
+  @PreAuthorize("#iam.hasScope('registration:read') or hasRole('ADMIN')")
   @RequestMapping(value = "/registration/list/pending", method = RequestMethod.GET)
   @ResponseBody
   public List<RegistrationRequestDto> listPendingRequests() {
@@ -121,13 +121,13 @@ public class RegistrationApiController {
 
   }
 
-  @PreAuthorize("#oauth2.hasScope('registration:write') or hasRole('ADMIN')")
+  @PreAuthorize("#iam.hasScope('registration:write') or hasRole('ADMIN')")
   @RequestMapping(value = "/registration/approve/{uuid}", method = RequestMethod.POST)
   public RegistrationRequestDto approveRequest(@PathVariable("uuid") String uuid) {
     return service.approveRequest(uuid);
   }
 
-  @PreAuthorize("#oauth2.hasScope('registration:write') or hasRole('ADMIN')")
+  @PreAuthorize("#iam.hasScope('registration:write') or hasRole('ADMIN')")
   @RequestMapping(value = "/registration/reject/{uuid}", method = RequestMethod.POST)
   public RegistrationRequestDto rejectRequest(@PathVariable("uuid") String uuid,
       @RequestParam(required = false) String motivation) {

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/core/MeControllerTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/core/MeControllerTests.java
@@ -18,8 +18,8 @@ package it.infn.mw.iam.test.core;
 import static it.infn.mw.iam.test.scim.ScimUtils.SCIM_CLIENT_ID;
 import static it.infn.mw.iam.test.scim.ScimUtils.SCIM_READ_SCOPE;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
@@ -32,6 +32,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import it.infn.mw.iam.IamLoginService;
@@ -69,22 +70,43 @@ public class MeControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = TESTUSER_USERNAME, authorities = {})
+  @WithMockOAuthUser(user = TESTUSER_USERNAME, scopes = {})
   public void insufficientScopeUser() throws Exception {
 
     restUtils.getMe(FORBIDDEN);
   }
 
   @Test
-  @WithMockOAuthUser(user = NOT_FOUND_USERNAME, authorities = {"ROLE_USER"})
+  @WithMockUser(username = TESTUSER_USERNAME, roles = {})
+  public void insufficientAuthoritiesUser() throws Exception {
+
+    restUtils.getMe(FORBIDDEN);
+  }
+
+  @Test
+  @WithMockOAuthUser(user = NOT_FOUND_USERNAME, scopes = {SCIM_READ_SCOPE})
+  public void notFoundUserWithToken() throws Exception {
+
+    restUtils.getMe(NOT_FOUND);
+  }
+
+  @Test
+  @WithMockUser(username = NOT_FOUND_USERNAME, roles = {"USER"})
   public void notFoundUser() throws Exception {
 
     restUtils.getMe(NOT_FOUND);
   }
 
   @Test
-  @WithMockOAuthUser(user = TESTUSER_USERNAME, authorities = {"ROLE_USER"})
-  public void authenticatedUser() throws Exception {
+  @WithMockOAuthUser(user = TESTUSER_USERNAME, scopes = {SCIM_READ_SCOPE})
+  public void authenticatedUserWithToken() throws Exception {
+
+    assertThat(restUtils.getMe().getUserName(), equalTo(TESTUSER_USERNAME));
+  }
+
+  @Test
+  @WithMockUser(username = TESTUSER_USERNAME, roles = {"USER"})
+  public void authenticatedUserNoToken() throws Exception {
 
     assertThat(restUtils.getMe().getUserName(), equalTo(TESTUSER_USERNAME));
   }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/TokenEndpointClientAuthenticationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/TokenEndpointClientAuthenticationTests.java
@@ -15,8 +15,12 @@
  */
 package it.infn.mw.iam.test.oauth;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -30,7 +34,10 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import it.infn.mw.iam.IamLoginService;
+import it.infn.mw.iam.test.util.WithAnonymousUser;
 import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
 
 
@@ -42,9 +49,16 @@ public class TokenEndpointClientAuthenticationTests {
   private static final String TOKEN_ENDPOINT = "/token";
   private static final String GRANT_TYPE = "client_credentials";
   private static final String SCOPE = "read-tasks";
+  private static final String SCOPE_SUBSET = "openid";
+
+  private static final String TEST_USER_UUID = "80e5fb8d-b7c8-451a-89ba-346ae278a66f";
+  private static final String PRODUCTION_GROUP_UUID = "c617d586-54e6-411d-8e38-64967798fa8a";
 
   @Autowired
   private MockMvc mvc;
+
+  @Autowired
+  private ObjectMapper mapper;
 
   @Test
   public void testTokenEndpointFormClientAuthentication() throws Exception {
@@ -114,10 +128,151 @@ public class TokenEndpointClientAuthenticationTests {
       .andExpect(jsonPath("$.scope", equalTo(SCOPE)));
     // @formatter:on
   }
-  
+
   @Test
   public void testTokenEndpointOptionsMethodAllowed() throws Exception {
-    mvc.perform(options(TOKEN_ENDPOINT))
-      .andExpect(status().isOk());
+    mvc.perform(options(TOKEN_ENDPOINT)).andExpect(status().isOk());
+  }
+
+  @Test
+  @WithAnonymousUser
+  public void testInsufficientScopedClientCredentialTokenForbidsAccess() throws Exception {
+
+    String clientId = "scim-client-rw";
+    String clientSecret = "secret";
+
+    String response = mvc
+      .perform(post(TOKEN_ENDPOINT).with(httpBasic(clientId, clientSecret))
+        .param("grant_type", GRANT_TYPE)
+        .param("scope", SCOPE_SUBSET))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.scope", equalTo(SCOPE_SUBSET)))
+      .andExpect(jsonPath("$.scope", not(containsString("scim:read"))))
+      .andExpect(jsonPath("$.scope", not(containsString("scim:write"))))
+      .andReturn()
+      .getResponse()
+      .getContentAsString();
+
+    ObjectMapper mapper = new ObjectMapper();
+    String accessTokenNoSCIM = mapper.readTree(response).get("access_token").asText();
+
+    String scimAuthorizationHeader = String.format("Bearer %s", accessTokenNoSCIM);
+
+    mvc.perform(get("/scim/Users").header("Authorization", scimAuthorizationHeader))
+      .andExpect(status().isForbidden());
+
+    mvc
+      .perform(
+          get("/scim/Users/" + TEST_USER_UUID).header("Authorization", scimAuthorizationHeader))
+      .andExpect(status().isForbidden());
+
+    mvc
+      .perform(
+          delete("/scim/Users/" + TEST_USER_UUID).header("Authorization", scimAuthorizationHeader))
+      .andExpect(status().isForbidden());
+
+    mvc.perform(get("/scim/Groups").header("Authorization", scimAuthorizationHeader))
+      .andExpect(status().isForbidden());
+
+    mvc
+      .perform(get("/scim/Groups/" + PRODUCTION_GROUP_UUID).header("Authorization",
+          scimAuthorizationHeader))
+      .andExpect(status().isForbidden());
+
+    mvc
+      .perform(delete("/scim/Groups/" + PRODUCTION_GROUP_UUID).header("Authorization",
+          scimAuthorizationHeader))
+      .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithAnonymousUser
+  public void testSCIMScopedClientCredentialTokenAllowsAccess() throws Exception {
+
+    String clientId = "scim-client-rw";
+    String clientSecret = "secret";
+
+    String response = mvc
+      .perform(post(TOKEN_ENDPOINT).with(httpBasic(clientId, clientSecret))
+        .param("grant_type", GRANT_TYPE)
+        .param("scope", "scim:read scim:write"))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.scope", containsString("scim:read")))
+      .andExpect(jsonPath("$.scope", containsString("scim:write")))
+      .andReturn()
+      .getResponse()
+      .getContentAsString();
+
+    String accessTokenSCIM = mapper.readTree(response).get("access_token").asText();
+
+    String scimAuthorizationHeader = String.format("Bearer %s", accessTokenSCIM);
+
+    mvc.perform(get("/scim/Users").header("Authorization", scimAuthorizationHeader))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.startIndex", equalTo(1)))
+      .andExpect(jsonPath("$.Resources[1].userName", equalTo("test")));
+
+    mvc
+      .perform(
+          get("/scim/Users/" + TEST_USER_UUID).header("Authorization", scimAuthorizationHeader))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.userName", equalTo("test")));
+
+    mvc
+      .perform(
+          delete("/scim/Users/" + TEST_USER_UUID).header("Authorization", scimAuthorizationHeader))
+      .andExpect(status().isNoContent());
+
+    mvc.perform(get("/scim/Groups").header("Authorization", scimAuthorizationHeader))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.startIndex", equalTo(1)))
+      .andExpect(jsonPath("$.Resources[0].displayName", equalTo("Production")));
+
+    mvc
+      .perform(get("/scim/Groups/" + PRODUCTION_GROUP_UUID).header("Authorization",
+          scimAuthorizationHeader))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.displayName", equalTo("Production")));
+
+    mvc
+      .perform(delete("/scim/Groups/" + PRODUCTION_GROUP_UUID).header("Authorization",
+          scimAuthorizationHeader))
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.detail", equalTo("Group is not empty")));
+  }
+
+  @Test
+  @WithAnonymousUser
+  public void testAdminScopedClientCredentialTokenAllowsAccess() throws Exception {
+
+    String clientId = "admin-client-rw";
+    String clientSecret = "secret";
+
+    String response = mvc
+      .perform(post(TOKEN_ENDPOINT).with(httpBasic(clientId, clientSecret))
+        .param("grant_type", GRANT_TYPE)
+        .param("scope", "iam:admin.read iam:admin.write"))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.scope", containsString("iam:admin.read")))
+      .andExpect(jsonPath("$.scope", containsString("iam:admin.write")))
+      .andReturn()
+      .getResponse()
+      .getContentAsString();
+
+    String accessTokenAdmin = mapper.readTree(response).get("access_token").asText();
+
+    String adminAuthorizationHeader = String.format("Bearer %s", accessTokenAdmin);
+
+    mvc
+      .perform(
+          get("/iam/api/clients/" + clientId).header("Authorization", adminAuthorizationHeader))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.client_id", equalTo(clientId)));
+
+    mvc
+      .perform(
+          delete("/iam/api/clients/" + clientId).header("Authorization", adminAuthorizationHeader))
+      .andExpect(status().isNoContent());
+
   }
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/authzcode/AuthorizationCodeIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/authzcode/AuthorizationCodeIntegrationTests.java
@@ -359,7 +359,7 @@ public class AuthorizationCodeIntegrationTests {
       RestAssured.given()
           .header("Authorization", "Bearer " + refreshedToken)
       .when()
-          .get("/iam/account/me/authorities")
+          .get("/iam/me/authorities")
       .then()
           .statusCode(HttpStatus.FORBIDDEN.value());
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/devicecode/DeviceCodeTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/devicecode/DeviceCodeTests.java
@@ -22,10 +22,12 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertNotNull;
 import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -392,6 +394,9 @@ public class DeviceCodeTests extends EndpointsTestUtils implements DeviceCodeTes
       .andExpect(jsonPath("$.scope", containsString("openid")))
       .andExpect(jsonPath("$.scope", containsString("profile")))
       .andExpect(jsonPath("$.scope", containsString("offline_access")))
+      .andExpect(jsonPath("$.scope", not(containsString("email"))))
+      .andExpect(jsonPath("$.scope", not(containsString("phone"))))
+      .andExpect(jsonPath("$.scope", not(containsString("address"))))
       .andReturn()
       .getResponse()
       .getContentAsString();
@@ -722,5 +727,174 @@ public class DeviceCodeTests extends EndpointsTestUtils implements DeviceCodeTes
     // Check that the token can be used for userinfo
     mvc.perform(get(USERINFO_ENDPOINT).header("Authorization", authorizationHeader))
       .andExpect(status().isOk());
+  }
+
+  @Test
+  public void testRefreshedTokenAfterDeviceCodeApprovalFlowWorks() throws Exception {
+
+    final String SCIM_DEVICE_CLIENT_ID = "scim-client-rw";
+    final String SCIM_DEVICE_CLIENT_SECRET = "secret";
+
+    String response = mvc
+      .perform(post(DEVICE_CODE_ENDPOINT).contentType(APPLICATION_FORM_URLENCODED)
+        .with(httpBasic(SCIM_DEVICE_CLIENT_ID, SCIM_DEVICE_CLIENT_SECRET))
+        .param("client_id", SCIM_DEVICE_CLIENT_ID)
+        .param("scope", "openid profile offline_access scim:read scim:write"))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.user_code").isString())
+      .andExpect(jsonPath("$.device_code").isString())
+      .andExpect(jsonPath("$.verification_uri", equalTo(DEVICE_USER_URL)))
+      .andReturn()
+      .getResponse()
+      .getContentAsString();
+
+    JsonNode responseJson = mapper.readTree(response);
+
+    String userCode = responseJson.get("user_code").asText();
+    String deviceCode = responseJson.get("device_code").asText();
+
+    mvc
+      .perform(
+          post(TOKEN_ENDPOINT).with(httpBasic(SCIM_DEVICE_CLIENT_ID, SCIM_DEVICE_CLIENT_SECRET))
+            .param("grant_type", DEVICE_CODE_GRANT_TYPE)
+            .param("device_code", deviceCode))
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.error", equalTo("authorization_pending")))
+      .andExpect(jsonPath("$.error_description",
+          equalTo("Authorization pending for code: " + deviceCode)));
+
+    MockHttpSession session = (MockHttpSession) mvc.perform(get(DEVICE_USER_URL))
+      .andExpect(status().is3xxRedirection())
+      .andExpect(redirectedUrl("http://localhost:8080/login"))
+      .andReturn()
+      .getRequest()
+      .getSession();
+
+    session = (MockHttpSession) mvc.perform(get("http://localhost:8080/login").session(session))
+      .andExpect(status().isOk())
+      .andExpect(view().name("iam/login"))
+      .andReturn()
+      .getRequest()
+      .getSession();
+
+    session = (MockHttpSession) mvc
+      .perform(post(LOGIN_URL).param("username", TEST_USERNAME)
+        .param("password", TEST_PASSWORD)
+        .param("submit", "Login")
+        .session(session))
+      .andExpect(status().is3xxRedirection())
+      .andExpect(redirectedUrl(DEVICE_USER_URL))
+      .andReturn()
+      .getRequest()
+      .getSession();
+
+    session = (MockHttpSession) mvc.perform(get(DEVICE_USER_URL).session(session))
+      .andExpect(status().isOk())
+      .andExpect(view().name("requestUserCode"))
+      .andReturn()
+      .getRequest()
+      .getSession();
+
+    session = (MockHttpSession) mvc
+      .perform(post(DEVICE_USER_VERIFY_URL).param("user_code", userCode).session(session))
+      .andExpect(status().isOk())
+      .andExpect(view().name("approveDevice"))
+      .andReturn()
+      .getRequest()
+      .getSession();
+
+    session = (MockHttpSession) mvc
+      .perform(post(DEVICE_USER_APPROVE_URL).param("user_code", userCode)
+        .param("user_oauth_approval", "true")
+        .session(session))
+      .andExpect(status().isOk())
+      .andExpect(view().name("deviceApproved"))
+      .andReturn()
+      .getRequest()
+      .getSession();
+
+
+    String tokenResponse = mvc
+      .perform(
+          post(TOKEN_ENDPOINT).with(httpBasic(SCIM_DEVICE_CLIENT_ID, SCIM_DEVICE_CLIENT_SECRET))
+            .param("grant_type", DEVICE_CODE_GRANT_TYPE)
+            .param("device_code", deviceCode))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.access_token").exists())
+      .andExpect(jsonPath("$.refresh_token").exists())
+      .andExpect(jsonPath("$.id_token").exists())
+      .andExpect(jsonPath("$.scope").exists())
+      .andExpect(jsonPath("$.scope", containsString("openid")))
+      .andExpect(jsonPath("$.scope", containsString("profile")))
+      .andExpect(jsonPath("$.scope", containsString("offline_access")))
+      .andExpect(jsonPath("$.scope", containsString("scim:read")))
+      .andExpect(jsonPath("$.scope", containsString("scim:write")))
+      .andExpect(jsonPath("$.scope", not(containsString("email"))))
+      .andExpect(jsonPath("$.scope", not(containsString("phone"))))
+      .andExpect(jsonPath("$.scope", not(containsString("address"))))
+      .andReturn()
+      .getResponse()
+      .getContentAsString();
+
+    JsonNode tokenResponseJson = mapper.readTree(tokenResponse);
+
+    String accessToken = tokenResponseJson.get("access_token").asText();
+    String refreshToken = tokenResponseJson.get("refresh_token").asText();
+
+    String authorizationHeader = String.format("Bearer %s", accessToken);
+
+    // Check that the token can be used for userinfo and introspection
+    mvc.perform(get(USERINFO_ENDPOINT).header("Authorization", authorizationHeader))
+      .andExpect(status().isOk());
+
+    mvc
+      .perform(post(INTROSPECTION_ENDPOINT)
+        .with(httpBasic(SCIM_DEVICE_CLIENT_ID, SCIM_DEVICE_CLIENT_SECRET))
+        .param("token", accessToken))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.active", equalTo(true)));
+
+    String refreshTokenResponse = mvc
+      .perform(
+          post(TOKEN_ENDPOINT).with(httpBasic(SCIM_DEVICE_CLIENT_ID, SCIM_DEVICE_CLIENT_SECRET))
+            .param("grant_type", "refresh_token")
+            .param("refresh_token", refreshToken)
+            .param("scope", "openid"))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.access_token").exists())
+      .andExpect(jsonPath("$.id_token").exists())
+      .andExpect(jsonPath("$.scope").exists())
+      .andExpect(jsonPath("$.scope", containsString("openid")))
+      .andExpect(jsonPath("$.scope", not(containsString("scim:read"))))
+      .andExpect(jsonPath("$.scope", not(containsString("scim:write"))))
+      .andReturn()
+      .getResponse()
+      .getContentAsString();
+
+    String accessTokenNoSCIM = mapper.readTree(refreshTokenResponse).get("access_token").asText();
+
+    String scimAuthorizationHeader = String.format("Bearer %s", accessTokenNoSCIM);
+
+    mvc.perform(get("/scim/Users").header("Authorization", scimAuthorizationHeader))
+      .andExpect(status().isForbidden());
+    mvc.perform(get("/scim/Groups").header("Authorization", scimAuthorizationHeader))
+      .andExpect(status().isForbidden());
+    mvc
+      .perform(get("/scim/Users/80e5fb8d-b7c8-451a-89ba-346ae278a66f").header("Authorization",
+          scimAuthorizationHeader))
+      .andExpect(status().isForbidden());
+    mvc
+      .perform(get("/scim/Groups/c617d586-54e6-411d-8e38-649677980001").header("Authorization",
+          scimAuthorizationHeader))
+      .andExpect(status().isForbidden());
+    mvc
+      .perform(delete("/scim/Users/80e5fb8d-b7c8-451a-89ba-346ae278a66f").header("Authorization",
+          scimAuthorizationHeader))
+      .andExpect(status().isForbidden());
+    mvc
+      .perform(delete("/scim/Groups/c617d586-54e6-411d-8e38-649677980001").header("Authorization",
+          scimAuthorizationHeader))
+      .andExpect(status().isForbidden());
+
   }
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/me/ScimMeEndpointTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/me/ScimMeEndpointTests.java
@@ -26,6 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -42,7 +43,7 @@ public class ScimMeEndpointTests {
 
   @Autowired
   private MockOAuth2Filter mockOAuth2Filter;
-  
+
   @Autowired
   private MockMvc mvc;
 
@@ -55,11 +56,21 @@ public class ScimMeEndpointTests {
   public void teardown() {
     mockOAuth2Filter.cleanupSecurityContext();
   }
-  
+
   @Test
   @WithMockOAuthUser(clientId = "password-grant", user = "test", authorities = {"ROLE_USER"},
-      scopes = {"openid", "profile"})
-  public void meEndpointUserInfo() throws Exception {
+      scopes = {"openid", "profile", "scim:read"})
+  public void meEndpointUserInfoWithToken() throws Exception {
+    //@formatter:off
+    mvc.perform(get(ME_ENDPOINT)
+        .contentType(SCIM_CONTENT_TYPE))
+      .andExpect(status().isOk());
+    //@formatter:on
+  }
+
+  @Test
+  @WithMockUser(username = "test", roles = {"USER"})
+  public void meEndpointUserInfoNoToken() throws Exception {
     //@formatter:off
     mvc.perform(get(ME_ENDPOINT)
         .contentType(SCIM_CONTENT_TYPE))
@@ -76,6 +87,6 @@ public class ScimMeEndpointTests {
       .andExpect(jsonPath("$.status", equalTo("400")))
       .andExpect(jsonPath("$.detail", equalTo("No user linked to the current OAuth token")));
   }
-  
-  
+
+
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/me/patch/ScimMeEndpointPatchRemoveTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/me/patch/ScimMeEndpointPatchRemoveTests.java
@@ -28,6 +28,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import com.google.common.collect.Lists;
@@ -50,7 +51,6 @@ import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
 @SpringBootTest(
     classes = {IamLoginService.class, CoreControllerTestSupport.class, ScimRestUtilsMvc.class},
     webEnvironment = WebEnvironment.MOCK)
-@WithMockOAuthUser(user = "test_104", authorities = {"ROLE_USER"})
 public class ScimMeEndpointPatchRemoveTests {
 
   @Autowired
@@ -77,6 +77,8 @@ public class ScimMeEndpointPatchRemoveTests {
   }
 
   @Test
+  @WithMockOAuthUser(user = "test_104", authorities = {"ROLE_USER"},
+      scopes = {"scim:write", "scim:read"})
   public void testPatchRemovePicture() throws Exception {
 
     ScimPhoto currentPhoto = scimUtils.getMe().getPhotos().get(0);
@@ -89,6 +91,8 @@ public class ScimMeEndpointPatchRemoveTests {
   }
 
   @Test
+  @WithMockOAuthUser(user = "test_104", authorities = {"ROLE_USER"},
+      scopes = {"scim:write", "scim:read"})
   public void testPatchRemoveOidcId() throws Exception {
 
     ScimOidcId currentOidcId = scimUtils.getMe().getIndigoUser().getOidcIds().get(0);
@@ -101,7 +105,48 @@ public class ScimMeEndpointPatchRemoveTests {
   }
 
   @Test
+  @WithMockOAuthUser(user = "test_104", authorities = {"ROLE_USER"},
+      scopes = {"scim:write", "scim:read"})
   public void testPatchRemoveSamlId() throws Exception {
+
+    ScimSamlId currentSamlId = scimUtils.getMe().getIndigoUser().getSamlIds().get(0);
+
+    ScimUser updates = ScimUser.builder().addSamlId(currentSamlId).build();
+
+    scimUtils.patchMe(remove, updates);
+
+    assertThat(scimUtils.getMe().getIndigoUser().getSamlIds(), hasSize(equalTo(0)));
+  }
+
+  @Test
+  @WithMockUser(username = "test_104", roles = {"USER"})
+  public void testPatchRemovePictureNoToken() throws Exception {
+
+    ScimPhoto currentPhoto = scimUtils.getMe().getPhotos().get(0);
+
+    ScimUser updates = ScimUser.builder().addPhoto(currentPhoto).build();
+
+    scimUtils.patchMe(remove, updates);
+
+    assertThat(scimUtils.getMe().hasPhotos(), equalTo(false));
+  }
+
+  @Test
+  @WithMockUser(username = "test_104", roles = {"USER"})
+  public void testPatchRemoveOidcIdNoToken() throws Exception {
+
+    ScimOidcId currentOidcId = scimUtils.getMe().getIndigoUser().getOidcIds().get(0);
+
+    ScimUser updates = ScimUser.builder().addOidcId(currentOidcId).build();
+
+    scimUtils.patchMe(remove, updates);
+
+    assertThat(scimUtils.getMe().getIndigoUser().getOidcIds(), hasSize(equalTo(0)));
+  }
+
+  @Test
+  @WithMockUser(username = "test_104", roles = {"USER"})
+  public void testPatchRemoveSamlIdNoToken() throws Exception {
 
     ScimSamlId currentSamlId = scimUtils.getMe().getIndigoUser().getSamlIds().get(0);
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/service/client/ClientManagementServiceTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/service/client/ClientManagementServiceTests.java
@@ -101,10 +101,10 @@ public class ClientManagementServiceTests {
     
     ListResponseDTO<RegisteredClientDTO> clients = managementService.retrieveAllClients(pageable);
 
-    assertThat(clients.getTotalResults(), is(16L));
+    assertThat(clients.getTotalResults(), is(18L));
     assertThat(clients.getItemsPerPage(), is(10));
     assertThat(clients.getStartIndex(), is(1));
-    assertThat(clients.getResources().get(0).getClientId(), is("client"));
+    assertThat(clients.getResources().get(0).getClientId(), is("admin-client-ro"));
 
   }
 

--- a/iam-persistence/src/main/resources/db/migration/test/V100000___test_data.sql
+++ b/iam-persistence/src/main/resources/db/migration/test/V100000___test_data.sql
@@ -52,6 +52,8 @@ INSERT INTO client_scope (owner_id, scope) VALUES
   (1, 'read:/'),
   (1, 'write:/'),
   (1, 'attr'),
+  (1, 'scim:read'),
+  (1, 'scim:write'),
   (2, 'openid'),
   (2, 'profile'),
   (2, 'read-tasks'),

--- a/iam-persistence/src/main/resources/db/migration/test/V100000___test_data.sql
+++ b/iam-persistence/src/main/resources/db/migration/test/V100000___test_data.sql
@@ -157,6 +157,8 @@ INSERT INTO client_grant_type (owner_id, grant_type) VALUES
   (5, 'refresh_token'),
   (6, 'client_credentials'),
   (7, 'client_credentials'),
+  (7, 'refresh_token'),
+  (7, 'urn:ietf:params:oauth:grant-type:device_code'),
   (8, 'urn:ietf:params:oauth:grant-type:token-exchange'),
   (8, 'client_credentials'),
   (8, 'password'),

--- a/iam-persistence/src/main/resources/db/migration/test/V100000___test_data.sql
+++ b/iam-persistence/src/main/resources/db/migration/test/V100000___test_data.sql
@@ -54,6 +54,8 @@ INSERT INTO client_scope (owner_id, scope) VALUES
   (1, 'attr'),
   (1, 'scim:read'),
   (1, 'scim:write'),
+  (1, 'iam:admin.read'),
+  (1, 'iam:admin.write'),
   (2, 'openid'),
   (2, 'profile'),
   (2, 'read-tasks'),

--- a/iam-persistence/src/main/resources/db/migration/test/V100000___test_data.sql
+++ b/iam-persistence/src/main/resources/db/migration/test/V100000___test_data.sql
@@ -34,6 +34,12 @@ INSERT INTO client_details (id, client_id, client_secret, client_name, dynamical
   false, null, 3600, 600, true,'PRIVATE_KEY', false, 'RS256',
   '{"keys":[{"kty":"RSA","e":"AQAB","kid":"rsa1","n":"1y1CP181zqPNPlV1JDM7Xv0QnGswhSTHe8_XPZHxDTJkykpk_1BmgA3ovP62QRE2ORgsv5oSBI_Z_RaOc4Zx2FonjEJF2oBHtBjsAiF-pxGkM5ZPjFNgFTGp1yUUBjFDcEeIGCwPEyYSt93sQIP_0DRbViMUnpyn3xgM_a1dO5brEWR2n1Uqff1yA5NXfLS03qpl2dpH4HFY5-Zs4bvtJykpAOhoHuIQbz-hmxb9MZ3uTAwsx2HiyEJtz-suyTBHO3BM2o8UcCeyfa34ShPB8i86-sf78fOk2KeRIW1Bju3ANmdV3sxL0j29cesxKCZ06u2ZiGR3Srbft8EdLPzf-w"}]}');
 
+INSERT INTO client_details (id, client_id, client_secret, client_name, dynamically_registered,
+  refresh_token_validity_seconds, access_token_validity_seconds, id_token_validity_seconds, allow_introspection,
+  token_endpoint_auth_method, require_auth_time, created_at) VALUES
+(17, 'admin-client-ro', 'secret', 'Admin client (read-only)', false, null, 3600, 600, true, 'SECRET_POST',false, CURRENT_TIMESTAMP()),
+(18, 'admin-client-rw', 'secret', 'Admin client (read-write)', false, null, 3600, 600, true, 'SECRET_POST',false, CURRENT_TIMESTAMP());
+  
 INSERT INTO client_scope (owner_id, scope) VALUES
   (1, 'openid'),
   (1, 'profile'),
@@ -133,7 +139,10 @@ INSERT INTO client_scope (owner_id, scope) VALUES
   (14, 'profile'),
   (14, 'email'),
   (14, 'address'),
-  (14, 'phone');
+  (14, 'phone'),
+  (17, 'iam:admin.read'),
+  (18, 'iam:admin.read'),
+  (18, 'iam:admin.write');
   
   
 INSERT INTO client_redirect_uri (owner_id, redirect_uri) VALUES
@@ -175,7 +184,13 @@ INSERT INTO client_grant_type (owner_id, grant_type) VALUES
   (12, 'refresh_token'),
   (12, 'urn:ietf:params:oauth:grant-type:device_code'),
   (13, 'implicit'),
-  (14, 'urn:ietf:params:oauth:grant-type:device_code');
+  (14, 'urn:ietf:params:oauth:grant-type:device_code'),
+  (17, 'client_credentials'),
+  (17, 'urn:ietf:params:oauth:grant-type:device_code'),
+  (17, 'authorization_code'),
+  (18, 'client_credentials'),
+  (18, 'urn:ietf:params:oauth:grant-type:device_code'),
+  (18, 'authorization_code');
     
 INSERT INTO iam_user_info(ID,GIVENNAME,FAMILYNAME, EMAIL, EMAILVERIFIED, BIRTHDATE, GENDER) VALUES
   (2, 'Test', 'User', 'test@iam.test', true, '1950-01-01','M'),


### PR DESCRIPTION
Fixed pre-authorization annotations in order to avoid cases where it relies on already approved scopes instead of effective token's scopes.
Added more specific tests.