### PR TITLE
Enable CORS also on well-known endpoint

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/security/CorsConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/security/CorsConfig.java
@@ -15,32 +15,46 @@
  */
 package it.infn.mw.iam.config.security;
 
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 
+@ConfigurationProperties("cors")
 @Configuration
 public class CorsConfig {
 
   private static final String[] CORS_ENDPOINT_MATCHERS =
   // @formatter:off
     {
-        "/api/**", 
-        "/resource/**", 
+        "/api/**",
+        "/resource/**",
         "/register/**",
-        "/iam/**", 
-        "/scim/**", 
-        "/token", 
-        "/introspect", 
-        "/userinfo", 
-        "/revoke/**", 
+        "/iam/**",
+        "/scim/**",
+        "/token",
+        "/introspect",
+        "/userinfo",
+        "/revoke/**",
         "/jwk",
         "/devicecode",
-        "/.well-known/**"
+        "/.well-known/openid-configuration"
     };
     //@formatter:on
+
+  private List<String> allowedOrigins;
+
+  public List<String> getAllowedOrigins() {
+    return allowedOrigins;
+  }
+
+  public void setAllowedOrigins(List<String> allowedOrigins) {
+    this.allowedOrigins = allowedOrigins;
+  }
 
   @Bean
   CorsFilter corsFilter() {
@@ -49,6 +63,7 @@ public class CorsConfig {
     corsConfig.setAllowedMethods(
         java.util.List.of("HEAD", "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
     corsConfig.applyPermitDefaultValues();
+    corsConfig.setAllowedOriginPatterns(allowedOrigins);
 
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     for (String m : CORS_ENDPOINT_MATCHERS) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/security/CorsConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/security/CorsConfig.java
@@ -15,16 +15,12 @@
  */
 package it.infn.mw.iam.config.security;
 
-import java.util.List;
-
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 
-@ConfigurationProperties("cors")
 @Configuration
 public class CorsConfig {
 
@@ -46,16 +42,6 @@ public class CorsConfig {
     };
     //@formatter:on
 
-  private List<String> allowedOrigins;
-
-  public List<String> getAllowedOrigins() {
-    return allowedOrigins;
-  }
-
-  public void setAllowedOrigins(List<String> allowedOrigins) {
-    this.allowedOrigins = allowedOrigins;
-  }
-
   @Bean
   CorsFilter corsFilter() {
 
@@ -63,7 +49,6 @@ public class CorsConfig {
     corsConfig.setAllowedMethods(
         java.util.List.of("HEAD", "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
     corsConfig.applyPermitDefaultValues();
-    corsConfig.setAllowedOriginPatterns(allowedOrigins);
 
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     for (String m : CORS_ENDPOINT_MATCHERS) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/security/CorsConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/security/CorsConfig.java
@@ -37,7 +37,8 @@ public class CorsConfig {
         "/userinfo", 
         "/revoke/**", 
         "/jwk",
-        "/devicecode"
+        "/devicecode",
+        "/.well-known/**"
     };
     //@formatter:on
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/security/MitreSecurityConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/security/MitreSecurityConfig.java
@@ -306,5 +306,25 @@ public class MitreSecurityConfig {
       // @formatter:on
     }
   }
+  
+  @Configuration
+  @Order(28)
+  public static class WellKnownEndpointConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(final HttpSecurity http) throws Exception {
+
+      // @formatter:off
+      http.antMatcher("/.well-known**")
+          .cors()
+        .and()
+          .sessionManagement()
+          .sessionCreationPolicy(STATELESS)
+        .and()
+          .authorizeRequests()
+            .antMatchers("/**").permitAll();
+      // @formatter:on
+    }
+  }
 
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/security/MitreSecurityConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/security/MitreSecurityConfig.java
@@ -315,7 +315,7 @@ public class MitreSecurityConfig {
     protected void configure(final HttpSecurity http) throws Exception {
 
       // @formatter:off
-      http.antMatcher("/.well-known**")
+      http.antMatcher("/.well-known/openid-configuration")
           .cors()
         .and()
           .sessionManagement()

--- a/iam-login-service/src/main/resources/application.yml
+++ b/iam-login-service/src/main/resources/application.yml
@@ -90,13 +90,17 @@ spring:
   mvc:
     pathmatch:
       matching-strategy: "ant-path-matcher"
+
+cors:
+  allowed-origins: ${ALLOWED_ORIGINS:**}
+
 iam:
   host: ${IAM_HOST:localhost}
   baseUrl: ${IAM_BASE_URL:http://${iam.host}:8080}
   issuer: ${IAM_ISSUER:http://${iam.host}:8080}
   topbarTitle: ${IAM_TOPBAR_TITLE:INDIGO IAM for ${iam.organisation.name}}
   showSql: ${IAM_DATABASE_SHOW_SQL:false}
-  
+
   jwk:
     keystore-location: ${IAM_KEY_STORE_LOCATION:classpath:keystore.jwks}
     default-key-id: ${IAM_JWK_DEFAULT_KEY_ID:rsa1}
@@ -104,7 +108,7 @@ iam:
     default-jwe-encrypt-key-id: ${IAM_JWK_DEFAULT_JWE_ENCRYPT_KEY_ID:${iam.jwk.default-key-id}}
     default-jws-algorithm: ${IAM_JWK_DEFAULT_JWS_ALGORITHM:RS256}
     default-jwe-algorithm: ${IAM_JWT_DEFAULT_JWE_ALGORITHM:RSA_OAEP_256} 
-    
+
   jwt-profile:
     default-profile: ${IAM_JWT_DEFAULT_PROFILE:iam}
   

--- a/iam-login-service/src/main/resources/application.yml
+++ b/iam-login-service/src/main/resources/application.yml
@@ -91,9 +91,6 @@ spring:
     pathmatch:
       matching-strategy: "ant-path-matcher"
 
-cors:
-  allowed-origins: ${ALLOWED_ORIGINS:**}
-
 iam:
   host: ${IAM_HOST:localhost}
   baseUrl: ${IAM_BASE_URL:http://${iam.host}:8080}


### PR DESCRIPTION
When a GET request to the well-known endpoint which contains some Origin in the header is performed, IAM replies with `Access-Control-Allow-Origin: *` in the response header.

E.g. request without origin in the request header
```
$ curl -k http://localhost:8080/.well-known/openid-configuration -I 
HTTP/1.1 200 
Vary: Origin
Vary: Access-Control-Request-Method
Vary: Access-Control-Request-Headers
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
Content-Type: application/json;charset=UTF-8
Content-Language: en-US
Content-Length: 3113
Date: Mon, 11 Mar 2024 16:02:10 GMT
```
request with origin:
```
$ curl -k http://localhost:8080/.well-known/openid-configuration -I -H "Origin: https://test.example"
HTTP/1.1 200 
Vary: Origin
Vary: Access-Control-Request-Method
Vary: Access-Control-Request-Headers
Access-Control-Allow-Origin: *
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
Content-Type: application/json;charset=UTF-8
Content-Language: en-US
Content-Length: 3113
Date: Mon, 11 Mar 2024 16:02:22 GMT
```