### PR TITLE
Change VOMS warning message when requesting a too long proxy

### DIFF
--- a/iam-voms-aa/src/main/java/it/infn/mw/voms/aa/VOMSWarning.java
+++ b/iam-voms-aa/src/main/java/it/infn/mw/voms/aa/VOMSWarning.java
@@ -19,27 +19,27 @@ import static java.lang.String.format;
 
 public class VOMSWarning {
 
-  public static final String OrderNotSatisfiedMessage =
+  public static final String ORDER_NOT_SATISFIED_MESSAGE =
       "The requested order could not be satisfied.";
-  public static final String ShortenedAttributeValidityMessage =
+  public static final String SHORTENED_ATTRIBUTE_VALIDITY_MESSAGE =
       "The validity of this VOMS AC in your proxy is shortened to %d seconds, "
           + "which is the maximum allowed by this VOMS server configuration.";
-  public static final String AttributeSubsetMessage =
+  public static final String ATTRIBUTE_SUBSET_MESSAGE =
       "Only a subset of the requested attributes has been returned.";
 
   private int code;
   private String message;
 
   public static VOMSWarning orderNotSatisfied() {
-    return new VOMSWarning(1, OrderNotSatisfiedMessage);
+    return new VOMSWarning(1, ORDER_NOT_SATISFIED_MESSAGE);
   }
 
   public static VOMSWarning shortenedAttributeValidity(long maxAcValidityInSeconds) {
-    return new VOMSWarning(2, format(ShortenedAttributeValidityMessage, maxAcValidityInSeconds));
+    return new VOMSWarning(2, format(SHORTENED_ATTRIBUTE_VALIDITY_MESSAGE, maxAcValidityInSeconds));
   }
 
   public static VOMSWarning attributeSubset() {
-    return new VOMSWarning(3, AttributeSubsetMessage);
+    return new VOMSWarning(3, ATTRIBUTE_SUBSET_MESSAGE);
   }
 
   private VOMSWarning(int legacyCode, String message) {

--- a/iam-voms-aa/src/main/java/it/infn/mw/voms/aa/VOMSWarning.java
+++ b/iam-voms-aa/src/main/java/it/infn/mw/voms/aa/VOMSWarning.java
@@ -53,9 +53,9 @@ public class VOMSWarning {
     return code;
   }
 
-  public String getDefaultMessage() {
+  public String getMessage() {
 
-    return ORDER_NOT_SATISFIED_MESSAGE;
+    return message;
   }
 
 }

--- a/iam-voms-aa/src/main/java/it/infn/mw/voms/aa/VOMSWarning.java
+++ b/iam-voms-aa/src/main/java/it/infn/mw/voms/aa/VOMSWarning.java
@@ -55,7 +55,7 @@ public class VOMSWarning {
 
   public String getDefaultMessage() {
 
-    return message;
+    return ORDER_NOT_SATISFIED_MESSAGE;
   }
 
 }

--- a/iam-voms-aa/src/main/java/it/infn/mw/voms/aa/VOMSWarning.java
+++ b/iam-voms-aa/src/main/java/it/infn/mw/voms/aa/VOMSWarning.java
@@ -15,17 +15,32 @@
  */
 package it.infn.mw.voms.aa;
 
-public enum VOMSWarning {
+import static java.lang.String.format;
 
-  OrderNotSatisfied(1, "The requested order could not be satisfied."),
-  ShortenedAttributeValidity(
-      2,
-      "The validity period of the issued attributes has been shortened to the maximum allowed by "
-      + "this VOMS server configuration."),
-  AttributeSubset(3, "Only a subset of the requested attributes has been returned.");
+public class VOMSWarning {
+
+  public static final String OrderNotSatisfiedMessage =
+      "The requested order could not be satisfied.";
+  public static final String ShortenedAttributeValidityMessage =
+      "The validity of this VOMS AC in your proxy is shortened to %l seconds, "
+          + "which is the maximum allowed by this VOMS server configuration.";
+  public static final String AttributeSubsetMessage =
+      "Only a subset of the requested attributes has been returned.";
 
   private int code;
   private String message;
+
+  public static VOMSWarning orderNotSatisfied() {
+    return new VOMSWarning(1, OrderNotSatisfiedMessage);
+  }
+
+  public static VOMSWarning shortenedAttributeValidity(long maxAcValidityInSeconds) {
+    return new VOMSWarning(2, format(ShortenedAttributeValidityMessage, maxAcValidityInSeconds));
+  }
+
+  public static VOMSWarning attributeSubset() {
+    return new VOMSWarning(3, AttributeSubsetMessage);
+  }
 
   private VOMSWarning(int legacyCode, String message) {
 

--- a/iam-voms-aa/src/main/java/it/infn/mw/voms/aa/VOMSWarning.java
+++ b/iam-voms-aa/src/main/java/it/infn/mw/voms/aa/VOMSWarning.java
@@ -22,7 +22,7 @@ public class VOMSWarning {
   public static final String OrderNotSatisfiedMessage =
       "The requested order could not be satisfied.";
   public static final String ShortenedAttributeValidityMessage =
-      "The validity of this VOMS AC in your proxy is shortened to %l seconds, "
+      "The validity of this VOMS AC in your proxy is shortened to %d seconds, "
           + "which is the maximum allowed by this VOMS server configuration.";
   public static final String AttributeSubsetMessage =
       "Only a subset of the requested attributes has been returned.";

--- a/iam-voms-aa/src/main/java/it/infn/mw/voms/aa/VOMSWarning.java
+++ b/iam-voms-aa/src/main/java/it/infn/mw/voms/aa/VOMSWarning.java
@@ -19,27 +19,15 @@ import static java.lang.String.format;
 
 public class VOMSWarning {
 
-  public static final String ORDER_NOT_SATISFIED_MESSAGE =
-      "The requested order could not be satisfied.";
   public static final String SHORTENED_ATTRIBUTE_VALIDITY_MESSAGE =
       "The validity of this VOMS AC in your proxy is shortened to %d seconds, "
           + "which is the maximum allowed by this VOMS server configuration.";
-  public static final String ATTRIBUTE_SUBSET_MESSAGE =
-      "Only a subset of the requested attributes has been returned.";
 
   private int code;
   private String message;
 
-  public static VOMSWarning orderNotSatisfied() {
-    return new VOMSWarning(1, ORDER_NOT_SATISFIED_MESSAGE);
-  }
-
   public static VOMSWarning shortenedAttributeValidity(long maxAcValidityInSeconds) {
-    return new VOMSWarning(2, format(SHORTENED_ATTRIBUTE_VALIDITY_MESSAGE, maxAcValidityInSeconds));
-  }
-
-  public static VOMSWarning attributeSubset() {
-    return new VOMSWarning(3, ATTRIBUTE_SUBSET_MESSAGE);
+    return new VOMSWarning(1, format(SHORTENED_ATTRIBUTE_VALIDITY_MESSAGE, maxAcValidityInSeconds));
   }
 
   private VOMSWarning(int legacyCode, String message) {
@@ -53,7 +41,7 @@ public class VOMSWarning {
     return code;
   }
 
-  public String getMessage() {
+  public String getDefaultMessage() {
 
     return message;
   }

--- a/iam-voms-aa/src/main/java/it/infn/mw/voms/aa/VOMSWarningMessage.java
+++ b/iam-voms-aa/src/main/java/it/infn/mw/voms/aa/VOMSWarningMessage.java
@@ -56,17 +56,19 @@ public class VOMSWarningMessage {
 
   public static VOMSWarningMessage orderingNotSatisfied(String vo) {
 
-    return new VOMSWarningMessage(VOMSWarning.OrderNotSatisfied, vo);
+    return new VOMSWarningMessage(VOMSWarning.orderNotSatisfied(), vo);
   }
 
-  public static VOMSWarningMessage shortenedAttributeValidity(String vo) {
+  public static VOMSWarningMessage shortenedAttributeValidity(String vo,
+      long maxAcValidityInSeconds) {
 
-    return new VOMSWarningMessage(VOMSWarning.ShortenedAttributeValidity, vo);
+    return new VOMSWarningMessage(VOMSWarning.shortenedAttributeValidity(maxAcValidityInSeconds),
+        vo);
   }
 
   public static VOMSWarningMessage attributeSubset(String vo) {
 
-    return new VOMSWarningMessage(VOMSWarning.AttributeSubset, vo);
+    return new VOMSWarningMessage(VOMSWarning.attributeSubset(), vo);
   }
 
 }

--- a/iam-voms-aa/src/main/java/it/infn/mw/voms/aa/VOMSWarningMessage.java
+++ b/iam-voms-aa/src/main/java/it/infn/mw/voms/aa/VOMSWarningMessage.java
@@ -19,11 +19,13 @@ public class VOMSWarningMessage {
 
   private final VOMSWarning warning;
   private final String vo;
+  private final String message;
 
   private VOMSWarningMessage(VOMSWarning warning, String vo) {
 
     this.warning = warning;
     this.vo = vo;
+    this.message = warning.getMessage();
   }
 
   /**
@@ -32,6 +34,14 @@ public class VOMSWarningMessage {
   public String getVo() {
 
     return vo;
+  }
+
+  /**
+   * @return the message
+   */
+  public String getMessage() {
+
+    return message;
   }
 
   /**

--- a/iam-voms-aa/src/main/java/it/infn/mw/voms/aa/VOMSWarningMessage.java
+++ b/iam-voms-aa/src/main/java/it/infn/mw/voms/aa/VOMSWarningMessage.java
@@ -25,7 +25,7 @@ public class VOMSWarningMessage {
 
     this.warning = warning;
     this.vo = vo;
-    this.message = warning.getMessage();
+    this.message = warning.getDefaultMessage();
   }
 
   /**
@@ -52,21 +52,11 @@ public class VOMSWarningMessage {
     return warning;
   }
 
-  public static VOMSWarningMessage orderingNotSatisfied(String vo) {
-
-    return new VOMSWarningMessage(VOMSWarning.orderNotSatisfied(), vo);
-  }
-
   public static VOMSWarningMessage shortenedAttributeValidity(String vo,
       long maxAcValidityInSeconds) {
 
     return new VOMSWarningMessage(VOMSWarning.shortenedAttributeValidity(maxAcValidityInSeconds),
         vo);
-  }
-
-  public static VOMSWarningMessage attributeSubset(String vo) {
-
-    return new VOMSWarningMessage(VOMSWarning.attributeSubset(), vo);
   }
 
 }

--- a/iam-voms-aa/src/main/java/it/infn/mw/voms/aa/VOMSWarningMessage.java
+++ b/iam-voms-aa/src/main/java/it/infn/mw/voms/aa/VOMSWarningMessage.java
@@ -19,13 +19,11 @@ public class VOMSWarningMessage {
 
   private final VOMSWarning warning;
   private final String vo;
-  private final String message;
 
   private VOMSWarningMessage(VOMSWarning warning, String vo) {
 
     this.warning = warning;
     this.vo = vo;
-    this.message = null;
   }
 
   /**
@@ -34,16 +32,6 @@ public class VOMSWarningMessage {
   public String getVo() {
 
     return vo;
-  }
-
-  /**
-   * @return the message
-   */
-  public String getMessage() {
-
-    if (message == null)
-      return warning.getDefaultMessage();
-    return message;
   }
 
   /**

--- a/iam-voms-aa/src/main/java/it/infn/mw/voms/aa/impl/VOMSAAImpl.java
+++ b/iam-voms-aa/src/main/java/it/infn/mw/voms/aa/impl/VOMSAAImpl.java
@@ -71,7 +71,9 @@ public class VOMSAAImpl implements AttributeAuthority {
     }
 
     if (requestedValidity > MAX_VALIDITY) {
-      context.getResponse().getWarnings().add(shortenedAttributeValidity(context.getVOName()));
+      context.getResponse()
+        .getWarnings()
+        .add(shortenedAttributeValidity(context.getVOName(), MAX_VALIDITY));
     }
 
     Instant now = clock.instant();


### PR DESCRIPTION
When the requested lifetime for a proxy is longer than the maximum allowed by the server, voms-aa responds with

```
The validity of this VOMS AC in your proxy is shortened to <seconds> seconds, which is the maximum allowed by this VOMS server configuration.
```

(instead of previous message, which was _The validity period of the issued attributes has been shortened to the maximum allowed by this VOMS server configuration_).