### PR TITLE
Allow to add nickname as attribute during a registration request

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/IamProperties.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/IamProperties.java
@@ -221,6 +221,8 @@ public class IamProperties {
     boolean showRegistrationButtonInLoginPage = true;
 
     boolean requireExternalAuthentication = false;
+    
+    boolean addNicknameAsAttribute = false;
 
     ExternalAuthenticationType authenticationType;
 
@@ -244,6 +246,14 @@ public class IamProperties {
 
     public void setRequireExternalAuthentication(boolean requireExternalAuthentication) {
       this.requireExternalAuthentication = requireExternalAuthentication;
+    }
+    
+    public boolean isAddNicknameAsAttribute() {
+      return addNicknameAsAttribute;
+    }
+
+    public void setAddNicknameAsAttribute(boolean addNicknameAsAttribute) {
+      this.addNicknameAsAttribute = addNicknameAsAttribute;
     }
 
     public ExternalAuthenticationType getAuthenticationType() {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/registration/DefaultRegistrationRequestService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/registration/DefaultRegistrationRequestService.java
@@ -412,12 +412,4 @@ public class DefaultRegistrationRequestService
     return handleApprove(request);
   }
 
-  public void setValidationService(RegistrationRequestValidationService validationService) {
-    this.validationService = validationService;
-  }
-
-  public RegistrationRequestValidationService getValidationService() {
-    return validationService;
-  }
-
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/registration/DefaultRegistrationRequestService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/registration/DefaultRegistrationRequestService.java
@@ -128,7 +128,7 @@ public class DefaultRegistrationRequestService
 
   private ApplicationEventPublisher eventPublisher;
 
-  private static final String NICKNAME_ATTRIBUTE_KEY = "nickname";
+  public static final String NICKNAME_ATTRIBUTE_KEY = "nickname";
 
   private IamRegistrationRequest findRequestById(String requestUuid) {
     return requestRepository.findByUuid(requestUuid)

--- a/iam-login-service/src/main/java/it/infn/mw/iam/registration/DefaultRegistrationRequestService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/registration/DefaultRegistrationRequestService.java
@@ -64,6 +64,7 @@ import it.infn.mw.iam.core.IamRegistrationRequestStatus;
 import it.infn.mw.iam.core.user.IamAccountService;
 import it.infn.mw.iam.notification.NotificationFactory;
 import it.infn.mw.iam.persistence.model.IamAccount;
+import it.infn.mw.iam.persistence.model.IamAttribute;
 import it.infn.mw.iam.persistence.model.IamAup;
 import it.infn.mw.iam.persistence.model.IamAupSignature;
 import it.infn.mw.iam.persistence.model.IamLabel;
@@ -122,6 +123,8 @@ public class DefaultRegistrationRequestService
   private Clock clock;
 
   private ApplicationEventPublisher eventPublisher;
+  
+  private static final String NICKNAME_ATTRIBUTE_KEY = "nickname";
 
   private IamRegistrationRequest findRequestById(String requestUuid) {
     return requestRepository.findByUuid(requestUuid)
@@ -199,6 +202,7 @@ public class DefaultRegistrationRequestService
         accountService.createAccount(userConverter.entityFromDto(userBuilder.build()));
     accountEntity.setConfirmationKey(tokenGenerator.generateToken());
     accountEntity.setActive(false);
+    accountEntity.getAttributes().add(IamAttribute.newInstance(NICKNAME_ATTRIBUTE_KEY, dto.getUsername()));
 
     createAupSignatureForAccountIfNeeded(accountEntity);
 

--- a/iam-login-service/src/main/resources/application.yml
+++ b/iam-login-service/src/main/resources/application.yml
@@ -153,6 +153,7 @@ iam:
     authentication-type: ${IAM_REGISTRATION_AUTHENTICATION_TYPE:oidc}
     oidc-issuer: ${IAM_REGISTRATION_OIDC_ISSUER:https://example.org}
     saml-entity-id: ${IAM_REGISTRATION_SAML_ENTITY_ID:urn:example}
+    add-nickname-as-attribute: ${IAM_ADD_NICKNAME_AS_ATTRIBUTE:false}
     
   local-authn:
     login-page-visibility: ${IAM_LOCAL_AUTHN_LOGIN_PAGE_VISIBILITY:visible}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/OidcExtAuthRegistrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/OidcExtAuthRegistrationTests.java
@@ -16,11 +16,13 @@
 package it.infn.mw.iam.test.registration;
 
 import static it.infn.mw.iam.authn.ExternalAuthenticationHandlerSupport.EXT_AUTH_ERROR_KEY;
+import static it.infn.mw.iam.registration.DefaultRegistrationRequestService.NICKNAME_ATTRIBUTE_KEY;
 import static it.infn.mw.iam.test.ext_authn.oidc.OidcTestConfig.TEST_OIDC_CLIENT_ID;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
@@ -114,34 +116,31 @@ public class OidcExtAuthRegistrationTests {
     // If the user tries to authenticate with his external account, he's redirected to the
     // login page with an account disabled error
 
-    MockHttpSession session =
-        (MockHttpSession) mvc
-          .perform(get("/openid_connect_login").with(
-              SecurityMockMvcRequestPostProcessors.authentication(anonymousAuthenticationToken())))
-          .andExpect(status().isFound())
-          .andExpect(MockMvcResultMatchers
-            .redirectedUrlPattern(OidcTestConfig.TEST_OIDC_AUTHORIZATION_ENDPOINT_URI + "**"))
-          .andReturn()
-          .getRequest()
-          .getSession();
+    MockHttpSession session = (MockHttpSession) mvc
+      .perform(get("/openid_connect_login")
+        .with(SecurityMockMvcRequestPostProcessors.authentication(anonymousAuthenticationToken())))
+      .andExpect(status().isFound())
+      .andExpect(MockMvcResultMatchers
+        .redirectedUrlPattern(OidcTestConfig.TEST_OIDC_AUTHORIZATION_ENDPOINT_URI + "**"))
+      .andReturn()
+      .getRequest()
+      .getSession();
 
     String state = (String) session.getAttribute("state");
     String nonce = (String) session.getAttribute("nonce");
 
     oidcProvider.prepareTokenResponse(TEST_OIDC_CLIENT_ID, TEST_100_USER, nonce);
 
-    session =
-        (MockHttpSession) mvc
-          .perform(get("/openid_connect_login").param("state", state)
-            .param("code", "1234")
-            .session(session))
-          .andExpect(status().isFound())
-          .andExpect(MockMvcResultMatchers.redirectedUrlPattern("/login**"))
-          .andExpect(
-              MockMvcResultMatchers.request().sessionAttribute(EXT_AUTH_ERROR_KEY, notNullValue()))
-          .andReturn()
-          .getRequest()
-          .getSession();
+    session = (MockHttpSession) mvc
+      .perform(
+          get("/openid_connect_login").param("state", state).param("code", "1234").session(session))
+      .andExpect(status().isFound())
+      .andExpect(MockMvcResultMatchers.redirectedUrlPattern("/login**"))
+      .andExpect(
+          MockMvcResultMatchers.request().sessionAttribute(EXT_AUTH_ERROR_KEY, notNullValue()))
+      .andReturn()
+      .getRequest()
+      .getSession();
 
     assertThat(session.getAttribute(EXT_AUTH_ERROR_KEY), instanceOf(DisabledException.class));
 
@@ -152,33 +151,30 @@ public class OidcExtAuthRegistrationTests {
     // the same happens after having confirmed the request
     mvc.perform(get("/registration/confirm/{token}", token)).andExpect(status().isOk());
 
-    session =
-        (MockHttpSession) mvc
-          .perform(get("/openid_connect_login").with(
-              SecurityMockMvcRequestPostProcessors.authentication(anonymousAuthenticationToken())))
-          .andExpect(status().isFound())
-          .andExpect(MockMvcResultMatchers
-            .redirectedUrlPattern(OidcTestConfig.TEST_OIDC_AUTHORIZATION_ENDPOINT_URI + "**"))
-          .andReturn()
-          .getRequest()
-          .getSession();
+    session = (MockHttpSession) mvc
+      .perform(get("/openid_connect_login")
+        .with(SecurityMockMvcRequestPostProcessors.authentication(anonymousAuthenticationToken())))
+      .andExpect(status().isFound())
+      .andExpect(MockMvcResultMatchers
+        .redirectedUrlPattern(OidcTestConfig.TEST_OIDC_AUTHORIZATION_ENDPOINT_URI + "**"))
+      .andReturn()
+      .getRequest()
+      .getSession();
 
     state = (String) session.getAttribute("state");
     nonce = (String) session.getAttribute("nonce");
 
     oidcProvider.prepareTokenResponse(TEST_OIDC_CLIENT_ID, TEST_100_USER, nonce);
 
-    session =
-        (MockHttpSession) mvc
-          .perform(get("/openid_connect_login").param("state", state)
-            .param("code", "1234")
-            .session(session))
-          .andExpect(status().isFound())
-          .andExpect(MockMvcResultMatchers.redirectedUrlPattern("/login**"))
-          .andExpect(request().sessionAttribute(EXT_AUTH_ERROR_KEY, notNullValue()))
-          .andReturn()
-          .getRequest()
-          .getSession();
+    session = (MockHttpSession) mvc
+      .perform(
+          get("/openid_connect_login").param("state", state).param("code", "1234").session(session))
+      .andExpect(status().isFound())
+      .andExpect(MockMvcResultMatchers.redirectedUrlPattern("/login**"))
+      .andExpect(request().sessionAttribute(EXT_AUTH_ERROR_KEY, notNullValue()))
+      .andReturn()
+      .getRequest()
+      .getSession();
 
     assertThat(session.getAttribute(EXT_AUTH_ERROR_KEY), instanceOf(DisabledException.class));
     err = (DisabledException) session.getAttribute(EXT_AUTH_ERROR_KEY);
@@ -187,6 +183,7 @@ public class OidcExtAuthRegistrationTests {
 
     IamAccount account = iamAccountRepo.findByOidcId(OidcTestConfig.TEST_OIDC_ISSUER, TEST_100_USER)
       .orElseThrow(() -> new AssertionError("Expected account not found"));
+    assertFalse(account.getAttributeByName(NICKNAME_ATTRIBUTE_KEY).get().getValue().equals(username));
 
     iamAccountRepo.delete(account);
   }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/OidcExtAuthRegistrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/OidcExtAuthRegistrationTests.java
@@ -22,7 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
@@ -183,7 +183,7 @@ public class OidcExtAuthRegistrationTests {
 
     IamAccount account = iamAccountRepo.findByOidcId(OidcTestConfig.TEST_OIDC_ISSUER, TEST_100_USER)
       .orElseThrow(() -> new AssertionError("Expected account not found"));
-    assertFalse(account.getAttributeByName(NICKNAME_ATTRIBUTE_KEY).get().getValue().equals(username));
+    assertTrue(account.getAttributeByName(NICKNAME_ATTRIBUTE_KEY).isEmpty());
 
     iamAccountRepo.delete(account);
   }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/RegistrationAttributesTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/RegistrationAttributesTests.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.registration;
+
+import static it.infn.mw.iam.registration.DefaultRegistrationRequestService.NICKNAME_ATTRIBUTE_KEY;
+import static it.infn.mw.iam.test.ext_authn.saml.SamlAuthenticationTestSupport.DEFAULT_IDP_ID;
+import static it.infn.mw.iam.test.ext_authn.saml.SamlAuthenticationTestSupport.T1_EPUID;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import it.infn.mw.iam.authn.saml.util.Saml2Attribute;
+import it.infn.mw.iam.persistence.model.IamAccount;
+import it.infn.mw.iam.persistence.model.IamSamlId;
+import it.infn.mw.iam.persistence.repository.IamAccountRepository;
+import it.infn.mw.iam.registration.RegistrationRequestDto;
+import it.infn.mw.iam.test.api.TestSupport;
+import it.infn.mw.iam.test.ext_authn.oidc.OidcTestConfig;
+import it.infn.mw.iam.test.util.WithMockOIDCUser;
+import it.infn.mw.iam.test.util.WithMockSAMLUser;
+import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
+import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
+
+
+@RunWith(SpringRunner.class)
+@IamMockMvcIntegrationTest
+@TestPropertySource(properties = {"iam.registration.add-nickname-as-attribute=true"})
+public class RegistrationAttributesTests extends TestSupport {
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Autowired
+  private MockOAuth2Filter oauth2Filter;
+
+  @Autowired
+  private MockMvc mvc;
+
+  @Autowired
+  private IamAccountRepository iamAccountRepo;
+
+  @Before
+  public void setup() {
+    oauth2Filter.cleanupSecurityContext();
+  }
+
+  @After
+  public void teardown() {
+    oauth2Filter.cleanupSecurityContext();
+  }
+
+  private RegistrationRequestDto createRegistrationRequest() {
+
+    String username = "test-attributes";
+
+    String email = username + "@example.org";
+    RegistrationRequestDto request = new RegistrationRequestDto();
+    request.setGivenname("Test");
+    request.setFamilyname("User");
+    request.setEmail(email);
+    request.setUsername(username);
+    request.setNotes("Some short notes...");
+    request.setPassword("password");
+
+    return request;
+  }
+
+  @Test
+  public void linkAttributesFromLocalRegistrationRequest() throws Exception {
+
+    RegistrationRequestDto r = createRegistrationRequest();
+    mvc
+      .perform(post("/registration/create").contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(r)))
+      .andExpect(status().isOk());
+
+    IamAccount account = iamAccountRepo.findByEmail("test-attributes@example.org")
+      .orElseThrow(() -> new AssertionError("Expected account not found"));
+    assertTrue(account.getAttributeByName(NICKNAME_ATTRIBUTE_KEY)
+      .get()
+      .getValue()
+      .equals("test-attributes"));
+
+    iamAccountRepo.delete(account);
+
+  }
+
+  @Test
+  @WithMockOIDCUser(subject = TEST_100_USER, issuer = OidcTestConfig.TEST_OIDC_ISSUER)
+  public void linkAttributesFromOidcRegistrationRequest() throws Exception {
+
+    String username = "test-oidc-subject";
+
+    String email = username + "@example.org";
+    RegistrationRequestDto request = new RegistrationRequestDto();
+    request.setGivenname("Test");
+    request.setFamilyname("User");
+    request.setEmail(email);
+    request.setUsername(username);
+    request.setNotes("Some short notes...");
+
+    mvc
+      .perform(post("/registration/create").contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsBytes(request)))
+      .andExpect(status().isOk());
+
+    IamAccount account = iamAccountRepo.findByOidcId(OidcTestConfig.TEST_OIDC_ISSUER, TEST_100_USER)
+      .orElseThrow(() -> new AssertionError("Expected account not found"));
+    assertTrue(
+        account.getAttributeByName(NICKNAME_ATTRIBUTE_KEY).get().getValue().equals(username));
+
+    iamAccountRepo.delete(account);
+  }
+
+  @Test
+  @WithMockSAMLUser(issuer = DEFAULT_IDP_ID, subject = T1_EPUID)
+  public void linkAttributesFromSamlRegistrationRequest() throws Throwable {
+
+    String username = "test-saml-ext-reg";
+
+    String email = username + "@example.org";
+    RegistrationRequestDto request = new RegistrationRequestDto();
+    request.setGivenname("Test");
+    request.setFamilyname("Saml User");
+    request.setEmail(email);
+    request.setUsername(username);
+    request.setNotes("Some short notes...");
+
+    mvc
+      .perform(post("/registration/create").contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsBytes(request)))
+      .andExpect(status().isOk());
+
+    IamSamlId id = new IamSamlId(DEFAULT_IDP_ID, Saml2Attribute.EPUID.getAttributeName(), T1_EPUID);
+
+    IamAccount account = iamAccountRepo.findBySamlId(id)
+      .orElseThrow(() -> new AssertionError("Expected account not found"));
+    assertTrue(
+        account.getAttributeByName(NICKNAME_ATTRIBUTE_KEY).get().getValue().equals(username));
+
+    iamAccountRepo.delete(account);
+  }
+
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/RegistrationAttributesTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/RegistrationAttributesTests.java
@@ -18,7 +18,6 @@ package it.infn.mw.iam.test.registration;
 import static it.infn.mw.iam.registration.DefaultRegistrationRequestService.NICKNAME_ATTRIBUTE_KEY;
 import static it.infn.mw.iam.test.ext_authn.saml.SamlAuthenticationTestSupport.DEFAULT_IDP_ID;
 import static it.infn.mw.iam.test.ext_authn.saml.SamlAuthenticationTestSupport.T1_EPUID;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/RegistrationUsernameTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/RegistrationUsernameTests.java
@@ -16,7 +16,7 @@
 package it.infn.mw.iam.test.registration;
 
 import static it.infn.mw.iam.registration.DefaultRegistrationRequestService.NICKNAME_ATTRIBUTE_KEY;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -35,7 +35,6 @@ import it.infn.mw.iam.persistence.model.IamAccount;
 import it.infn.mw.iam.persistence.repository.IamAccountRepository;
 import it.infn.mw.iam.registration.RegistrationRequestDto;
 import it.infn.mw.iam.test.api.TestSupport;
-import it.infn.mw.iam.test.ext_authn.oidc.OidcTestConfig;
 import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
 import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 
@@ -52,7 +51,7 @@ public class RegistrationUsernameTests extends TestSupport {
 
   @Autowired
   private MockMvc mvc;
-  
+
   @Autowired
   private IamAccountRepository iamAccountRepo;
 
@@ -92,12 +91,12 @@ public class RegistrationUsernameTests extends TestSupport {
           .content(objectMapper.writeValueAsString(r)))
         .andExpect(status().isOk());
     }
-    
-    IamAccount account = iamAccountRepo.findByUsername("bob")
-        .orElseThrow(() -> new AssertionError("Expected account not found"));
-      assertFalse(account.getAttributeByName(NICKNAME_ATTRIBUTE_KEY).get().getValue().equals("bob"));
 
-      iamAccountRepo.delete(account);
+    IamAccount account = iamAccountRepo.findByUsername("bob")
+      .orElseThrow(() -> new AssertionError("Expected account not found"));
+    assertTrue(account.getAttributeByName(NICKNAME_ATTRIBUTE_KEY).isEmpty());
+
+    iamAccountRepo.delete(account);
 
   }
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/RegistrationUsernameTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/RegistrationUsernameTests.java
@@ -15,6 +15,8 @@
  */
 package it.infn.mw.iam.test.registration;
 
+import static it.infn.mw.iam.registration.DefaultRegistrationRequestService.NICKNAME_ATTRIBUTE_KEY;
+import static org.junit.Assert.assertFalse;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -29,8 +31,11 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import it.infn.mw.iam.persistence.model.IamAccount;
+import it.infn.mw.iam.persistence.repository.IamAccountRepository;
 import it.infn.mw.iam.registration.RegistrationRequestDto;
 import it.infn.mw.iam.test.api.TestSupport;
+import it.infn.mw.iam.test.ext_authn.oidc.OidcTestConfig;
 import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
 import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 
@@ -47,6 +52,9 @@ public class RegistrationUsernameTests extends TestSupport {
 
   @Autowired
   private MockMvc mvc;
+  
+  @Autowired
+  private IamAccountRepository iamAccountRepo;
 
   @Before
   public void setup() {
@@ -84,6 +92,12 @@ public class RegistrationUsernameTests extends TestSupport {
           .content(objectMapper.writeValueAsString(r)))
         .andExpect(status().isOk());
     }
+    
+    IamAccount account = iamAccountRepo.findByUsername("bob")
+        .orElseThrow(() -> new AssertionError("Expected account not found"));
+      assertFalse(account.getAttributeByName(NICKNAME_ATTRIBUTE_KEY).get().getValue().equals("bob"));
+
+      iamAccountRepo.delete(account);
 
   }
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/SamlExtAuthRegistrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/SamlExtAuthRegistrationTests.java
@@ -21,7 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
@@ -150,8 +150,8 @@ public class SamlExtAuthRegistrationTests extends SamlAuthenticationTestSupport 
 
     IamAccount account = iamAccountRepo.findBySamlId(id)
       .orElseThrow(() -> new AssertionError("Expected account not found"));
-    assertFalse(
-        account.getAttributeByName(NICKNAME_ATTRIBUTE_KEY).get().getValue().equals(username));
+    assertTrue(account.getAttributeByName(NICKNAME_ATTRIBUTE_KEY).isEmpty());
+
 
     iamAccountRepo.delete(account);
   }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/SamlExtAuthRegistrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/SamlExtAuthRegistrationTests.java
@@ -16,10 +16,12 @@
 package it.infn.mw.iam.test.registration;
 
 import static it.infn.mw.iam.authn.ExternalAuthenticationHandlerSupport.EXT_AUTH_ERROR_KEY;
+import static it.infn.mw.iam.registration.DefaultRegistrationRequestService.NICKNAME_ATTRIBUTE_KEY;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
@@ -148,6 +150,8 @@ public class SamlExtAuthRegistrationTests extends SamlAuthenticationTestSupport 
 
     IamAccount account = iamAccountRepo.findBySamlId(id)
       .orElseThrow(() -> new AssertionError("Expected account not found"));
+    assertFalse(
+        account.getAttributeByName(NICKNAME_ATTRIBUTE_KEY).get().getValue().equals(username));
 
     iamAccountRepo.delete(account);
   }


### PR DESCRIPTION
Setting the property `iam.registration.add-nickname-as-attribute=true` (or the environment variable `IAM_ADD_NICKNAME_AS_ATTRIBUTE=true`), during user's registration request, his|her username is saved also as an attribute named "nickname".

Default value of this property is `false` to maintain backward compatibility.

This PR should solve issue https://github.com/indigo-iam/iam/issues/770.