### PR TITLE
Fix tokens default validity in seconds

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/management/service/DefaultClientManagementService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/management/service/DefaultClientManagementService.java
@@ -29,7 +29,6 @@ import javax.validation.constraints.NotBlank;
 import org.mitre.oauth2.model.ClientDetailsEntity;
 import org.mitre.oauth2.model.OAuth2AccessTokenEntity;
 import org.mitre.openid.connect.service.OIDCTokenService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -71,8 +70,6 @@ public class DefaultClientManagementService implements ClientManagementService {
   private final IamTokenService tokenService;
   private final ApplicationEventPublisher eventPublisher;
 
-
-  @Autowired
   public DefaultClientManagementService(Clock clock, ClientService clientService,
       ClientConverter converter, ClientDefaultsService defaultsService, UserConverter userConverter,
       IamAccountRepository accountRepo, OIDCTokenService oidcTokenService,

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/ClientConverter.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/service/ClientConverter.java
@@ -26,7 +26,6 @@ import java.util.Set;
 import org.mitre.oauth2.model.ClientDetailsEntity;
 import org.mitre.oauth2.model.ClientDetailsEntity.AuthMethod;
 import org.mitre.oauth2.model.PKCEAlgorithm;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.google.common.base.Strings;
@@ -49,7 +48,6 @@ public class ClientConverter {
 
   private final ClientRegistrationProperties clientProperties;
 
-  @Autowired
   public ClientConverter(IamProperties properties, ClientRegistrationProperties clientProperties) {
     this.iamProperties = properties;
     clientRegistrationBaseUrl =
@@ -70,30 +68,32 @@ public class ClientConverter {
       throws ParseException {
     ClientDetailsEntity client = entityFromRegistrationRequest(dto);
 
-    if (dto.getAccessTokenValiditySeconds() != null) {
+    if (dto.getAccessTokenValiditySeconds() != null && dto.getAccessTokenValiditySeconds() > 0) {
       client.setAccessTokenValiditySeconds(dto.getAccessTokenValiditySeconds());
     } else {
       client.setAccessTokenValiditySeconds(
           clientProperties.getClientDefaults().getDefaultAccessTokenValiditySeconds());
     }
 
-    if (dto.getRefreshTokenValiditySeconds() != null) {
+    if (dto.getRefreshTokenValiditySeconds() != null && dto.getRefreshTokenValiditySeconds() > 0) {
       client.setRefreshTokenValiditySeconds(dto.getRefreshTokenValiditySeconds());
     } else {
       client.setRefreshTokenValiditySeconds(
           clientProperties.getClientDefaults().getDefaultRefreshTokenValiditySeconds());
     }
 
-    if (dto.getIdTokenValiditySeconds() != null) {
-      if (dto.getIdTokenValiditySeconds() <= 0) {
-        client.setIdTokenValiditySeconds(null);
-      } else {
-        client.setIdTokenValiditySeconds(dto.getIdTokenValiditySeconds());
-      }
+    if (dto.getIdTokenValiditySeconds() != null && dto.getIdTokenValiditySeconds() > 0) {
+      client.setIdTokenValiditySeconds(dto.getIdTokenValiditySeconds());
+    } else {
+      client.setIdTokenValiditySeconds(
+          clientProperties.getClientDefaults().getDefaultIdTokenValiditySeconds());
     }
 
     if (dto.getDeviceCodeValiditySeconds() != null && dto.getDeviceCodeValiditySeconds() > 0) {
       client.setDeviceCodeValiditySeconds(dto.getDeviceCodeValiditySeconds());
+    } else {
+      client.setDeviceCodeValiditySeconds(
+          clientProperties.getClientDefaults().getDefaultDeviceCodeValiditySeconds());
     }
 
     client.setAllowIntrospection(dto.isAllowIntrospection());

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/MitreServicesConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/MitreServicesConfig.java
@@ -26,10 +26,12 @@ import org.mitre.jwt.signer.service.impl.JWKSetCacheService;
 import org.mitre.jwt.signer.service.impl.SymmetricKeyJWTValidatorCacheService;
 import org.mitre.oauth2.service.ClientDetailsEntityService;
 import org.mitre.oauth2.service.DeviceCodeService;
+import org.mitre.oauth2.service.OAuth2TokenEntityService;
 import org.mitre.oauth2.service.SystemScopeService;
 import org.mitre.oauth2.service.impl.BlacklistAwareRedirectResolver;
 import org.mitre.oauth2.service.impl.DefaultDeviceCodeService;
 import org.mitre.oauth2.service.impl.DefaultOAuth2ClientDetailsEntityService;
+import org.mitre.oauth2.service.impl.DefaultOAuth2ProviderTokenService;
 import org.mitre.openid.connect.config.ConfigurationPropertiesBean;
 import org.mitre.openid.connect.config.UIConfiguration;
 import org.mitre.openid.connect.filter.AuthorizationRequestFilter;
@@ -176,6 +178,12 @@ public class MitreServicesConfig {
   @Qualifier("iamClientDetailsEntityService")
   ClientDetailsEntityService clientDetailsEntityService() {
     return new DefaultOAuth2ClientDetailsEntityService();
+  }
+
+  @Bean
+  OAuth2TokenEntityService tokenServices() {
+
+    return new DefaultOAuth2ProviderTokenService();
   }
 
   @Bean(name = "mitreUserInfoInterceptor")

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/MitreServicesConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/MitreServicesConfig.java
@@ -26,12 +26,10 @@ import org.mitre.jwt.signer.service.impl.JWKSetCacheService;
 import org.mitre.jwt.signer.service.impl.SymmetricKeyJWTValidatorCacheService;
 import org.mitre.oauth2.service.ClientDetailsEntityService;
 import org.mitre.oauth2.service.DeviceCodeService;
-import org.mitre.oauth2.service.OAuth2TokenEntityService;
 import org.mitre.oauth2.service.SystemScopeService;
 import org.mitre.oauth2.service.impl.BlacklistAwareRedirectResolver;
 import org.mitre.oauth2.service.impl.DefaultDeviceCodeService;
 import org.mitre.oauth2.service.impl.DefaultOAuth2ClientDetailsEntityService;
-import org.mitre.oauth2.service.impl.DefaultOAuth2ProviderTokenService;
 import org.mitre.openid.connect.config.ConfigurationPropertiesBean;
 import org.mitre.openid.connect.config.UIConfiguration;
 import org.mitre.openid.connect.filter.AuthorizationRequestFilter;
@@ -108,7 +106,7 @@ public class MitreServicesConfig {
   private String topbarTitle;
 
   @Bean
-  public ConfigurationPropertiesBean config(IamProperties properties) {
+  ConfigurationPropertiesBean config(IamProperties properties) {
 
     ConfigurationPropertiesBean config = new ConfigurationPropertiesBean();
 
@@ -137,7 +135,7 @@ public class MitreServicesConfig {
 
 
   @Bean
-  public UIConfiguration uiConfiguration() {
+  UIConfiguration uiConfiguration() {
 
     Set<String> jsFiles =
         Sets.newHashSet("resources/js/client.js", "resources/js/grant.js", "resources/js/scope.js",
@@ -180,27 +178,20 @@ public class MitreServicesConfig {
     return new DefaultOAuth2ClientDetailsEntityService();
   }
 
-  @Bean
-  OAuth2TokenEntityService tokenServices() {
-
-    return new DefaultOAuth2ProviderTokenService();
-  }
-
-
   @Bean(name = "mitreUserInfoInterceptor")
-  public IamUserInfoInterceptor userInfoInterceptor(UserInfoService service) {
+  IamUserInfoInterceptor userInfoInterceptor(UserInfoService service) {
 
     return new IamUserInfoInterceptor(service);
   }
 
   @Bean(name = "mitreServerConfigInterceptor")
-  public ServerConfigInterceptor serverConfigInterceptor() {
+  ServerConfigInterceptor serverConfigInterceptor() {
 
     return new ServerConfigInterceptor();
   }
 
   @Bean
-  public FilterRegistrationBean<AuthorizationRequestFilter> disabledMitreFilterRegistration(
+  FilterRegistrationBean<AuthorizationRequestFilter> disabledMitreFilterRegistration(
       AuthorizationRequestFilter f) {
 
     FilterRegistrationBean<AuthorizationRequestFilter> b =
@@ -210,25 +201,25 @@ public class MitreServicesConfig {
   }
 
   @Bean(name = "mitreAuthzRequestFilter")
-  public AuthorizationRequestFilter authorizationRequestFilter() {
+  AuthorizationRequestFilter authorizationRequestFilter() {
 
     return new AuthorizationRequestFilter();
   }
 
   @Bean
-  public AuthenticationTimeStamper timestamper() {
+  AuthenticationTimeStamper timestamper() {
 
     return new AuthenticationTimeStamper();
   }
 
   @Bean
-  public Http403ForbiddenEntryPoint http403ForbiddenEntryPoint() {
+  Http403ForbiddenEntryPoint http403ForbiddenEntryPoint() {
 
     return new Http403ForbiddenEntryPoint();
   }
 
   @Bean
-  public OAuth2AuthenticationEntryPoint oauth2AuthenticationEntryPoint() {
+  OAuth2AuthenticationEntryPoint oauth2AuthenticationEntryPoint() {
 
     OAuth2AuthenticationEntryPoint entryPoint = new OAuth2AuthenticationEntryPoint();
     entryPoint.setRealmName("openidconnect");
@@ -236,20 +227,20 @@ public class MitreServicesConfig {
   }
 
   @Bean
-  public TokenEnhancer defaultTokenEnhancer() {
+  TokenEnhancer defaultTokenEnhancer() {
 
     return new ConnectTokenEnhancer();
   }
 
   @Bean(name = "clientUserDetailsService")
-  public ClientUserDetailsService defaultClientUserDetailsService(
+  ClientUserDetailsService defaultClientUserDetailsService(
       ClientDetailsEntityService clientService) {
 
     return new IAMClientUserDetailsService(clientService);
   }
 
   @Bean
-  public DynamicClientValidationService clientValidationService(ScopeMatcherRegistry registry,
+  DynamicClientValidationService clientValidationService(ScopeMatcherRegistry registry,
       SystemScopeService scopeService, BlacklistedSiteService blacklistService,
       ConfigurationPropertiesBean config,
       @Qualifier("clientAssertionValidator") AssertionValidator validator,

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/IamTokenService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/IamTokenService.java
@@ -23,15 +23,16 @@ import org.mitre.oauth2.model.OAuth2RefreshTokenEntity;
 import org.mitre.oauth2.service.impl.DefaultOAuth2ProviderTokenService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
 import com.google.common.collect.Sets;
 
-import it.infn.mw.iam.config.client_registration.ClientRegistrationProperties;
 import it.infn.mw.iam.persistence.repository.IamOAuthAccessTokenRepository;
 import it.infn.mw.iam.persistence.repository.IamOAuthRefreshTokenRepository;
 
-@Service
+@Service("defaultOAuth2ProviderTokenService")
+@Primary
 public class IamTokenService extends DefaultOAuth2ProviderTokenService {
 
   public static final Logger LOG = LoggerFactory.getLogger(IamTokenService.class);
@@ -40,9 +41,8 @@ public class IamTokenService extends DefaultOAuth2ProviderTokenService {
   private final IamOAuthRefreshTokenRepository refreshTokenRepo;
 
   public IamTokenService(IamOAuthAccessTokenRepository atRepo,
-      IamOAuthRefreshTokenRepository rtRepo, ClientRegistrationProperties props) {
+      IamOAuthRefreshTokenRepository rtRepo) {
 
-    super(props.getClientDefaults().getDefaultAccessTokenValiditySeconds());
     this.accessTokenRepo = atRepo;
     this.refreshTokenRepo = rtRepo;
   }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/IamTokenService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/IamTokenService.java
@@ -23,17 +23,15 @@ import org.mitre.oauth2.model.OAuth2RefreshTokenEntity;
 import org.mitre.oauth2.service.impl.DefaultOAuth2ProviderTokenService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
 import com.google.common.collect.Sets;
 
+import it.infn.mw.iam.config.client_registration.ClientRegistrationProperties;
 import it.infn.mw.iam.persistence.repository.IamOAuthAccessTokenRepository;
 import it.infn.mw.iam.persistence.repository.IamOAuthRefreshTokenRepository;
 
-@Service("defaultOAuth2ProviderTokenService")
-@Primary
+@Service
 public class IamTokenService extends DefaultOAuth2ProviderTokenService {
 
   public static final Logger LOG = LoggerFactory.getLogger(IamTokenService.class);
@@ -41,11 +39,10 @@ public class IamTokenService extends DefaultOAuth2ProviderTokenService {
   private final IamOAuthAccessTokenRepository accessTokenRepo;
   private final IamOAuthRefreshTokenRepository refreshTokenRepo;
 
-
-  @Autowired
   public IamTokenService(IamOAuthAccessTokenRepository atRepo,
-      IamOAuthRefreshTokenRepository rtRepo) {
+      IamOAuthRefreshTokenRepository rtRepo, ClientRegistrationProperties props) {
 
+    super(props.getClientDefaults().getDefaultAccessTokenValiditySeconds());
     this.accessTokenRepo = atRepo;
     this.refreshTokenRepo = rtRepo;
   }

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/tokensettings/tokensettings.component.html
@@ -21,6 +21,10 @@
             <label for="at_timeout">Access token timeout (seconds)</label>
             <input id="at_timeout" class="form-control" type="text"
                 ng-model="$ctrl.client.access_token_validity_seconds">
+            <p class="help-block">
+                This will setup after how many seconds the access token
+                expires. Type 0 to leave the default lifetime ({{$ctrl.accessTokenValiditySeconds}} s).
+            </p>
         </div>
 
     </div>

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/client/ClientManagementAPIIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/client/ClientManagementAPIIntegrationTests.java
@@ -20,7 +20,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.Matchers.is;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -198,8 +198,8 @@ public class ClientManagementAPIIntegrationTests extends TestSupport {
       .getContentAsString();
 
     RegisteredClientDTO client = mapper.readValue(responseJson, RegisteredClientDTO.class);
-    assertTrue(client.getAccessTokenValiditySeconds().equals(3600));
-    assertTrue(client.getRefreshTokenValiditySeconds().equals(108000));
+    assertThat(client.getAccessTokenValiditySeconds(), is(3600));
+    assertThat(client.getRefreshTokenValiditySeconds(), is(108000));
 
     clientJson = ClientJsonStringBuilder.builder()
       .scopes("openid")
@@ -216,8 +216,8 @@ public class ClientManagementAPIIntegrationTests extends TestSupport {
       .getContentAsString();
 
     client = mapper.readValue(responseJson, RegisteredClientDTO.class);
-    assertTrue(client.getAccessTokenValiditySeconds().equals(0));
-    assertTrue(client.getRefreshTokenValiditySeconds().equals(0));
+    assertThat(client.getAccessTokenValiditySeconds(), is(3600));
+    assertThat(client.getRefreshTokenValiditySeconds(), is(108000));
 
     clientJson = ClientJsonStringBuilder.builder()
       .scopes("openid")
@@ -234,8 +234,8 @@ public class ClientManagementAPIIntegrationTests extends TestSupport {
       .getContentAsString();
 
     client = mapper.readValue(responseJson, RegisteredClientDTO.class);
-    assertTrue(client.getAccessTokenValiditySeconds().equals(10));
-    assertTrue(client.getRefreshTokenValiditySeconds().equals(10));
+    assertThat(client.getAccessTokenValiditySeconds(), is(10));
+    assertThat(client.getRefreshTokenValiditySeconds(), is(10));
 
   }
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/client/RegistrationAccessTokenTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/client/RegistrationAccessTokenTests.java
@@ -24,6 +24,8 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.not;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
+import java.text.ParseException;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,6 +33,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTParser;
 
 import io.restassured.RestAssured;
 import it.infn.mw.iam.api.client.management.service.ClientManagementService;
@@ -69,7 +74,7 @@ public class RegistrationAccessTokenTests extends TestSupport {
   }
 
   @Test
-  public void testRatWorkAsExpected() {
+  public void testRatWorkAsExpected() throws ParseException {
 
     String clientJson = ClientJsonStringBuilder.builder().scopes("openid").build();
     
@@ -87,6 +92,8 @@ public class RegistrationAccessTokenTests extends TestSupport {
     // @formatter:on
 
     assertThat(registerResponse.getRegistrationAccessToken(), notNullValue());
+    JWT jwt = JWTParser.parse(registerResponse.getRegistrationAccessToken());
+    assertThat(jwt.getJWTClaimsSet().getExpirationTime(), nullValue());
     assertThat(registerResponse.getScope(), not(empty()));
 
     RegisteredClientDTO getResponse =

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/mitre/ProtectedResourceIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/mitre/ProtectedResourceIntegrationTests.java
@@ -1,0 +1,183 @@
+package it.infn.mw.iam.test.api.mitre;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mitre.openid.connect.web.ProtectedResourceRegistrationEndpoint;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.nimbusds.jwt.JWTParser;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ValidatableResponse;
+import it.infn.mw.iam.api.client.management.service.ClientManagementService;
+import it.infn.mw.iam.api.common.client.RegisteredClientDTO;
+import it.infn.mw.iam.test.oauth.client_registration.ClientRegistrationTestSupport.ClientJsonStringBuilder;
+import it.infn.mw.iam.test.util.annotation.IamRandomPortIntegrationTest;
+
+@RunWith(SpringRunner.class)
+@IamRandomPortIntegrationTest
+public class ProtectedResourceIntegrationTests {
+
+  @Value("${local.server.port}")
+  private Integer iamPort;
+
+  @Autowired
+  private ClientManagementService managementService;
+
+  private ValidatableResponse doCreateProtectedResource(String clientJson) {
+
+    return RestAssured.given()
+      .port(iamPort)
+      .contentType(APPLICATION_JSON_VALUE)
+      .body(clientJson)
+      .log()
+      .all(true)
+      .when()
+      .post("/" + ProtectedResourceRegistrationEndpoint.URL)
+      .then()
+      .log()
+      .all(true);
+  }
+
+  private ValidatableResponse doGetProtectedResource(String clientId, String rat) {
+
+    return RestAssured.given()
+      .port(iamPort)
+      .accept(APPLICATION_JSON_VALUE)
+      .header("Authorization", "Bearer " + rat)
+      .log()
+      .all(true)
+      .when()
+      .get("/" + ProtectedResourceRegistrationEndpoint.URL + "/" + clientId)
+      .then()
+      .log()
+      .all(true);
+  }
+
+  private ValidatableResponse doUpdateProtectedResource(String clientId, String clientJson,
+      String rat) {
+
+    return RestAssured.given()
+      .port(iamPort)
+      .contentType(APPLICATION_JSON_VALUE)
+      .accept(APPLICATION_JSON_VALUE)
+      .header("Authorization", "Bearer " + rat)
+      .body(clientJson)
+      .log()
+      .all(true)
+      .when()
+      .put("/" + ProtectedResourceRegistrationEndpoint.URL + "/" + clientId)
+      .then()
+      .log()
+      .all(true);
+  }
+
+  private ValidatableResponse doDeleteProtectedResource(String clientId, String rat) {
+
+    return RestAssured.given()
+      .port(iamPort)
+      .accept(APPLICATION_JSON_VALUE)
+      .header("Authorization", "Bearer " + rat)
+      .log()
+      .all(true)
+      .when()
+      .delete("/" + ProtectedResourceRegistrationEndpoint.URL + "/" + clientId)
+      .then()
+      .log()
+      .all(true);
+  }
+
+  @Test
+  public void protectedResourceLifeCycle() throws Exception {
+
+    final String NAME = "protected-resource";
+    String clientJson = ClientJsonStringBuilder.builder().name(NAME).scopes("openid").build();
+
+    // create protected resource
+    RegisteredClientDTO testedResource =
+        doCreateProtectedResource(clientJson).statusCode(HttpStatus.CREATED.value())
+          .extract()
+          .as(RegisteredClientDTO.class);
+
+    // verify registration access token exists and expiration is null
+    assertNull(JWTParser.parse(testedResource.getRegistrationAccessToken())
+      .getJWTClaimsSet()
+      .getExpirationTime());
+
+    // retrieve protected resource directly from db
+    RegisteredClientDTO fromDb =
+        managementService.retrieveClientByClientId(testedResource.getClientId()).get();
+    assertEquals(testedResource.getClientId(), fromDb.getClientId());
+    assertTrue(fromDb.getGrantTypes().isEmpty());
+    assertTrue(fromDb.getResponseTypes().isEmpty());
+    assertTrue(fromDb.getRedirectUris().isEmpty());
+    assertEquals(NAME, fromDb.getClientName());
+    assertEquals(0, fromDb.getAccessTokenValiditySeconds());
+    assertEquals(0, fromDb.getIdTokenValiditySeconds());
+    assertEquals(0, fromDb.getRefreshTokenValiditySeconds());
+    assertTrue(fromDb.isDynamicallyRegistered());
+    assertTrue(fromDb.isAllowIntrospection());
+    assertFalse(fromDb.getScope().isEmpty());
+    assertEquals(1, fromDb.getScope().size());
+    assertTrue(fromDb.getScope().contains("openid"));
+
+
+    // retrieve protected resource from API
+    RegisteredClientDTO fromAPI = doGetProtectedResource(testedResource.getClientId(),
+        testedResource.getRegistrationAccessToken()).statusCode(HttpStatus.OK.value())
+          .extract()
+          .as(RegisteredClientDTO.class);
+
+    assertEquals(testedResource.getClientId(), fromAPI.getClientId());
+    assertEquals(NAME, fromAPI.getClientName());
+    assertNull(fromAPI.getGrantTypes());
+    assertNull(fromAPI.getResponseTypes());
+    assertNull(fromAPI.getRedirectUris());
+    assertNull(fromAPI.getAccessTokenValiditySeconds());
+    assertNull(fromAPI.getIdTokenValiditySeconds());
+    assertNull(fromAPI.getRefreshTokenValiditySeconds());
+    assertEquals(0, fromAPI.getClientSecretExpiresAt().toInstant().getEpochSecond());
+    assertFalse(fromAPI.getScope().isEmpty());
+    assertEquals(1, fromAPI.getScope().size());
+    assertTrue(fromAPI.getScope().contains("openid"));
+
+    // update protected resource from API
+    clientJson = ClientJsonStringBuilder.builder()
+      .clientId(testedResource.getClientId())
+      .name(NAME)
+      .scopes("openid email")
+      .build();
+    RegisteredClientDTO updated = doUpdateProtectedResource(testedResource.getClientId(),
+        clientJson, testedResource.getRegistrationAccessToken()).statusCode(HttpStatus.OK.value())
+          .extract()
+          .as(RegisteredClientDTO.class);
+
+    assertEquals(testedResource.getClientId(), updated.getClientId());
+    assertEquals(NAME, updated.getClientName());
+    assertNull(updated.getGrantTypes());
+    assertNull(updated.getResponseTypes());
+    assertNull(updated.getRedirectUris());
+    assertNull(updated.getAccessTokenValiditySeconds());
+    assertNull(updated.getIdTokenValiditySeconds());
+    assertNull(updated.getRefreshTokenValiditySeconds());
+    assertEquals(0, updated.getClientSecretExpiresAt().toInstant().getEpochSecond());
+    assertFalse(updated.getScope().isEmpty());
+    assertEquals(2, updated.getScope().size());
+    assertTrue(updated.getScope().contains("openid"));
+    assertTrue(updated.getScope().contains("email"));
+
+    doDeleteProtectedResource(testedResource.getClientId(),
+        testedResource.getRegistrationAccessToken()).statusCode(HttpStatus.NO_CONTENT.value());
+
+    assertTrue(managementService.retrieveClientByClientId(testedResource.getClientId()).isEmpty());
+  }
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/mitre/ProtectedResourceIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/mitre/ProtectedResourceIntegrationTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package it.infn.mw.iam.test.api.mitre;
 
 import static org.junit.Assert.assertNull;

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/proxy/ProxyServiceIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/proxy/ProxyServiceIntegrationTests.java
@@ -23,6 +23,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.sql.Date;
+import java.time.Duration;
+import java.time.Instant;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
@@ -31,7 +33,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -44,7 +45,6 @@ import it.infn.mw.iam.persistence.model.IamX509Certificate;
 import it.infn.mw.iam.persistence.model.IamX509ProxyCertificate;
 import it.infn.mw.iam.persistence.repository.IamAccountRepository;
 import it.infn.mw.iam.test.core.CoreControllerTestSupport;
-import it.infn.mw.iam.test.rcauth.RCAuthTestSupport;
 import it.infn.mw.iam.test.util.WithAnonymousUser;
 import it.infn.mw.iam.test.util.WithMockOAuthUser;
 import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
@@ -52,13 +52,8 @@ import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 
 @RunWith(SpringRunner.class)
 @IamMockMvcIntegrationTest
-@SpringBootTest(classes = {IamLoginService.class, RCAuthTestSupport.class,
-    CoreControllerTestSupport.class, ProxyCertificateClockConfig.class},
-    webEnvironment = WebEnvironment.MOCK)
-@TestPropertySource(properties = {"proxycert.enabled=true", "rcauth.enabled=true",
-    "rcauth.client-id=" + RCAuthTestSupport.CLIENT_ID,
-    "rcauth.client-secret=" + RCAuthTestSupport.CLIENT_SECRET,
-    "rcauth.issuer=" + RCAuthTestSupport.ISSUER})
+@SpringBootTest(classes = {IamLoginService.class, CoreControllerTestSupport.class})
+@TestPropertySource(properties = {"proxycert.enabled=true"})
 public class ProxyServiceIntegrationTests extends ProxyCertificateTestSupport {
 
   @Autowired
@@ -91,8 +86,11 @@ public class ProxyServiceIntegrationTests extends ProxyCertificateTestSupport {
     IamX509Certificate cert = testAccount.getX509Certificates().iterator().next();
     IamX509ProxyCertificate proxyCert = new IamX509ProxyCertificate();
 
-    proxyCert.setChain(generateTest0Proxy(NOW, ONE_YEAR_FROM_NOW));
-    proxyCert.setExpirationTime(Date.from(ONE_YEAR_FROM_NOW));
+    Instant current = Instant.now();
+    Instant plusOneYearDuration = current.plus(Duration.ofDays(365));
+
+    proxyCert.setChain(generateTest0Proxy(current, plusOneYearDuration));
+    proxyCert.setExpirationTime(Date.from(plusOneYearDuration));
     proxyCert.setCertificate(cert);
     cert.setProxy(proxyCert);
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/IdTokenEnhancerTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/IdTokenEnhancerTests.java
@@ -97,7 +97,7 @@ public class IdTokenEnhancerTests {
     assertThat(token.getJWTClaimsSet().getClaim("preferred_username"), is(notNullValue()));
     assertThat(token.getJWTClaimsSet().getClaim("organisation_name"), is(notNullValue()));
     assertThat(token.getJWTClaimsSet().getClaim("groups"), is(notNullValue()));
-    
+    assertThat(token.getJWTClaimsSet().getExpirationTime(), is(notNullValue()));
   }
 
   @Test

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/client_registration/ClientRegistrationTestSupport.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/client_registration/ClientRegistrationTestSupport.java
@@ -17,6 +17,7 @@ package it.infn.mw.iam.test.oauth.client_registration;
 
 import static com.google.common.collect.Sets.newHashSet;
 import static org.mitre.oauth2.model.RegisteredClientFields.CLAIMS_REDIRECT_URIS;
+import static org.mitre.oauth2.model.RegisteredClientFields.CLIENT_ID;
 import static org.mitre.oauth2.model.RegisteredClientFields.CLIENT_NAME;
 import static org.mitre.oauth2.model.RegisteredClientFields.CONTACTS;
 import static org.mitre.oauth2.model.RegisteredClientFields.GRANT_TYPES;
@@ -45,6 +46,7 @@ public class ClientRegistrationTestSupport {
 
     static final Joiner JOINER = Joiner.on(RegisteredClientFields.SCOPE_SEPARATOR);
 
+    String clientId = null;
     String name = "test_client";
     Set<String> redirectUris = Sets.newHashSet("http://localhost:9090");
     Set<String> grantTypes = Sets.newHashSet("client_credentials");
@@ -57,6 +59,11 @@ public class ClientRegistrationTestSupport {
 
     public static ClientJsonStringBuilder builder() {
       return new ClientJsonStringBuilder();
+    }
+
+    public ClientJsonStringBuilder clientId(String clientId) {
+      this.clientId = clientId;
+      return this;
     }
 
     public ClientJsonStringBuilder name(String name) {
@@ -97,6 +104,9 @@ public class ClientRegistrationTestSupport {
 
     public String build() {
       JsonObject json = new JsonObject();
+      if (clientId != null) {
+        json.addProperty(CLIENT_ID, clientId);
+      }
       json.addProperty(CLIENT_NAME, name);
       json.addProperty(SCOPE, JOINER.join(scopes));
       json.add(REDIRECT_URIS, getAsArray(redirectUris));

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 
     <testcontainers.version>1.16.2</testcontainers.version>
 
-    <mitreid.version>1.3.6.cnaf-20231113</mitreid.version>
+    <mitreid.version>1.3.6.cnaf-20231129</mitreid.version>
     <spring-security-oauth2.version>2.5.2.RELEASE</spring-security-oauth2.version>
 
     <voms.version>3.3.2</voms.version>


### PR DESCRIPTION
We were fixing an infinite AT settings with a expiration = now. We'd prefer to set the default validity in seconds set at configuration time.
We need to be sure not braking RAT logic or ID tokens.