### PR TITLE
Add authorities list to SCIM user and rename isAdmin to isVoAdmin

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/converter/UserConverter.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/converter/UserConverter.java
@@ -243,7 +243,7 @@ public class UserConverter implements Converter<ScimUser, IamAccount> {
           .build()));
     }
 
-    builder.setAdmin(entity.getAuthorities().stream().anyMatch(a -> a.isAdminAuthority()));
+    builder.voAdmin(entity.getAuthorities().stream().anyMatch(a -> a.isAdminAuthority()));
 
     if (properties.isIncludeManagedGroups()) {
       groupManagerService.getManagedGroupInfoForAccount(entity)
@@ -253,6 +253,10 @@ public class UserConverter implements Converter<ScimUser, IamAccount> {
           .value(mg.getId())
           .ref(resourceLocationProvider.groupLocation(mg.getId()))
           .build()));
+    }
+
+    if (properties.isIncludeAuthorities()) {
+      entity.getAuthorities().forEach(a -> builder.addAuthority(a.getAuthority()));
     }
 
     return builder.build();

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/converter/UserConverter.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/converter/UserConverter.java
@@ -243,8 +243,6 @@ public class UserConverter implements Converter<ScimUser, IamAccount> {
           .build()));
     }
 
-    builder.voAdmin(entity.getAuthorities().stream().anyMatch(a -> a.isAdminAuthority()));
-
     if (properties.isIncludeManagedGroups()) {
       groupManagerService.getManagedGroupInfoForAccount(entity)
         .getManagedGroups()

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/converter/UserConverter.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/converter/UserConverter.java
@@ -243,7 +243,7 @@ public class UserConverter implements Converter<ScimUser, IamAccount> {
           .build()));
     }
 
-    builder.isAdmin(entity.getAuthorities().stream().anyMatch(a -> a.isAdminAuthority()));
+    builder.setAdmin(entity.getAuthorities().stream().anyMatch(a -> a.isAdminAuthority()));
 
     if (properties.isIncludeManagedGroups()) {
       groupManagerService.getManagedGroupInfoForAccount(entity)

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimIndigoUser.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimIndigoUser.java
@@ -41,7 +41,6 @@ public class ScimIndigoUser {
     X509_CERTS(ScimConstants.INDIGO_USER_SCHEMA + ".x509Certificates"),
     AUP_SIGNATURE_TIME(ScimConstants.INDIGO_USER_SCHEMA + ".aupSignatureTime"),
     LABELS(ScimConstants.INDIGO_USER_SCHEMA + ".labels"),
-    IS_VO_ADMIN(ScimConstants.INDIGO_USER_SCHEMA + ".isVoAdmin"),
     AUTHORITIES(ScimConstants.INDIGO_USER_SCHEMA + ".authorities"),
     ATTRIBUTES(ScimConstants.INDIGO_USER_SCHEMA + ".attributes"),
     MANAGED_GROUPS(ScimConstants.INDIGO_USER_SCHEMA + ".managedGroups");

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimIndigoUser.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimIndigoUser.java
@@ -76,9 +76,6 @@ public class ScimIndigoUser {
   @JsonSerialize(using = JsonDateSerializer.class)
   private final Date endTime;
 
-  @JsonProperty("isVoAdmin")
-  private final Boolean isVoAdmin;
-
   private final List<String> authorities;
 
   @Valid
@@ -105,7 +102,6 @@ public class ScimIndigoUser {
     this.authorities = null;
     this.attributes = null;
     this.managedGroups = null;
-    this.isVoAdmin = null;
   }
 
   private ScimIndigoUser(Builder b) {
@@ -118,7 +114,6 @@ public class ScimIndigoUser {
     this.labels = b.labels;
     this.attributes = b.attributes;
     this.managedGroups = b.managedGroups;
-    this.isVoAdmin = b.isVoAdmin;
     this.authorities = b.authorities;
   }
 
@@ -147,10 +142,6 @@ public class ScimIndigoUser {
 
   public List<ScimLabel> getLabels() {
     return labels;
-  }
-
-  public Boolean isVoAdmin() {
-    return isVoAdmin;
   }
 
   public List<String> getAuthorities() {
@@ -185,7 +176,6 @@ public class ScimIndigoUser {
     private Date aupSignatureTime;
     private Date endTime;
 
-    private Boolean isVoAdmin;
     private List<String> authorities = Lists.newLinkedList();
     private List<ScimAttribute> attributes = Lists.newLinkedList();
     private List<ScimGroupRef> managedGroups = Lists.newLinkedList();
@@ -230,11 +220,6 @@ public class ScimIndigoUser {
 
     public Builder addLabel(ScimLabel label) {
       labels.add(label);
-      return this;
-    }
-
-    public Builder isVoAdmin(Boolean isVoAdmin) {
-      this.isVoAdmin = isVoAdmin;
       return this;
     }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimIndigoUser.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimIndigoUser.java
@@ -18,7 +18,6 @@ package it.infn.mw.iam.api.scim.model;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Objects;
 
 import javax.validation.Valid;
 
@@ -43,6 +42,7 @@ public class ScimIndigoUser {
     AUP_SIGNATURE_TIME(ScimConstants.INDIGO_USER_SCHEMA + ".aupSignatureTime"),
     LABELS(ScimConstants.INDIGO_USER_SCHEMA + ".labels"),
     IS_VO_ADMIN(ScimConstants.INDIGO_USER_SCHEMA + ".isVoAdmin"),
+    AUTHORITIES(ScimConstants.INDIGO_USER_SCHEMA + ".authorities"),
     ATTRIBUTES(ScimConstants.INDIGO_USER_SCHEMA + ".attributes"),
     MANAGED_GROUPS(ScimConstants.INDIGO_USER_SCHEMA + ".managedGroups");
     // @formatter:on
@@ -76,7 +76,10 @@ public class ScimIndigoUser {
   @JsonSerialize(using = JsonDateSerializer.class)
   private final Date endTime;
 
+  @JsonProperty("isVoAdmin")
   private final Boolean isVoAdmin;
+
+  private final List<String> authorities;
 
   @Valid
   private final List<ScimAttribute> attributes;
@@ -99,6 +102,7 @@ public class ScimIndigoUser {
     this.aupSignatureTime = aupSignatureTime;
     this.endTime = endTime;
     this.labels = null;
+    this.authorities = null;
     this.attributes = null;
     this.managedGroups = null;
     this.isVoAdmin = null;
@@ -114,7 +118,8 @@ public class ScimIndigoUser {
     this.labels = b.labels;
     this.attributes = b.attributes;
     this.managedGroups = b.managedGroups;
-    this.isVoAdmin = b.isAdmin;
+    this.isVoAdmin = b.isVoAdmin;
+    this.authorities = b.authorities;
   }
 
   public List<ScimSshKey> getSshKeys() {
@@ -148,6 +153,10 @@ public class ScimIndigoUser {
     return isVoAdmin;
   }
 
+  public List<String> getAuthorities() {
+    return authorities;
+  }
+
   public List<ScimAttribute> getAttributes() {
     return attributes;
   }
@@ -176,7 +185,8 @@ public class ScimIndigoUser {
     private Date aupSignatureTime;
     private Date endTime;
 
-    private Boolean isAdmin;
+    private Boolean isVoAdmin;
+    private List<String> authorities = Lists.newLinkedList();
     private List<ScimAttribute> attributes = Lists.newLinkedList();
     private List<ScimGroupRef> managedGroups = Lists.newLinkedList();
 
@@ -223,8 +233,13 @@ public class ScimIndigoUser {
       return this;
     }
 
-    public Builder isAdmin(Boolean isAdmin) {
-      this.isAdmin = isAdmin;
+    public Builder isVoAdmin(Boolean isVoAdmin) {
+      this.isVoAdmin = isVoAdmin;
+      return this;
+    }
+
+    public Builder addAuthority(String authority) {
+      authorities.add(authority);
       return this;
     }
 
@@ -240,31 +255,6 @@ public class ScimIndigoUser {
 
     public ScimIndigoUser build() {
       return new ScimIndigoUser(this);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(attributes, aupSignatureTime, certificates, endTime, isAdmin, labels,
-          managedGroups, oidcIds, samlIds, sshKeys);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-      if (this == obj)
-        return true;
-      if (obj == null)
-        return false;
-      if (getClass() != obj.getClass())
-        return false;
-      Builder other = (Builder) obj;
-      return Objects.equals(attributes, other.attributes)
-          && Objects.equals(aupSignatureTime, other.aupSignatureTime)
-          && Objects.equals(certificates, other.certificates)
-          && Objects.equals(endTime, other.endTime) && Objects.equals(isAdmin, other.isAdmin)
-          && Objects.equals(labels, other.labels)
-          && Objects.equals(managedGroups, other.managedGroups)
-          && Objects.equals(oidcIds, other.oidcIds) && Objects.equals(samlIds, other.samlIds)
-          && Objects.equals(sshKeys, other.sshKeys);
     }
 
   }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimIndigoUser.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimIndigoUser.java
@@ -42,7 +42,7 @@ public class ScimIndigoUser {
     X509_CERTS(ScimConstants.INDIGO_USER_SCHEMA + ".x509Certificates"),
     AUP_SIGNATURE_TIME(ScimConstants.INDIGO_USER_SCHEMA + ".aupSignatureTime"),
     LABELS(ScimConstants.INDIGO_USER_SCHEMA + ".labels"),
-    IS_ADMIN(ScimConstants.INDIGO_USER_SCHEMA + ".isAdmin"),
+    IS_VO_ADMIN(ScimConstants.INDIGO_USER_SCHEMA + ".isVoAdmin"),
     ATTRIBUTES(ScimConstants.INDIGO_USER_SCHEMA + ".attributes"),
     MANAGED_GROUPS(ScimConstants.INDIGO_USER_SCHEMA + ".managedGroups");
     // @formatter:on
@@ -76,8 +76,7 @@ public class ScimIndigoUser {
   @JsonSerialize(using = JsonDateSerializer.class)
   private final Date endTime;
 
-  @JsonProperty(value = "isAdmin")
-  private final Boolean isAdmin;
+  private final Boolean isVoAdmin;
 
   @Valid
   private final List<ScimAttribute> attributes;
@@ -102,7 +101,7 @@ public class ScimIndigoUser {
     this.labels = null;
     this.attributes = null;
     this.managedGroups = null;
-    this.isAdmin = null;
+    this.isVoAdmin = null;
   }
 
   private ScimIndigoUser(Builder b) {
@@ -115,7 +114,7 @@ public class ScimIndigoUser {
     this.labels = b.labels;
     this.attributes = b.attributes;
     this.managedGroups = b.managedGroups;
-    this.isAdmin = b.isAdmin;
+    this.isVoAdmin = b.isAdmin;
   }
 
   public List<ScimSshKey> getSshKeys() {
@@ -145,8 +144,8 @@ public class ScimIndigoUser {
     return labels;
   }
 
-  public Boolean isAdmin() {
-    return isAdmin;
+  public Boolean isVoAdmin() {
+    return isVoAdmin;
   }
 
   public List<ScimAttribute> getAttributes() {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimUser.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimUser.java
@@ -457,11 +457,11 @@ public class ScimUser extends ScimResource {
       return this;
     }
 
-    public Builder setAdmin(Boolean isAdmin) {
+    public Builder voAdmin(Boolean isVoAdmin) {
 
-      Preconditions.checkNotNull(isAdmin, "Null isAdmin");
+      Preconditions.checkNotNull(isVoAdmin, "Null isAdmin");
 
-      indigoUserBuilder.isAdmin(isAdmin);
+      indigoUserBuilder.isVoAdmin(isVoAdmin);
       return this;
     }
 
@@ -470,6 +470,14 @@ public class ScimUser extends ScimResource {
       Preconditions.checkNotNull(endTime, "Null membership end-time");
 
       indigoUserBuilder.endTime(endTime);
+      return this;
+    }
+
+    public Builder addAuthority(String authority) {
+
+      Preconditions.checkNotNull(authority, "Null authority");
+
+      indigoUserBuilder.addAuthority(authority);
       return this;
     }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimUser.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimUser.java
@@ -457,7 +457,7 @@ public class ScimUser extends ScimResource {
       return this;
     }
 
-    public Builder isAdmin(Boolean isAdmin) {
+    public Builder setAdmin(Boolean isAdmin) {
 
       Preconditions.checkNotNull(isAdmin, "Null isAdmin");
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimUser.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimUser.java
@@ -457,14 +457,6 @@ public class ScimUser extends ScimResource {
       return this;
     }
 
-    public Builder voAdmin(Boolean isVoAdmin) {
-
-      Preconditions.checkNotNull(isVoAdmin, "Null isAdmin");
-
-      indigoUserBuilder.isVoAdmin(isVoAdmin);
-      return this;
-    }
-
     public Builder endTime(Date endTime) {
 
       Preconditions.checkNotNull(endTime, "Null membership end-time");

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/scim/ScimProperties.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/scim/ScimProperties.java
@@ -61,6 +61,7 @@ public class ScimProperties {
 
   List<LabelDescriptor> includeLabels = Lists.newArrayList();
   List<AttributeDescriptor> includeAttributes = Lists.newArrayList();
+  boolean includeAuthorities = false;
   boolean includeManagedGroups = false;
 
   public List<LabelDescriptor> getIncludeLabels() {
@@ -77,6 +78,14 @@ public class ScimProperties {
 
   public void setIncludeAttributes(List<AttributeDescriptor> includeAttributes) {
     this.includeAttributes = includeAttributes;
+  }
+
+  public boolean isIncludeAuthorities() {
+    return includeAuthorities;
+  }
+
+  public void setIncludeAuthorities(boolean includeAuthorities) {
+    this.includeAuthorities = includeAuthorities;
   }
 
   public boolean isIncludeManagedGroups() {

--- a/iam-login-service/src/main/resources/application.yml
+++ b/iam-login-service/src/main/resources/application.yml
@@ -282,4 +282,5 @@ lifecycle:
       enabled: ${IAM_LIFECYCLE_EXPIRED_ACCOUNT_TASK_ENABLED:true}
 
 scim:
+  include_authorities: ${IAM_SCIM_INCLUDE_AUTHORITIES:false}
   include_managed_groups: ${IAM_SCIM_INCLUDE_MANAGED_GROUPS:false}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/ScimRestUtilsMvc.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/ScimRestUtilsMvc.java
@@ -56,8 +56,6 @@ public class ScimRestUtilsMvc extends RestUtils {
     return doPost(getUsersLocation(), user, SCIM_CONTENT_TYPE, expectedStatus);
   }
 
-
-
   public ScimUser getUser(String uuid) throws Exception {
 
     return mapper.readValue(getUser(uuid, OK).andReturn().getResponse().getContentAsString(),

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/converter/ScimAccountAuthoritiesConverterTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/converter/ScimAccountAuthoritiesConverterTests.java
@@ -87,18 +87,18 @@ public class ScimAccountAuthoritiesConverterTests {
 
     ScimUser user = scimUtils.getUser(testAccount.getUuid());
 
-    assertThat(user.getIndigoUser().isAdmin(), equalTo(false));
+    assertThat(user.getIndigoUser().isVoAdmin(), equalTo(false));
 
     authorityService.addAuthorityToAccount(testAccount, GM_AUTHORITY);
 
     user = scimUtils.getUser(testAccount.getUuid());
 
-    assertThat(user.getIndigoUser().isAdmin(), equalTo(false));
+    assertThat(user.getIndigoUser().isVoAdmin(), equalTo(false));
 
     authorityService.addAuthorityToAccount(testAccount, ADMIN_AUTHORITY);
 
     user = scimUtils.getUser(testAccount.getUuid());
 
-    assertThat(user.getIndigoUser().isAdmin(), equalTo(true));
+    assertThat(user.getIndigoUser().isVoAdmin(), equalTo(true));
   }
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/converter/ScimAccountAuthoritiesConverterTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/converter/ScimAccountAuthoritiesConverterTests.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import it.infn.mw.iam.api.account.authority.AccountAuthorityService;
@@ -41,8 +42,10 @@ import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 
 @RunWith(SpringRunner.class)
 @IamMockMvcIntegrationTest
+@TestPropertySource(properties = {"scim.include_authorities=true"})
 public class ScimAccountAuthoritiesConverterTests {
 
+  private static final String USER_AUTHORITY = "ROLE_USER";
   private static final String GM_AUTHORITY = "ROLE_GM" + UUID.randomUUID();
   private static final String ADMIN_AUTHORITY = "ROLE_ADMIN";
 
@@ -87,18 +90,28 @@ public class ScimAccountAuthoritiesConverterTests {
 
     ScimUser user = scimUtils.getUser(testAccount.getUuid());
 
-    assertThat(user.getIndigoUser().isVoAdmin(), equalTo(false));
+    assertThat(user.getIndigoUser().isVoAdmin().booleanValue(), equalTo(false));
+    assertThat(user.getIndigoUser().getAuthorities().size(), equalTo(1));
+    assertThat(user.getIndigoUser().getAuthorities().get(0), equalTo(USER_AUTHORITY));
 
     authorityService.addAuthorityToAccount(testAccount, GM_AUTHORITY);
 
     user = scimUtils.getUser(testAccount.getUuid());
 
-    assertThat(user.getIndigoUser().isVoAdmin(), equalTo(false));
+    assertThat(user.getIndigoUser().isVoAdmin().booleanValue(), equalTo(false));
+    assertThat(user.getIndigoUser().getAuthorities().size(), equalTo(2));
+    assertThat(user.getIndigoUser().getAuthorities().contains(USER_AUTHORITY), equalTo(true));
+    assertThat(user.getIndigoUser().getAuthorities().contains(GM_AUTHORITY), equalTo(true));
 
     authorityService.addAuthorityToAccount(testAccount, ADMIN_AUTHORITY);
 
     user = scimUtils.getUser(testAccount.getUuid());
 
-    assertThat(user.getIndigoUser().isVoAdmin(), equalTo(true));
+    assertThat(user.getIndigoUser().isVoAdmin().booleanValue(), equalTo(true));
+    assertThat(user.getIndigoUser().getAuthorities().size(), equalTo(3));
+    assertThat(user.getIndigoUser().getAuthorities().contains(USER_AUTHORITY), equalTo(true));
+    assertThat(user.getIndigoUser().getAuthorities().contains(GM_AUTHORITY), equalTo(true));
+    assertThat(user.getIndigoUser().getAuthorities().contains(ADMIN_AUTHORITY), equalTo(true));
+
   }
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/converter/ScimAccountAuthoritiesConverterTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/converter/ScimAccountAuthoritiesConverterTests.java
@@ -90,7 +90,6 @@ public class ScimAccountAuthoritiesConverterTests {
 
     ScimUser user = scimUtils.getUser(testAccount.getUuid());
 
-    assertThat(user.getIndigoUser().isVoAdmin().booleanValue(), equalTo(false));
     assertThat(user.getIndigoUser().getAuthorities().size(), equalTo(1));
     assertThat(user.getIndigoUser().getAuthorities().get(0), equalTo(USER_AUTHORITY));
 
@@ -98,7 +97,6 @@ public class ScimAccountAuthoritiesConverterTests {
 
     user = scimUtils.getUser(testAccount.getUuid());
 
-    assertThat(user.getIndigoUser().isVoAdmin().booleanValue(), equalTo(false));
     assertThat(user.getIndigoUser().getAuthorities().size(), equalTo(2));
     assertThat(user.getIndigoUser().getAuthorities().contains(USER_AUTHORITY), equalTo(true));
     assertThat(user.getIndigoUser().getAuthorities().contains(GM_AUTHORITY), equalTo(true));
@@ -107,7 +105,6 @@ public class ScimAccountAuthoritiesConverterTests {
 
     user = scimUtils.getUser(testAccount.getUuid());
 
-    assertThat(user.getIndigoUser().isVoAdmin().booleanValue(), equalTo(true));
     assertThat(user.getIndigoUser().getAuthorities().size(), equalTo(3));
     assertThat(user.getIndigoUser().getAuthorities().contains(USER_AUTHORITY), equalTo(true));
     assertThat(user.getIndigoUser().getAuthorities().contains(GM_AUTHORITY), equalTo(true));

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/core/provisioning/user/ScimUserServiceTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/core/provisioning/user/ScimUserServiceTests.java
@@ -193,7 +193,7 @@ public class ScimUserServiceTests {
       .addAttribute(TESTUSER_ATTRIBUTE) // not writable
       .addLabel(TESTUSER_LABEL) // not writable
       .addManagedGroup(TESTUSER_GROUP_REF) // not writable
-      .addAuthority("ROLE_ADMIN")
+      .addAuthority("ROLE_ADMIN") // not writable
       .build();
 
     userService.create(scimUser);

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/core/provisioning/user/ScimUserServiceTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/core/provisioning/user/ScimUserServiceTests.java
@@ -191,7 +191,7 @@ public class ScimUserServiceTests {
       .addEmail(TESTUSER_EMAIL) // mandatory
       .name(TESTUSER_NAME) // mandatory
       .addAttribute(TESTUSER_ATTRIBUTE) // not writable
-      .isAdmin(true) // not writable
+      .setAdmin(true) // not writable
       .addLabel(TESTUSER_LABEL) // not writable
       .addManagedGroup(TESTUSER_GROUP_REF) // not writable
       .build();

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/core/provisioning/user/ScimUserServiceTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/core/provisioning/user/ScimUserServiceTests.java
@@ -191,9 +191,10 @@ public class ScimUserServiceTests {
       .addEmail(TESTUSER_EMAIL) // mandatory
       .name(TESTUSER_NAME) // mandatory
       .addAttribute(TESTUSER_ATTRIBUTE) // not writable
-      .setAdmin(true) // not writable
+      .voAdmin(true) // not writable
       .addLabel(TESTUSER_LABEL) // not writable
       .addManagedGroup(TESTUSER_GROUP_REF) // not writable
+      .addAuthority("ROLE_ADMIN")
       .build();
 
     userService.create(scimUser);

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/core/provisioning/user/ScimUserServiceTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/core/provisioning/user/ScimUserServiceTests.java
@@ -191,7 +191,6 @@ public class ScimUserServiceTests {
       .addEmail(TESTUSER_EMAIL) // mandatory
       .name(TESTUSER_NAME) // mandatory
       .addAttribute(TESTUSER_ATTRIBUTE) // not writable
-      .voAdmin(true) // not writable
       .addLabel(TESTUSER_LABEL) // not writable
       .addManagedGroup(TESTUSER_GROUP_REF) // not writable
       .addAuthority("ROLE_ADMIN")

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/me/ScimMeFullResponseEndpointTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/me/ScimMeFullResponseEndpointTests.java
@@ -17,7 +17,7 @@ package it.infn.mw.iam.test.scim.me;
 
 import static it.infn.mw.iam.api.scim.model.ScimConstants.SCIM_CONTENT_TYPE;
 import static it.infn.mw.iam.api.scim.model.ScimIndigoUser.INDIGO_USER_SCHEMA.ATTRIBUTES;
-import static it.infn.mw.iam.api.scim.model.ScimIndigoUser.INDIGO_USER_SCHEMA.IS_ADMIN;
+import static it.infn.mw.iam.api.scim.model.ScimIndigoUser.INDIGO_USER_SCHEMA.IS_VO_ADMIN;
 import static it.infn.mw.iam.api.scim.model.ScimIndigoUser.INDIGO_USER_SCHEMA.MANAGED_GROUPS;
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -74,8 +74,8 @@ public class ScimMeFullResponseEndpointTests {
       .andExpect(jsonPath("$." + ATTRIBUTES, hasSize(1)))
       .andExpect(jsonPath("$." + ATTRIBUTES + "[0].name").value("affiliation"))
       .andExpect(jsonPath("$." + ATTRIBUTES + "[0].value").value("INFN-CNAF"))
-      .andExpect(jsonPath("$." + IS_ADMIN).exists())
-      .andExpect(jsonPath("$." + IS_ADMIN).value("false"))
+      .andExpect(jsonPath("$." + IS_VO_ADMIN).exists())
+      .andExpect(jsonPath("$." + IS_VO_ADMIN).value("false"))
       .andExpect(jsonPath("$." + MANAGED_GROUPS).exists())
       .andExpect(jsonPath("$." + MANAGED_GROUPS).isArray())
       .andExpect(jsonPath("$." + MANAGED_GROUPS, hasSize(1)))

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/me/ScimMeFullResponseEndpointTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/me/ScimMeFullResponseEndpointTests.java
@@ -17,8 +17,9 @@ package it.infn.mw.iam.test.scim.me;
 
 import static it.infn.mw.iam.api.scim.model.ScimConstants.SCIM_CONTENT_TYPE;
 import static it.infn.mw.iam.api.scim.model.ScimIndigoUser.INDIGO_USER_SCHEMA.ATTRIBUTES;
-import static it.infn.mw.iam.api.scim.model.ScimIndigoUser.INDIGO_USER_SCHEMA.IS_VO_ADMIN;
+import static it.infn.mw.iam.api.scim.model.ScimIndigoUser.INDIGO_USER_SCHEMA.AUTHORITIES;
 import static it.infn.mw.iam.api.scim.model.ScimIndigoUser.INDIGO_USER_SCHEMA.MANAGED_GROUPS;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -41,7 +42,7 @@ import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 @RunWith(SpringJUnit4ClassRunner.class)
 @IamMockMvcIntegrationTest
 @TestPropertySource(properties = {"scim.include_attributes[0].name=affiliation",
-    "scim.include_managed_groups=true"})
+    "scim.include_managed_groups=true", "scim.include_authorities=true"})
 public class ScimMeFullResponseEndpointTests {
 
   private final static String ME_ENDPOINT = "/scim/Me";
@@ -74,8 +75,11 @@ public class ScimMeFullResponseEndpointTests {
       .andExpect(jsonPath("$." + ATTRIBUTES, hasSize(1)))
       .andExpect(jsonPath("$." + ATTRIBUTES + "[0].name").value("affiliation"))
       .andExpect(jsonPath("$." + ATTRIBUTES + "[0].value").value("INFN-CNAF"))
-      .andExpect(jsonPath("$." + IS_VO_ADMIN).exists())
-      .andExpect(jsonPath("$." + IS_VO_ADMIN).value("false"))
+      .andExpect(jsonPath("$." + AUTHORITIES).exists())
+      .andExpect(jsonPath("$." + AUTHORITIES).isArray())
+      .andExpect(jsonPath("$." + AUTHORITIES, hasSize(2)))
+      .andExpect(jsonPath("$." + AUTHORITIES, hasItem("ROLE_USER")))
+      .andExpect(jsonPath("$." + AUTHORITIES, hasItem("ROLE_GM:c617d586-54e6-411d-8e38-64967798fa8a")))
       .andExpect(jsonPath("$." + MANAGED_GROUPS).exists())
       .andExpect(jsonPath("$." + MANAGED_GROUPS).isArray())
       .andExpect(jsonPath("$." + MANAGED_GROUPS, hasSize(1)))

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/user/ScimUserCreationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/user/ScimUserCreationTests.java
@@ -458,7 +458,7 @@ public class ScimUserCreationTests extends ScimUserTestSupport {
     assertThat(user.getEmails().get(0).getValue(),
         equalTo(createdUser.getEmails().get(0).getValue()));
     assertNull(createdUser.getIndigoUser().getEndTime());
-    assertThat(createdUser.getIndigoUser().isVoAdmin(), equalTo(false));
+    assertThat(createdUser.getIndigoUser().getAuthorities().contains("ROLE_ADMIN"), equalTo(false));
   }
 
   @Test

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/user/ScimUserCreationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/user/ScimUserCreationTests.java
@@ -458,7 +458,7 @@ public class ScimUserCreationTests extends ScimUserTestSupport {
     assertThat(user.getEmails().get(0).getValue(),
         equalTo(createdUser.getEmails().get(0).getValue()));
     assertNull(createdUser.getIndigoUser().getEndTime());
-    assertThat(createdUser.getIndigoUser().isAdmin(), equalTo(false));
+    assertThat(createdUser.getIndigoUser().isVoAdmin(), equalTo(false));
   }
 
   @Test

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/user/ScimUserCreationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/user/ScimUserCreationTests.java
@@ -46,6 +46,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -73,6 +74,7 @@ import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 @SpringBootTest(
     classes = {IamLoginService.class, CoreControllerTestSupport.class, ScimRestUtilsMvc.class},
     webEnvironment = WebEnvironment.MOCK)
+@TestPropertySource(properties = {"scim.include_authorities=true"})
 public class ScimUserCreationTests extends ScimUserTestSupport {
 
   @Autowired
@@ -450,6 +452,7 @@ public class ScimUserCreationTests extends ScimUserTestSupport {
 
     ScimUser user = buildUser("user_with_exp_time", "userwithexptime@email.test", "User", "Test")
       .endTime(expTime)
+      .addAuthority("ROLE_ADMIN")
       .build();
     ScimUser createdUser = scimUtils.postUser(user);
 


### PR DESCRIPTION
Remove isVoAdmin SCIM info with the list of authorities:

```
{
  id: "73f16d93-2441-4a50-88ff-85360d78c6b5",
  meta: {  ...  },
  schemas: [ ... ],
  userName: "admin",
  ...
  active: true,
  urn:indigo-dc:scim:schemas:IndigoUser: {
    oidcIds: [ ... ],
    samlIds: [ ... ],
    certificates: [ ... ],
    authorities: [
      "ROLE_ADMIN",
      "ROLE_USER"
    ]
  }
}
```

in case `scim.include_authorities` is set to true (default: false).