### PR TITLE
Allow chinese characters in saved_user_auth_info db table

### DIFF
--- a/iam-persistence/src/main/resources/db/migration/h2/V100__alter_saved_user_auth_info_table.sql
+++ b/iam-persistence/src/main/resources/db/migration/h2/V100__alter_saved_user_auth_info_table.sql
@@ -1,0 +1,1 @@
+-- Nothing to do because H2 already supports Unicode

--- a/iam-persistence/src/main/resources/db/migration/mysql/V100__alter_saved_user_auth_info_table.sql
+++ b/iam-persistence/src/main/resources/db/migration/mysql/V100__alter_saved_user_auth_info_table.sql
@@ -1,1 +1,1 @@
-ALTER TABLE saved_user_auth_info MODIFY info_val varchar(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+ALTER TABLE saved_user_auth_info MODIFY info_val varchar(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/iam-persistence/src/main/resources/db/migration/mysql/V100__alter_saved_user_auth_info_table.sql
+++ b/iam-persistence/src/main/resources/db/migration/mysql/V100__alter_saved_user_auth_info_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE saved_user_auth_info MODIFY info_val varchar(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;


### PR DESCRIPTION
in particular, _character set_ of the `info_val` column has been changed from `latin1` to `utf8`.

This PR solves issue #700.

The error occurs when using MySQL 5.7 since:
* MySQL 5.7 has the default charset `latin1` and default collation `latin1_swedish_ci`
* MySQL 8.0 has the default charset `utf8mb4` and default collation `utf8mb4_0900_ai_ci` (which also accepts Chinese characters)

References:
* https://dev.mysql.com/doc/refman/5.7/en/charset.html
* https://dev.mysql.com/doc/refman/8.0/en/charset.html