### PR TITLE
Use correct email address for pwd reset

### DIFF
--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/password/user.password.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/password/user.password.component.js
@@ -50,7 +50,7 @@
         actionButtonText: 'Send password reset e-mail',
         headerText: 'Send password reset e-mail',
         bodyText:
-            `Are you sure you want to send the password reset e-mail to ${self.user.name.formatted} at ${self.userCtrl.user.emails[0].value}?`
+            `Are you sure you want to send the password reset e-mail to ${self.userCtrl.user.name.formatted} at ${self.userCtrl.user.emails[0].value}?`
       };
 
       ModalService.showModal({}, modalOptions)

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/password/user.password.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/password/user.password.component.js
@@ -30,7 +30,7 @@
 
     self.doPasswordReset = function() {
 
-      ResetPasswordService.forgotPassword(self.user.emails[0].value)
+      ResetPasswordService.forgotPassword(self.userCtrl.user.emails[0].value)
           .then(
               function(response) {
                 toaster.pop({
@@ -50,7 +50,7 @@
         actionButtonText: 'Send password reset e-mail',
         headerText: 'Send password reset e-mail',
         bodyText:
-            `Are you sure you want to send the password reset e-mail to ${self.user.name.formatted}?`
+            `Are you sure you want to send the password reset e-mail to ${self.user.name.formatted} at ${self.userCtrl.user.emails[0].value}?`
       };
 
       ModalService.showModal({}, modalOptions)


### PR DESCRIPTION
When an IAM Admin changes the email address of a user, then requests to change password without refreshing the web UI, the email is correctly sent to the new address.