### PR TITLE
Move cleanup tasks from MitreID into IAM codebase

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/IamConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/IamConfig.java
@@ -30,7 +30,6 @@ import org.h2.server.web.WebServlet;
 import org.mitre.oauth2.repository.SystemScopeRepository;
 import org.mitre.oauth2.service.IntrospectionResultAssembler;
 import org.mitre.oauth2.service.impl.DefaultIntrospectionResultAssembler;
-import org.mitre.oauth2.service.impl.DefaultOAuth2AuthorizationCodeService;
 import org.mitre.openid.connect.service.ScopeClaimTranslationService;
 import org.mitre.openid.connect.service.UserInfoService;
 import org.slf4j.Logger;
@@ -54,6 +53,7 @@ import com.google.common.collect.Maps;
 
 import it.infn.mw.iam.api.account.AccountUtils;
 import it.infn.mw.iam.authn.ExternalAuthenticationInfoProcessor;
+import it.infn.mw.iam.core.IamOAuth2AuthorizationCodeService;
 import it.infn.mw.iam.core.oauth.IamIntrospectionResultAssembler;
 import it.infn.mw.iam.core.oauth.attributes.AttributeMapHelper;
 import it.infn.mw.iam.core.oauth.profile.IamTokenEnhancer;
@@ -258,7 +258,7 @@ public class IamConfig {
 
   @Bean
   AuthorizationCodeServices authorizationCodeServices() {
-    return new DefaultOAuth2AuthorizationCodeService();
+    return new IamOAuth2AuthorizationCodeService();
   }
 
   @Bean

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/JpaConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/JpaConfig.java
@@ -101,14 +101,14 @@ public class JpaConfig extends JpaBaseConfiguration {
   }
 
   @Bean(name = {"defaultTransactionManager", "transactionManager"})
-  public PlatformTransactionManager defaultTransactionManager() {
+  PlatformTransactionManager defaultTransactionManager() {
 
     return new JpaTransactionManager();
   }
 
   @Bean
   @Profile("no-flyway")
-  public FlywayMigrationStrategy flywayMigrationStrategy() {
+  FlywayMigrationStrategy flywayMigrationStrategy() {
     return f -> {
       //  empty on purpose
     }; 
@@ -116,7 +116,7 @@ public class JpaConfig extends JpaBaseConfiguration {
 
   @Bean
   @Profile("flyway-repair")
-  public FlywayMigrationStrategy flywayRepairStrategy() {
+  FlywayMigrationStrategy flywayRepairStrategy() {
     return f -> {
       f.repair();
       f.migrate();

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/MitreServicesConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/MitreServicesConfig.java
@@ -108,7 +108,7 @@ public class MitreServicesConfig {
   private String topbarTitle;
 
   @Bean
-  public ConfigurationPropertiesBean config(IamProperties properties) {
+  ConfigurationPropertiesBean config(IamProperties properties) {
 
     ConfigurationPropertiesBean config = new ConfigurationPropertiesBean();
 
@@ -137,7 +137,7 @@ public class MitreServicesConfig {
 
 
   @Bean
-  public UIConfiguration uiConfiguration() {
+  UIConfiguration uiConfiguration() {
 
     Set<String> jsFiles =
         Sets.newHashSet("resources/js/client.js", "resources/js/grant.js", "resources/js/scope.js",
@@ -188,19 +188,19 @@ public class MitreServicesConfig {
 
 
   @Bean(name = "mitreUserInfoInterceptor")
-  public IamUserInfoInterceptor userInfoInterceptor(UserInfoService service) {
+  IamUserInfoInterceptor userInfoInterceptor(UserInfoService service) {
 
     return new IamUserInfoInterceptor(service);
   }
 
   @Bean(name = "mitreServerConfigInterceptor")
-  public ServerConfigInterceptor serverConfigInterceptor() {
+  ServerConfigInterceptor serverConfigInterceptor() {
 
     return new ServerConfigInterceptor();
   }
 
   @Bean
-  public FilterRegistrationBean<AuthorizationRequestFilter> disabledMitreFilterRegistration(
+  FilterRegistrationBean<AuthorizationRequestFilter> disabledMitreFilterRegistration(
       AuthorizationRequestFilter f) {
 
     FilterRegistrationBean<AuthorizationRequestFilter> b =
@@ -210,25 +210,25 @@ public class MitreServicesConfig {
   }
 
   @Bean(name = "mitreAuthzRequestFilter")
-  public AuthorizationRequestFilter authorizationRequestFilter() {
+  AuthorizationRequestFilter authorizationRequestFilter() {
 
     return new AuthorizationRequestFilter();
   }
 
   @Bean
-  public AuthenticationTimeStamper timestamper() {
+  AuthenticationTimeStamper timestamper() {
 
     return new AuthenticationTimeStamper();
   }
 
   @Bean
-  public Http403ForbiddenEntryPoint http403ForbiddenEntryPoint() {
+  Http403ForbiddenEntryPoint http403ForbiddenEntryPoint() {
 
     return new Http403ForbiddenEntryPoint();
   }
 
   @Bean
-  public OAuth2AuthenticationEntryPoint oauth2AuthenticationEntryPoint() {
+  OAuth2AuthenticationEntryPoint oauth2AuthenticationEntryPoint() {
 
     OAuth2AuthenticationEntryPoint entryPoint = new OAuth2AuthenticationEntryPoint();
     entryPoint.setRealmName("openidconnect");
@@ -236,20 +236,20 @@ public class MitreServicesConfig {
   }
 
   @Bean
-  public TokenEnhancer defaultTokenEnhancer() {
+  TokenEnhancer defaultTokenEnhancer() {
 
     return new ConnectTokenEnhancer();
   }
 
   @Bean(name = "clientUserDetailsService")
-  public ClientUserDetailsService defaultClientUserDetailsService(
+  ClientUserDetailsService defaultClientUserDetailsService(
       ClientDetailsEntityService clientService) {
 
     return new IAMClientUserDetailsService(clientService);
   }
 
   @Bean
-  public DynamicClientValidationService clientValidationService(ScopeMatcherRegistry registry,
+  DynamicClientValidationService clientValidationService(ScopeMatcherRegistry registry,
       SystemScopeService scopeService, BlacklistedSiteService blacklistService,
       ConfigurationPropertiesBean config,
       @Qualifier("clientAssertionValidator") AssertionValidator validator,

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/TaskConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/TaskConfig.java
@@ -15,7 +15,6 @@
  */
 package it.infn.mw.iam.config;
 
-import java.net.URISyntaxException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -127,7 +126,7 @@ public class TaskConfig implements SchedulingConfigurer {
   }
 
   @Scheduled(fixedDelayString = "${task.approvalCleanupPeriodMsec}", initialDelay = ONE_MINUTE_MSEC)
-  public void clearExpiredSites() throws URISyntaxException {
+  public void clearExpiredSites() {
 
     LOG.debug("Task clearExpiredSites starting ...");
     approvedSiteService.clearExpiredSites();

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/IamAuthenticationHolderEntityService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/IamAuthenticationHolderEntityService.java
@@ -15,14 +15,14 @@
  */
 package it.infn.mw.iam.core;
 
-import java.util.List;
 import java.util.Map;
 
-import org.mitre.data.PageCriteria;
+import org.mitre.data.DefaultPageCriteria;
 import org.mitre.oauth2.model.AuthenticationHolderEntity;
 import org.mitre.oauth2.repository.AuthenticationHolderRepository;
 import org.mitre.oauth2.service.AuthenticationHolderEntityService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Primary;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.stereotype.Service;
@@ -35,16 +35,14 @@ import it.infn.mw.iam.authn.ExternalAuthenticationInfoBuilder;
 @Primary
 public class IamAuthenticationHolderEntityService implements AuthenticationHolderEntityService {
 
-
-  final AuthenticationHolderRepository repo;
-  final ExternalAuthenticationInfoBuilder mapBuilder;
+  @Autowired
+  AuthenticationHolderRepository repo;
 
   @Autowired
-  public IamAuthenticationHolderEntityService(AuthenticationHolderRepository repo,
-      ExternalAuthenticationInfoBuilder mapBuilder) {
-    this.repo = repo;
-    this.mapBuilder = mapBuilder;
-  }
+  ExternalAuthenticationInfoBuilder mapBuilder;
+
+  @Value("${task.authenticationHolderCleanupCount}")
+  long cleanupCount;
 
   @Override
   public AuthenticationHolderEntity create(OAuth2Authentication authn) {
@@ -74,13 +72,8 @@ public class IamAuthenticationHolderEntityService implements AuthenticationHolde
   }
 
   @Override
-  public List<AuthenticationHolderEntity> getOrphanedAuthenticationHolders() {
+  public long clearOrphaned() {
 
-    return repo.getOrphanedAuthenticationHolders();
-  }
-
-  @Override
-  public List<AuthenticationHolderEntity> getOrphanedAuthenticationHolders(PageCriteria page) {
-    return repo.getOrphanedAuthenticationHolders(page);
+    return repo.clearOrphaned(new DefaultPageCriteria(0, Long.valueOf(cleanupCount).intValue()));
   }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/IamAuthenticationHolderEntityService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/IamAuthenticationHolderEntityService.java
@@ -74,6 +74,6 @@ public class IamAuthenticationHolderEntityService implements AuthenticationHolde
   @Override
   public long clearOrphaned() {
 
-    return repo.clearOrphaned(new DefaultPageCriteria(0, Long.valueOf(cleanupCount).intValue()));
+    return repo.clearOrphaned(new DefaultPageCriteria(0, (int) cleanupCount));
   }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/IamOAuth2AuthorizationCodeService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/IamOAuth2AuthorizationCodeService.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.core;
+
+import java.util.Calendar;
+
+import org.mitre.data.DefaultPageCriteria;
+import org.mitre.data.PageCriteria;
+import org.mitre.oauth2.repository.AuthorizationCodeRepository;
+import org.mitre.oauth2.service.impl.DefaultOAuth2AuthorizationCodeService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service("defaultOAuth2AuthorizationCodeService")
+@Primary
+public class IamOAuth2AuthorizationCodeService extends DefaultOAuth2AuthorizationCodeService {
+
+  public static final Logger LOG = LoggerFactory.getLogger(IamOAuth2AuthorizationCodeService.class);
+
+  @Autowired
+  private AuthorizationCodeRepository authorizationCodeRepository;
+
+  @Value("${task.authorizationCodeCleanupCount}")
+  long codeCleanupCount;
+  
+  
+  @Override
+  @Transactional(value="defaultTransactionManager")
+  public void clearExpiredAuthorizationCodes() {
+
+    LOG.debug("Cleaning expired authorization codes ...");
+    PageCriteria pageCriteria = new DefaultPageCriteria(0, Long.valueOf(codeCleanupCount).intValue());
+    long startedAt = Calendar.getInstance().getTimeInMillis();
+    long deleted = authorizationCodeRepository.deleteExpiredCodes(pageCriteria);
+    if (deleted > 0) {
+      LOG.info("Cleared {} expired authorization codes in {} secs", deleted, (Calendar.getInstance().getTimeInMillis() - startedAt) / 1000);
+    }
+  }
+  
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/IamOAuth2AuthorizationCodeService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/IamOAuth2AuthorizationCodeService.java
@@ -47,7 +47,7 @@ public class IamOAuth2AuthorizationCodeService extends DefaultOAuth2Authorizatio
   public void clearExpiredAuthorizationCodes() {
 
     LOG.debug("Cleaning expired authorization codes ...");
-    PageCriteria pageCriteria = new DefaultPageCriteria(0, Long.valueOf(codeCleanupCount).intValue());
+    PageCriteria pageCriteria = new DefaultPageCriteria(0, (int) codeCleanupCount);
     long startedAt = Calendar.getInstance().getTimeInMillis();
     long deleted = authorizationCodeRepository.deleteExpiredCodes(pageCriteria);
     if (deleted > 0) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/IamTokenService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/IamTokenService.java
@@ -142,13 +142,13 @@ public class IamTokenService extends DefaultOAuth2ProviderTokenService {
   @Override
   public void clearExpiredTokens() {
 
-    Pageable pageRequest = Pageable.ofSize(Long.valueOf(tokenCleanupCount).intValue());
+    Pageable pageRequest = Pageable.ofSize((int) tokenCleanupCount);
 
     LOG.debug("Cleaning expired access-tokens ...");
     Date startedAt = Calendar.getInstance().getTime();
     Page<Long> page = accessTokenRepo.findExpiredTokenIds(startedAt, pageRequest);
     LOG.debug("Found {} expired access-tokens", page.getSize());
-    if (page.getContent().size() > 0) {
+    if (!page.getContent().isEmpty()) {
       int deleted = accessTokenRepo.deleteTokensById(page.getContent());
       if (deleted > 0) {
         LOG.info("Removed {} expired access-tokens from database in {} millisecs", deleted,
@@ -160,7 +160,7 @@ public class IamTokenService extends DefaultOAuth2ProviderTokenService {
     startedAt = Calendar.getInstance().getTime();
     page = refreshTokenRepo.findExpiredTokenIds(startedAt, pageRequest);
     LOG.debug("Found {} expired access-tokens", page.getSize());
-    if (page.getContent().size() > 0) {
+    if (!page.getContent().isEmpty()) {
       int deleted = refreshTokenRepo.deleteTokensById(page.getContent());
       if (deleted > 0) {
         LOG.info("Removed {} expired refresh-tokens from database in {} millisecs", deleted,

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/IamTokenService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/IamTokenService.java
@@ -148,7 +148,7 @@ public class IamTokenService extends DefaultOAuth2ProviderTokenService {
     Date startedAt = Calendar.getInstance().getTime();
     Page<Long> page = accessTokenRepo.findExpiredTokenIds(startedAt, pageRequest);
     LOG.debug("Found {} expired access-tokens", page.getSize());
-    if (page.getSize() > 0) {
+    if (page.getContent().size() > 0) {
       int deleted = accessTokenRepo.deleteTokensById(page.getContent());
       if (deleted > 0) {
         LOG.info("Removed {} expired access-tokens from database in {} millisecs", deleted,
@@ -160,7 +160,7 @@ public class IamTokenService extends DefaultOAuth2ProviderTokenService {
     startedAt = Calendar.getInstance().getTime();
     page = refreshTokenRepo.findExpiredTokenIds(startedAt, pageRequest);
     LOG.debug("Found {} expired access-tokens", page.getSize());
-    if (page.getSize() > 0) {
+    if (page.getContent().size() > 0) {
       int deleted = refreshTokenRepo.deleteTokensById(page.getContent());
       if (deleted > 0) {
         LOG.info("Removed {} expired refresh-tokens from database in {} millisecs", deleted,

--- a/iam-login-service/src/main/java/it/infn/mw/iam/persistence/repository/IamOAuthAccessTokenRepository.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/persistence/repository/IamOAuthAccessTokenRepository.java
@@ -100,6 +100,6 @@ public interface IamOAuthAccessTokenRepository
   Page<Long> findExpiredTokenIds(@Param("timestamp") Date timestamp, Pageable pageable);
 
   @Modifying
-  @Query("delete from OAuth2AccessTokenEntity t where t.id in ?1")
-  int deleteTokensById(List<Long> ids);
+  @Query("delete from OAuth2AccessTokenEntity t where t.id in :idList")
+  int deleteTokensById(@Param("idList") List<Long> ids);
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/persistence/repository/IamOAuthAccessTokenRepository.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/persistence/repository/IamOAuthAccessTokenRepository.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import org.mitre.oauth2.model.OAuth2AccessTokenEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
@@ -94,4 +95,11 @@ public interface IamOAuthAccessTokenRepository
     + "select sua.id from SavedUserAuthentication sua where sua.name not in ("
     + "select a.username from IamAccount a))")
   List<OAuth2AccessTokenEntity> findOrphanedTokens();
+
+  @Query("select t.id from OAuth2AccessTokenEntity t where (t.expiration is not NULL and t.expiration < :timestamp)")
+  Page<Long> findExpiredTokenIds(@Param("timestamp") Date timestamp, Pageable pageable);
+
+  @Modifying
+  @Query("delete from OAuth2AccessTokenEntity t where t.id in :idList")
+  int deleteTokensById(@Param("idList") List<Long> idList);
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/persistence/repository/IamOAuthAccessTokenRepository.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/persistence/repository/IamOAuthAccessTokenRepository.java
@@ -100,6 +100,6 @@ public interface IamOAuthAccessTokenRepository
   Page<Long> findExpiredTokenIds(@Param("timestamp") Date timestamp, Pageable pageable);
 
   @Modifying
-  @Query("delete from OAuth2AccessTokenEntity t where t.id in :idList")
-  int deleteTokensById(@Param("idList") List<Long> idList);
+  @Query("delete from OAuth2AccessTokenEntity t where t.id in ?1")
+  int deleteTokensById(List<Long> ids);
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/persistence/repository/IamOAuthRefreshTokenRepository.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/persistence/repository/IamOAuthRefreshTokenRepository.java
@@ -91,6 +91,6 @@ public interface IamOAuthRefreshTokenRepository
   Page<Long> findExpiredTokenIds(@Param("timestamp") Date timestamp, Pageable pageable);
 
   @Modifying
-  @Query("delete from OAuth2RefreshTokenEntity t where t.id in :idList")
-  int deleteTokensById(@Param("idList") List<Long> idList);
+  @Query("delete from OAuth2RefreshTokenEntity t where t.id in ?1")
+  int deleteTokensById(List<Long> ids);
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/persistence/repository/IamOAuthRefreshTokenRepository.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/persistence/repository/IamOAuthRefreshTokenRepository.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.mitre.oauth2.model.OAuth2RefreshTokenEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
@@ -85,4 +86,11 @@ public interface IamOAuthRefreshTokenRepository
       + "select sua.id from SavedUserAuthentication sua where sua.name not in ("
       + "select a.username from IamAccount a))")
   List<OAuth2RefreshTokenEntity> findOrphanedTokens();
+
+  @Query("select t.id from OAuth2RefreshTokenEntity t where (t.expiration is not NULL and t.expiration < :timestamp)")
+  Page<Long> findExpiredTokenIds(@Param("timestamp") Date timestamp, Pageable pageable);
+
+  @Modifying
+  @Query("delete from OAuth2RefreshTokenEntity t where t.id in :idList")
+  int deleteTokensById(@Param("idList") List<Long> idList);
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/persistence/repository/IamOAuthRefreshTokenRepository.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/persistence/repository/IamOAuthRefreshTokenRepository.java
@@ -91,6 +91,6 @@ public interface IamOAuthRefreshTokenRepository
   Page<Long> findExpiredTokenIds(@Param("timestamp") Date timestamp, Pageable pageable);
 
   @Modifying
-  @Query("delete from OAuth2RefreshTokenEntity t where t.id in ?1")
-  int deleteTokensById(List<Long> ids);
+  @Query("delete from OAuth2RefreshTokenEntity t where t.id in :idList")
+  int deleteTokensById(@Param("idList") List<Long> ids);
 }

--- a/iam-login-service/src/main/resources/application.yml
+++ b/iam-login-service/src/main/resources/application.yml
@@ -117,7 +117,7 @@ iam:
   
   token:
     # This is the registration access token lifetime
-    lifetime: ${IAM_REGISTRATION_TOKEN_LIFETIME:-1}  
+    lifetime: ${IAM_REGISTRATION_TOKEN_LIFETIME:-1}
 
   organisation:
     name: ${IAM_ORGANISATION_NAME:indigo-dc}
@@ -212,9 +212,14 @@ notification:
 
 task:
   tokenCleanupPeriodMsec: ${IAM_TOKEN_CLEANUP_PERIOD_MSEC:300000}
+  tokenCleanupCount: ${IAM_TOKEN_CLEANUP_COUNT:100}
   approvalCleanupPeriodMsec: ${IAM_APPROVAL_CLEANUP_PERIOD_MSEC:300000}
   deviceCodeCleanupPeriodMsec: ${IAM_DEVICE_CODE_CLEANUP_PERIOD_MSEC:300000}
   wellKnownCacheCleanupPeriodSecs: ${IAM_WELL_KNOWN_CACHE_CLEANUP_PERIOD_SECS:300}
+  authorizationCodeCleanupPeriodMsec: ${IAM_AUTHORIZATION_CODE_CLEANUP_PERIOD_MSEC:300000}
+  authorizationCodeCleanupCount: ${IAM_AUTHORIZATION_CODE_CLEANUP_COUNT:100}
+  authenticationHolderCleanupPeriodMsec: ${IAM_AUTHENTICATION_HOLDER_CLEANUP_PERIOD_MSEC:300000}
+  authenticationHolderCleanupCount: ${IAM_AUTHENTICATION_HOLDER_CLEANUP_COUNT:100}
 
 client-registration:
   allow-for: ${IAM_CLIENT_REGISTRATION_ALLOW_FOR:ANYONE}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/CleanupServicesTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/CleanupServicesTests.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.oauth;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Calendar;
+import java.util.UUID;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mitre.oauth2.model.AuthorizationCodeEntity;
+import org.mitre.oauth2.model.ClientDetailsEntity;
+import org.mitre.oauth2.model.OAuth2AccessTokenEntity;
+import org.mitre.oauth2.model.OAuth2RefreshTokenEntity;
+import org.mitre.oauth2.repository.AuthorizationCodeRepository;
+import org.mitre.oauth2.service.OAuth2TokenEntityService;
+import org.mitre.oauth2.service.impl.DefaultOAuth2AuthorizationCodeService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.google.common.collect.Sets;
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.PlainJWT;
+
+import it.infn.mw.iam.IamLoginService;
+import it.infn.mw.iam.core.IamTokenService;
+import it.infn.mw.iam.persistence.repository.IamOAuthAccessTokenRepository;
+import it.infn.mw.iam.persistence.repository.IamOAuthRefreshTokenRepository;
+import it.infn.mw.iam.persistence.repository.client.IamClientRepository;
+import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
+
+
+@RunWith(SpringRunner.class)
+@IamMockMvcIntegrationTest
+@SpringBootTest(classes = {IamLoginService.class}, webEnvironment = WebEnvironment.MOCK)
+public class CleanupServicesTests extends EndpointsTestUtils {
+
+  private static final String PASSWORD_GRANT_CLIENT_ID = "password-grant";
+
+  @Autowired
+  private IamTokenService iamTokenService;
+
+  @Autowired
+  private DefaultOAuth2AuthorizationCodeService iamAuthorizationCodeService;
+
+  @Autowired
+  private IamOAuthAccessTokenRepository aTokenRepository;
+
+  @Autowired
+  private IamOAuthRefreshTokenRepository rTokenRepository;
+
+  @Autowired
+  private AuthorizationCodeRepository authzCodeRepository;
+
+  @Autowired
+  private IamClientRepository clientRepository;
+
+  @Autowired
+  private OAuth2TokenEntityService tokenEntityService;
+
+  private ClientDetailsEntity client;
+
+  @Before
+  public void clearAllAccessTokens() {
+
+    iamTokenService.clearExpiredTokens();
+    iamAuthorizationCodeService.clearExpiredAuthorizationCodes();
+    client = clientRepository.findByClientId(PASSWORD_GRANT_CLIENT_ID).get();
+  }
+
+  private void addExpiredAccessAndRefreshTokens(int count) {
+
+    Calendar cal = Calendar.getInstance();
+    cal.add(Calendar.DATE, -1);
+
+    for (int i=0; i<count; i++) {
+      OAuth2RefreshTokenEntity rTokenEntity = new OAuth2RefreshTokenEntity();
+      rTokenEntity.setExpiration(cal.getTime());
+      rTokenEntity.setClient(client);
+      JWTClaimsSet claims = new JWTClaimsSet.Builder().issuer("issuer")
+        .expirationTime(cal.getTime())
+        .subject(client.getClientId())
+        .jwtID(UUID.randomUUID().toString())
+        .build();
+      rTokenEntity.setJwt(new PlainJWT(claims));
+      rTokenRepository.save(rTokenEntity);
+      OAuth2AccessTokenEntity aTokenEntity = new OAuth2AccessTokenEntity();
+      aTokenEntity.setExpiration(cal.getTime());
+      aTokenEntity.setClient(client);
+      claims = new JWTClaimsSet.Builder().issuer("issuer")
+          .expirationTime(cal.getTime())
+          .subject(client.getClientId())
+          .jwtID(UUID.randomUUID().toString())
+          .build();
+      JWT at = new PlainJWT(claims);
+      aTokenEntity.setJwt(at);
+      aTokenEntity.setScope(Sets.newHashSet("openid", "profile"));
+      aTokenEntity.hashMe();
+      aTokenRepository.save(aTokenEntity);
+    }
+  }
+
+  private void addExpiredAuthorizationCode(int count) {
+
+    Calendar cal = Calendar.getInstance();
+    cal.add(Calendar.DATE, -1);
+
+    for (int i=0; i<count; i++) {
+      AuthorizationCodeEntity codeEntity = new AuthorizationCodeEntity();
+      codeEntity.setCode("code" + i);
+      codeEntity.setExpiration(cal.getTime());
+      authzCodeRepository.save(codeEntity);
+    }
+  }
+
+  @Test
+  public void clearExpiredTokensWorks() throws Exception {
+
+    long sizeAtBefore = aTokenRepository.count();
+    long sizeRtBefore = rTokenRepository.count();
+    addExpiredAccessAndRefreshTokens(10);
+    assertThat(aTokenRepository.count(), is(sizeAtBefore + 10L));
+    assertThat(rTokenRepository.count(), is(sizeRtBefore + 10L));
+    iamTokenService.clearExpiredTokens();
+    assertThat(aTokenRepository.count(), is(sizeAtBefore));
+    assertThat(rTokenRepository.count(), is(sizeRtBefore));
+
+  }
+
+  @Test
+  public void clearExpiredAuthorizationCodesWorks() {
+    
+    int sizeBefore = authzCodeRepository.getExpiredCodes().size();
+    addExpiredAuthorizationCode(5);
+    assertThat(authzCodeRepository.getExpiredCodes().size(), is(sizeBefore + 5));
+    iamAuthorizationCodeService.clearExpiredAuthorizationCodes();
+    assertThat(authzCodeRepository.getExpiredCodes().size(), is(0));
+  }
+
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/TokenServiceTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/TokenServiceTests.java
@@ -47,7 +47,7 @@ import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
 
 @RunWith(SpringRunner.class)
 @IamMockMvcIntegrationTest
-@SpringBootTest(properties = {"iam.showSql=true"}, classes = {IamLoginService.class}, webEnvironment = WebEnvironment.MOCK)
+@SpringBootTest(classes = {IamLoginService.class}, webEnvironment = WebEnvironment.MOCK)
 public class TokenServiceTests extends EndpointsTestUtils {
 
   private static final String PASSWORD_GRANT_CLIENT_ID = "password-grant";
@@ -100,6 +100,7 @@ public class TokenServiceTests extends EndpointsTestUtils {
       JWT at = new PlainJWT(claims);
       aTokenEntity.setJwt(at);
       aTokenEntity.setScope(Sets.newHashSet("openid", "profile"));
+      aTokenEntity.hashMe();
       aTokenRepository.save(aTokenEntity);
     }
   }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/TokenServiceTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/TokenServiceTests.java
@@ -47,7 +47,7 @@ import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
 
 @RunWith(SpringRunner.class)
 @IamMockMvcIntegrationTest
-@SpringBootTest(classes = {IamLoginService.class}, webEnvironment = WebEnvironment.MOCK)
+@SpringBootTest(properties = {"iam.showSql=true"}, classes = {IamLoginService.class}, webEnvironment = WebEnvironment.MOCK)
 public class TokenServiceTests extends EndpointsTestUtils {
 
   private static final String PASSWORD_GRANT_CLIENT_ID = "password-grant";

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/TokenServiceTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/TokenServiceTests.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.oauth;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Calendar;
+import java.util.UUID;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mitre.oauth2.model.ClientDetailsEntity;
+import org.mitre.oauth2.model.OAuth2AccessTokenEntity;
+import org.mitre.oauth2.model.OAuth2RefreshTokenEntity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.google.common.collect.Sets;
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.PlainJWT;
+
+import it.infn.mw.iam.IamLoginService;
+import it.infn.mw.iam.core.IamTokenService;
+import it.infn.mw.iam.persistence.repository.IamOAuthAccessTokenRepository;
+import it.infn.mw.iam.persistence.repository.IamOAuthRefreshTokenRepository;
+import it.infn.mw.iam.persistence.repository.client.IamClientRepository;
+import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
+
+
+@RunWith(SpringRunner.class)
+@IamMockMvcIntegrationTest
+@SpringBootTest(classes = {IamLoginService.class}, webEnvironment = WebEnvironment.MOCK)
+public class TokenServiceTests extends EndpointsTestUtils {
+
+  private static final String PASSWORD_GRANT_CLIENT_ID = "password-grant";
+
+  @Autowired
+  private IamTokenService iamTokenService;
+
+  @Autowired
+  private IamOAuthAccessTokenRepository aTokenRepository;
+
+  @Autowired
+  private IamOAuthRefreshTokenRepository rTokenRepository;
+
+  @Autowired
+  private IamClientRepository clientRepository;
+
+  private ClientDetailsEntity client;
+
+  @Before
+  public void clearAllAccessTokens() {
+
+    iamTokenService.clearExpiredTokens();
+    client = clientRepository.findByClientId(PASSWORD_GRANT_CLIENT_ID).get();
+  }
+
+  private void addExpiredAccessAndRefreshTokens(int count) {
+
+    Calendar cal = Calendar.getInstance();
+    cal.add(Calendar.DATE, -1);
+
+    for (int i=0; i<count; i++) {
+      OAuth2RefreshTokenEntity rTokenEntity = new OAuth2RefreshTokenEntity();
+      rTokenEntity.setExpiration(cal.getTime());
+      rTokenEntity.setClient(client);
+      JWTClaimsSet claims = new JWTClaimsSet.Builder().issuer("issuer")
+        .expirationTime(cal.getTime())
+        .subject(client.getClientId())
+        .jwtID(UUID.randomUUID().toString())
+        .build();
+      rTokenEntity.setJwt(new PlainJWT(claims));
+      rTokenRepository.save(rTokenEntity);
+      OAuth2AccessTokenEntity aTokenEntity = new OAuth2AccessTokenEntity();
+      aTokenEntity.setExpiration(cal.getTime());
+      aTokenEntity.setClient(client);
+      claims = new JWTClaimsSet.Builder().issuer("issuer")
+          .expirationTime(cal.getTime())
+          .subject(client.getClientId())
+          .jwtID(UUID.randomUUID().toString())
+          .build();
+      JWT at = new PlainJWT(claims);
+      aTokenEntity.setJwt(at);
+      aTokenEntity.setScope(Sets.newHashSet("openid", "profile"));
+      aTokenRepository.save(aTokenEntity);
+    }
+  }
+
+  @Test
+  public void clearExpiredTokensWorks() throws Exception {
+
+    long sizeAtBefore = aTokenRepository.count();
+    long sizeRtBefore = rTokenRepository.count();
+    addExpiredAccessAndRefreshTokens(10);
+    assertThat(aTokenRepository.count(), is(sizeAtBefore + 10L));
+    assertThat(rTokenRepository.count(), is(sizeRtBefore + 10L));
+    iamTokenService.clearExpiredTokens();
+    assertThat(aTokenRepository.count(), is(sizeAtBefore));
+    assertThat(rTokenRepository.count(), is(sizeRtBefore));
+
+  }
+
+}

--- a/iam-persistence/src/main/java/it/infn/mw/iam/persistence/migrations/RemoveOrphanTokens.java
+++ b/iam-persistence/src/main/java/it/infn/mw/iam/persistence/migrations/RemoveOrphanTokens.java
@@ -43,16 +43,16 @@ public class RemoveOrphanTokens implements SpringJdbcFlywayMigration {
   public void migrate(JdbcTemplate jdbcTemplate) throws DataAccessException {
 
     int updateResult = jdbcTemplate.update(DELETE_ACCESS_TOKENS_OF_DELETED_USERS);
-    LOG.info("Removed {} access tokens owned by deleted users", updateResult);
+    LOG.debug("Removed {} access tokens owned by deleted users", updateResult);
 
     updateResult = jdbcTemplate.update(DELETE_REFRESH_TOKENS_OF_DELETED_USERS);
-    LOG.info("Removed {} refresh tokens owned by deleted users", updateResult);
+    LOG.debug("Removed {} refresh tokens owned by deleted users", updateResult);
 
     updateResult = jdbcTemplate.update(DELETE_ACCESS_TOKENS_WITH_INVALID_AUTH_HOLDER);
-    LOG.info("Removed {} access tokens with invalid authentication holder", updateResult);
+    LOG.debug("Removed {} access tokens with invalid authentication holder", updateResult);
 
     updateResult = jdbcTemplate.update(DELETE_REFRESH_TOKENS_WITH_INVALID_AUTH_HOLDER);
-    LOG.info("Removed {} refresh tokens with invalid authentication holder", updateResult);
+    LOG.debug("Removed {} refresh tokens with invalid authentication holder", updateResult);
   }
 
 }

--- a/iam-persistence/src/main/resources/db/migration/h2/V103__add_more_foreign_keys.sql
+++ b/iam-persistence/src/main/resources/db/migration/h2/V103__add_more_foreign_keys.sql
@@ -1,0 +1,30 @@
+DELETE FROM device_code_request_parameter WHERE owner_id NOT IN (SELECT id FROM device_code);
+ALTER TABLE device_code_request_parameter ALTER COLUMN owner_id SET NOT NULL;
+ALTER TABLE device_code_request_parameter ADD CONSTRAINT FK_device_code_request_parameter_owner_id FOREIGN KEY (owner_id) REFERENCES device_code (id) ON DELETE CASCADE;
+
+DELETE FROM device_code_scope WHERE owner_id NOT IN (SELECT id FROM device_code);
+ALTER TABLE device_code_scope ALTER COLUMN owner_id SET NOT NULL;
+ALTER TABLE device_code_scope ALTER COLUMN scope SET NOT NULL;
+ALTER TABLE device_code_scope ADD CONSTRAINT FK_device_code_scope_owner_id FOREIGN KEY (owner_id) REFERENCES device_code (id) ON DELETE CASCADE;
+
+DELETE FROM device_code WHERE client_id NOT IN (SELECT id FROM client_details);
+ALTER TABLE device_code ALTER COLUMN client_id SET NOT NULL;
+ALTER TABLE device_code ADD CONSTRAINT FK_device_code_client_id FOREIGN KEY (client_id) REFERENCES client_details (client_id) ON DELETE CASCADE;
+
+DELETE FROM client_response_type WHERE owner_id NOT IN (SELECT id FROM client_details);
+ALTER TABLE client_response_type ALTER COLUMN owner_id SET NOT NULL;
+ALTER TABLE client_response_type ALTER COLUMN response_type SET NOT NULL;
+ALTER TABLE client_response_type ADD PRIMARY KEY (owner_id, response_type);
+ALTER TABLE client_response_type ADD CONSTRAINT FK_client_response_type_owner_id FOREIGN KEY (owner_id) REFERENCES client_details (id) ON DELETE CASCADE;
+
+DELETE FROM client_grant_type WHERE owner_id NOT IN (SELECT id FROM client_details);
+ALTER TABLE client_grant_type ALTER COLUMN owner_id SET NOT NULL;
+ALTER TABLE client_grant_type ALTER COLUMN grant_type SET NOT NULL;
+ALTER TABLE client_grant_type ADD PRIMARY KEY (owner_id, grant_type);
+ALTER TABLE client_grant_type ADD CONSTRAINT FK_client_grant_type_owner_id FOREIGN KEY (owner_id) REFERENCES client_details (id) ON DELETE CASCADE;
+
+DELETE FROM client_resource WHERE owner_id NOT IN (SELECT id FROM client_details);
+ALTER TABLE client_resource ALTER COLUMN owner_id SET NOT NULL;
+ALTER TABLE client_resource ALTER COLUMN resource_id SET NOT NULL;
+ALTER TABLE client_resource ADD PRIMARY KEY (owner_id, resource_id);
+ALTER TABLE client_resource ADD CONSTRAINT FK_client_resource_owner_id FOREIGN KEY (owner_id) REFERENCES client_details (id) ON DELETE CASCADE;

--- a/iam-persistence/src/main/resources/db/migration/mysql/V103__add_more_foreign_keys.sql
+++ b/iam-persistence/src/main/resources/db/migration/mysql/V103__add_more_foreign_keys.sql
@@ -1,0 +1,30 @@
+DELETE FROM device_code_request_parameter WHERE owner_id NOT IN (SELECT id FROM device_code);
+ALTER TABLE device_code_request_parameter MODIFY COLUMN owner_id BIGINT(20) NOT NULL;
+ALTER TABLE device_code_request_parameter ADD CONSTRAINT FK_device_code_request_parameter_owner_id FOREIGN KEY (owner_id) REFERENCES device_code (id) ON DELETE CASCADE;
+
+DELETE FROM device_code_scope WHERE owner_id NOT IN (SELECT id FROM device_code);
+ALTER TABLE device_code_scope MODIFY COLUMN owner_id BIGINT(20) NOT NULL;
+ALTER TABLE device_code_scope MODIFY COLUMN scope VARCHAR(256) NOT NULL;
+ALTER TABLE device_code_scope ADD CONSTRAINT FK_device_code_scope_owner_id FOREIGN KEY (owner_id) REFERENCES device_code (id) ON DELETE CASCADE;
+
+DELETE FROM device_code WHERE client_id NOT IN (SELECT id FROM client_details);
+ALTER TABLE device_code MODIFY COLUMN client_id VARCHAR(256) NOT NULL;
+ALTER TABLE device_code ADD CONSTRAINT FK_device_code_client_id FOREIGN KEY (client_id) REFERENCES client_details (client_id) ON DELETE CASCADE;
+
+DELETE FROM client_response_type WHERE owner_id NOT IN (SELECT id FROM client_details);
+ALTER TABLE client_response_type MODIFY COLUMN owner_id BIGINT(20) NOT NULL;
+ALTER TABLE client_response_type MODIFY COLUMN response_type VARCHAR(2000) NOT NULL;
+ALTER TABLE client_response_type ADD PRIMARY KEY (owner_id, response_type);
+ALTER TABLE client_response_type ADD CONSTRAINT FK_client_response_type_owner_id FOREIGN KEY (owner_id) REFERENCES client_details (id) ON DELETE CASCADE;
+
+DELETE FROM client_grant_type WHERE owner_id NOT IN (SELECT id FROM client_details);
+ALTER TABLE client_grant_type MODIFY COLUMN owner_id BIGINT(20) NOT NULL;
+ALTER TABLE client_grant_type MODIFY COLUMN grant_type VARCHAR(2000) NOT NULL;
+ALTER TABLE client_grant_type ADD PRIMARY KEY (owner_id, grant_type);
+ALTER TABLE client_grant_type ADD CONSTRAINT FK_client_grant_type_owner_id FOREIGN KEY (owner_id) REFERENCES client_details (id) ON DELETE CASCADE;
+
+DELETE FROM client_resource WHERE owner_id NOT IN (SELECT id FROM client_details);
+ALTER TABLE client_resource MODIFY COLUMN owner_id BIGINT(20) NOT NULL;
+ALTER TABLE client_resource MODIFY COLUMN resource_id VARCHAR(256) NOT NULL;
+ALTER TABLE client_resource ADD PRIMARY KEY (owner_id, resource_id);
+ALTER TABLE client_resource ADD CONSTRAINT FK_client_resource_owner_id FOREIGN KEY (owner_id) REFERENCES client_details (id) ON DELETE CASCADE;

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 
     <testcontainers.version>1.16.2</testcontainers.version>
 
-    <mitreid.version>1.3.6.cnaf-20240410</mitreid.version>
+    <mitreid.version>1.3.6.cnaf-20240417</mitreid.version>
     <spring-security-oauth2.version>2.5.2.RELEASE</spring-security-oauth2.version>
 
     <voms.version>3.3.2</voms.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 
     <testcontainers.version>1.16.2</testcontainers.version>
 
-    <mitreid.version>1.3.6.cnaf-20240207</mitreid.version>
+    <mitreid.version>1.3.6.cnaf-20240410</mitreid.version>
     <spring-security-oauth2.version>2.5.2.RELEASE</spring-security-oauth2.version>
 
     <voms.version>3.3.2</voms.version>


### PR DESCRIPTION
Cleanup tasks were defined and a bit hardcoded into MitreID codebase.
Those tasks can now be configured and are contained into IAM codebase.

| Property name (Environment variable name) | Property description | Property default value |
|----|----|----|
| `task.tokenCleanupPeriodMsec` `IAM_TOKEN_CLEANUP_PERIOD_MSEC` | Interval between 2 executions of token removal task | 300000 (ms) |
| `task.tokenCleanupCount` `IAM_TOKEN_CLEANUP_COUNT` | (**New**) Amount of access and refresh expired tokens to be deleted each time the task runs | 100 |
| `task.approvalCleanupPeriodMsec` `IAM_APPROVAL_CLEANUP_PERIOD_MSEC` | Interval between 2 executions of expired sites removal task. | 300000 (ms) |
| `task.deviceCodeCleanupPeriodMsec` `IAM_DEVICE_CODE_CLEANUP_PERIOD_MSEC` | Interval between 2 executions of expired codes for device code removal task. | 300000 (ms) |
| `task.authorizationCodeCleanupPeriodMsec` `IAM_AUTHORIZATION_CODE_CLEANUP_PERIOD_MSEC` | (**New**) Interval between 2 executions of expired authorization codes removal task. | 300000 (ms) |
| `task.authorizationCodeCleanupCount` `IAM_AUTHORIZATION_CODE_CLEANUP_COUNT` | (**New**) Amount of expired authorization codes to be deleted each time the task runs| 100 |
| `task.authenticationHolderCleanupPeriodMsec` `IAM_AUTHENTICATION_HOLDER_CLEANUP_PERIOD_MSEC` | (**New**) Interval between 2 executions of the task dedicated to remove the unused AuthenticationHolder entries. | 300000 (ms) |
| `task.authenticationHolderCleanupCount` `IAM_AUTHENTICATION_HOLDER_CLEANUP_COUNT` | (**New**) Amount of AuthenticationHolder entries to be deleted each time the task runs | 100 |

This PR also adds more missing foreign keys.