### PR TITLE
Multiplatform docker

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -83,7 +83,7 @@ jobs:
           type=ref,event=tag
 
     - name: Build & push iam-login-service docker image
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v5
       with:
         tags: ${{ steps.ls-meta.outputs.tags }}
         labels: ${{ steps.ls-meta.outputs.labels }}
@@ -93,7 +93,7 @@ jobs:
         push: ${{ startsWith(github.ref, 'refs/tags/') }}
 
     - name: Build & push iam-test-client docker image
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v5
       with:
         tags: ${{ steps.tc-meta.outputs.tags }}
         labels: ${{ steps.tc-meta.outputs.labels }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,7 +35,7 @@ jobs:
         mysql -uroot -proot -e "CREATE DATABASE iam CHARACTER SET latin1 COLLATE latin1_swedish_ci;"
         mysql -uroot -proot -e "GRANT ALL ON *.* TO 'iam'@'%';"
         mysql -uroot -proot -e "FLUSH PRIVILEGES;"
-        mvn -Dspring.profiles.active=mysql-test package install
+        mvn -Dspring.profiles.active=mysql-test -q package install
 
     - name: Copy artifacts to docker dir
       run: |
@@ -43,7 +43,7 @@ jobs:
         cp iam-test-client/target/iam-test-client.jar iam-test-client/docker
 
     - name: Generate buildpacks
-      run: mvn -DskipTests -U -B spring-boot:build-image
+      run: mvn -DskipTests -U -B -q spring-boot:build-image
     
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v3

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -44,7 +44,13 @@ jobs:
 
     - name: Generate buildpacks
       run: mvn -DskipTests -U -B spring-boot:build-image
-
+    
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v1
+    
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    
     - name: Docker login
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/login-action@v1
@@ -83,6 +89,7 @@ jobs:
         labels: ${{ steps.ls-meta.outputs.labels }}
         context: iam-login-service/docker/
         file: iam-login-service/docker/Dockerfile.prod
+        platforms: linux/amd64,linux/arm64
         push: ${{ startsWith(github.ref, 'refs/tags/') }}
 
     - name: Build & push iam-test-client docker image
@@ -92,4 +99,5 @@ jobs:
         labels: ${{ steps.tc-meta.outputs.labels }}
         context: iam-test-client/docker/
         file: iam-test-client/docker/Dockerfile.prod
+        platforms: linux/amd64,linux/arm64
         push: ${{ startsWith(github.ref, 'refs/tags/') }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -46,14 +46,14 @@ jobs:
       run: mvn -DskipTests -U -B spring-boot:build-image
     
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v3
     
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v3
     
     - name: Docker login
       if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -66,7 +66,7 @@ jobs:
 
     - name: Docker metainformation for iam-login-service
       id: ls-meta
-      uses: docker/metadata-action@v3
+      uses: docker/metadata-action@v5
       with:
         images: indigoiam/iam-login-service
         tags: |
@@ -75,7 +75,7 @@ jobs:
 
     - name: Docker metainformation for iam-test-client
       id: tc-meta
-      uses: docker/metadata-action@v3
+      uses: docker/metadata-action@v5
       with:
         images: indigoiam/iam-test-client
         tags: |


### PR DESCRIPTION
Add support for `docker buildx` for multiplatform docker images.
Currently, it builds `linux/amd64` and `linux/arm64` platforms.

Bumps some github docker actions versions.

Fix https://github.com/indigo-iam/iam/issues/751.