### PR TITLE
Make PATCH to change aup signature time working for client credentials

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/aup/AupSignatureController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/aup/AupSignatureController.java
@@ -153,7 +153,7 @@ public class AupSignatureController {
     String principal = null;
 
     if (updaterAccount.isPresent()) {
-      principal = updaterAccount.get().getUuid();
+      principal = updaterAccount.get().getUsername();
       eventPublisher.publishEvent(AupSignedOnBehalfEvent.signedByUser(this, principal, signature));
     } else if (authentication instanceof OAuth2Authentication) {
       OAuth2Authentication oauth2Auth = (OAuth2Authentication) authentication;
@@ -186,7 +186,7 @@ public class AupSignatureController {
       String principal = null;
 
       if (deleterAccount.isPresent()) {
-        principal = deleterAccount.get().getUuid();
+        principal = deleterAccount.get().getUsername();
         eventPublisher
           .publishEvent(AupSignatureDeletedEvent.deletedByUser(this, principal, signature.get()));
       } else if (authentication instanceof OAuth2Authentication) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/aup/AupSignatureController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/aup/AupSignatureController.java
@@ -26,6 +26,8 @@ import javax.security.auth.login.AccountNotFoundException;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -57,7 +59,8 @@ import it.infn.mw.iam.persistence.repository.IamAupSignatureRepository;
 public class AupSignatureController {
 
   private static final String ACCOUNT_NOT_FOUND_FOR_ID_MESSAGE = "Account not found for id: %s";
-  private static final String ACCOUNT_NOT_FOUND_FOR_AUTHENTICATED_USER_MESSAGE = "Account not found for authenticated user";
+  private static final String ACCOUNT_NOT_FOUND_FOR_AUTHENTICATED_USER_MESSAGE =
+      "Account not found for authenticated user";
 
   private final AupSignatureConverter signatureConverter;
   private final AccountUtils accountUtils;
@@ -108,7 +111,7 @@ public class AupSignatureController {
   public AupSignatureDTO getSignature() throws AccountNotFoundException {
 
     IamAccount account = accountUtils.getAuthenticatedUserAccount()
-        .orElseThrow(accountNotFoundException(ACCOUNT_NOT_FOUND_FOR_AUTHENTICATED_USER_MESSAGE));
+      .orElseThrow(accountNotFoundException(ACCOUNT_NOT_FOUND_FOR_AUTHENTICATED_USER_MESSAGE));
 
     IamAup aup = aupRepo.findDefaultAup().orElseThrow(aupNotFoundException());
     IamAupSignature sig =
@@ -118,7 +121,8 @@ public class AupSignatureController {
 
   @GetMapping(value = "/iam/aup/signature/{accountId}")
   @PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM') or #iam.isUser(#accountId)")
-  public AupSignatureDTO getSignatureForAccount(@PathVariable String accountId) throws AccountNotFoundException {
+  public AupSignatureDTO getSignatureForAccount(@PathVariable String accountId)
+      throws AccountNotFoundException {
 
     IamAccount account = accountUtils.getByAccountId(accountId)
       .orElseThrow(accountNotFoundException(format(ACCOUNT_NOT_FOUND_FOR_ID_MESSAGE, accountId)));
@@ -133,10 +137,10 @@ public class AupSignatureController {
   @PatchMapping(value = "/iam/aup/signature/{accountId}")
   @ResponseStatus(value = HttpStatus.CREATED)
   @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
-  public AupSignatureDTO updateSignatureForAccount(@PathVariable String accountId) throws AccountNotFoundException {
+  public AupSignatureDTO updateSignatureForAccount(@PathVariable String accountId,
+      Authentication authentication) throws AccountNotFoundException {
 
-    IamAccount updaterAccount = accountUtils.getAuthenticatedUserAccount()
-        .orElseThrow(accountNotFoundException(ACCOUNT_NOT_FOUND_FOR_AUTHENTICATED_USER_MESSAGE));
+    Optional<IamAccount> updaterAccount = accountUtils.getAuthenticatedUserAccount();
 
     IamAccount account = accountUtils.getByAccountId(accountId)
       .orElseThrow(accountNotFoundException(format(ACCOUNT_NOT_FOUND_FOR_ID_MESSAGE, accountId)));
@@ -144,7 +148,19 @@ public class AupSignatureController {
     Date now = new Date(timeProvider.currentTimeMillis());
 
     IamAupSignature signature = signatureRepo.createSignatureForAccount(aup, account, now);
-    eventPublisher.publishEvent(new AupSignedOnBehalfEvent(this, signature, updaterAccount.getUsername()));
+    if (updaterAccount.isPresent()) {
+      eventPublisher.publishEvent(
+          new AupSignedOnBehalfEvent(this, signature, updaterAccount.get().getUuid(), false));
+    } else {
+      String clientId = null;
+
+      if (authentication instanceof OAuth2Authentication) {
+        OAuth2Authentication oauth2Auth = (OAuth2Authentication) authentication;
+        clientId = oauth2Auth.getOAuth2Request().getClientId();
+      }
+
+      eventPublisher.publishEvent(new AupSignedOnBehalfEvent(this, signature, clientId, true));
+    }
 
     return signatureConverter.dtoFromEntity(signature);
   }
@@ -152,10 +168,11 @@ public class AupSignatureController {
   @DeleteMapping(value = "/iam/aup/signature/{accountId}")
   @ResponseStatus(value = HttpStatus.NO_CONTENT)
   @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
-  public void deleteSignatureForAccount(@PathVariable String accountId) throws AccountNotFoundException {
+  public void deleteSignatureForAccount(@PathVariable String accountId)
+      throws AccountNotFoundException {
 
     IamAccount deleterAccount = accountUtils.getAuthenticatedUserAccount()
-        .orElseThrow(accountNotFoundException(ACCOUNT_NOT_FOUND_FOR_AUTHENTICATED_USER_MESSAGE));
+      .orElseThrow(accountNotFoundException(ACCOUNT_NOT_FOUND_FOR_AUTHENTICATED_USER_MESSAGE));
     IamAccount signatureAccount = accountUtils.getByAccountId(accountId)
       .orElseThrow(accountNotFoundException(format(ACCOUNT_NOT_FOUND_FOR_ID_MESSAGE, accountId)));
 
@@ -166,7 +183,8 @@ public class AupSignatureController {
 
     if (signature.isPresent()) {
       signatureRepo.deleteSignatureForAccount(aup, signatureAccount);
-      eventPublisher.publishEvent(new AupSignatureDeletedEvent(this, deleterAccount.getUsername(), signature.get()));
+      eventPublisher.publishEvent(
+          new AupSignatureDeletedEvent(this, deleterAccount.getUsername(), signature.get()));
     }
   }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/IamAuditApplicationEvent.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/IamAuditApplicationEvent.java
@@ -29,22 +29,22 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 
 @JsonPropertyOrder({"timestamp", "@type", "category", "principal", "message"})
-@JsonTypeInfo(use=Id.NAME, property="@type")
+@JsonTypeInfo(use = Id.NAME, property = "@type")
 public abstract class IamAuditApplicationEvent extends ApplicationEvent {
 
   private static final long serialVersionUID = -6276169409979227109L;
-  
+
   public static final String NULL_PRINCIPAL = "<unknown>";
 
   @JsonInclude
   private final IamEventCategory category;
-  
+
   @JsonInclude
   private final String principal;
-  
+
   @JsonInclude
   private final String message;
-  
+
 
   public IamAuditApplicationEvent(IamEventCategory category, Object source, String message) {
     super(source);
@@ -57,6 +57,14 @@ public abstract class IamAuditApplicationEvent extends ApplicationEvent {
     } else {
       this.principal = auth.getName();
     }
+  }
+
+  public IamAuditApplicationEvent(IamEventCategory category, Object source, String message,
+      String principal) {
+    super(source);
+    this.message = message;
+    this.category = category;
+    this.principal = principal != null ? principal : NULL_PRINCIPAL;
   }
 
   protected IamAuditApplicationEvent(IamEventCategory category, Object source) {
@@ -80,9 +88,9 @@ public abstract class IamAuditApplicationEvent extends ApplicationEvent {
   public Object getSource() {
     return super.getSource();
   }
-  
+
   @JsonProperty("source")
-  public String getSourceClass(){
+  public String getSourceClass() {
     return super.getSource().getClass().getSimpleName();
   }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/IamAuditApplicationEvent.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/IamAuditApplicationEvent.java
@@ -45,26 +45,16 @@ public abstract class IamAuditApplicationEvent extends ApplicationEvent {
   @JsonInclude
   private final String message;
 
-
   public IamAuditApplicationEvent(IamEventCategory category, Object source, String message) {
-    super(source);
-    this.message = message;
-    this.category = category;
-    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-
-    if (auth == null) {
-      this.principal = NULL_PRINCIPAL;
-    } else {
-      this.principal = auth.getName();
-    }
+    this(category, source, message, SecurityContextHolder.getContext().getAuthentication());
   }
 
   public IamAuditApplicationEvent(IamEventCategory category, Object source, String message,
-      String principal) {
+      Authentication auth) {
     super(source);
-    this.message = message;
     this.category = category;
-    this.principal = principal != null ? principal : NULL_PRINCIPAL;
+    this.message = message;
+    this.principal = (auth != null) ? auth.getName() : NULL_PRINCIPAL;
   }
 
   protected IamAuditApplicationEvent(IamEventCategory category, Object source) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/aup/AupSignatureDeletedEvent.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/aup/AupSignatureDeletedEvent.java
@@ -34,10 +34,15 @@ public class AupSignatureDeletedEvent extends IamAuditApplicationEvent {
   @JsonSerialize(using = IamAupSignatureSerializer.class)
   final IamAupSignature signature;
 
-  public AupSignatureDeletedEvent(Object source, String actor, IamAupSignature signature) {
+  public AupSignatureDeletedEvent(Object source, String actor, IamAupSignature signature,
+      boolean isClient) {
     super(IamEventCategory.AUP, source,
-        format("Administrator %s requested AUP signature to the user %s", actor,
-            signature.getAccount().getUsername()));
+        isClient
+            ? format("Client %s deleted the AUP signature of %s user", actor,
+                signature.getAccount().getUsername())
+            : format("User %s deleted the AUP signature of %s user", actor,
+                signature.getAccount().getUsername()),
+        isClient ? "client: " + actor : "user: " + actor);
     this.signature = signature;
   }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/aup/AupSignatureDeletedEvent.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/aup/AupSignatureDeletedEvent.java
@@ -15,8 +15,6 @@
  */
 package it.infn.mw.iam.audit.events.aup;
 
-import static java.lang.String.format;
-
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import it.infn.mw.iam.audit.events.IamAuditApplicationEvent;
@@ -34,16 +32,23 @@ public class AupSignatureDeletedEvent extends IamAuditApplicationEvent {
   @JsonSerialize(using = IamAupSignatureSerializer.class)
   final IamAupSignature signature;
 
-  public AupSignatureDeletedEvent(Object source, String actor, IamAupSignature signature,
-      boolean isClient) {
-    super(IamEventCategory.AUP, source,
-        isClient
-            ? format("Client %s deleted the AUP signature of %s user", actor,
-                signature.getAccount().getUsername())
-            : format("User %s deleted the AUP signature of %s user", actor,
-                signature.getAccount().getUsername()),
-        isClient ? "client: " + actor : "user: " + actor);
+  public AupSignatureDeletedEvent(Object source, String message, IamAupSignature signature) {
+    super(IamEventCategory.AUP, source, message);
     this.signature = signature;
+  }
+
+  public static AupSignatureDeletedEvent deletedByClient(Object source, String clientId,
+      IamAupSignature signature) {
+    String message = String.format("Client %s deleted the AUP signature of %s user", clientId,
+        signature.getAccount().getUsername());
+    return new AupSignatureDeletedEvent(source, message, signature);
+  }
+
+  public static AupSignatureDeletedEvent deletedByUser(Object source, String userId,
+      IamAupSignature signature) {
+    String message = String.format("User %s deleted the AUP signature of %s user", userId,
+        signature.getAccount().getUsername());
+    return new AupSignatureDeletedEvent(source, message, signature);
   }
 
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/aup/AupSignedOnBehalfEvent.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/aup/AupSignedOnBehalfEvent.java
@@ -34,9 +34,15 @@ public class AupSignedOnBehalfEvent extends IamAuditApplicationEvent {
   @JsonSerialize(using = IamAupSignatureSerializer.class)
   final IamAupSignature signature;
 
-  public AupSignedOnBehalfEvent(Object source, IamAupSignature signature, String signedBy) {
-    super(IamEventCategory.AUP, source, format("Administrator %s signed the AUP on behalf of %s",
-        signedBy, signature.getAccount().getUsername()));
+  public AupSignedOnBehalfEvent(Object source, IamAupSignature signature, String signedBy,
+      boolean isClient) {
+    super(IamEventCategory.AUP, source,
+        isClient
+            ? format("Client %s signed the AUP on behalf of %s user", signedBy,
+                signature.getAccount().getUsername())
+            : format("User %s signed the AUP on behalf of %s user", signedBy,
+                signature.getAccount().getUsername()),
+        isClient ? "client: " + signedBy : "user: " + signedBy);
     this.signature = signature;
   }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/aup/AupSignedOnBehalfEvent.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/aup/AupSignedOnBehalfEvent.java
@@ -15,8 +15,6 @@
  */
 package it.infn.mw.iam.audit.events.aup;
 
-import static java.lang.String.format;
-
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import it.infn.mw.iam.audit.events.IamAuditApplicationEvent;
@@ -34,15 +32,23 @@ public class AupSignedOnBehalfEvent extends IamAuditApplicationEvent {
   @JsonSerialize(using = IamAupSignatureSerializer.class)
   final IamAupSignature signature;
 
-  public AupSignedOnBehalfEvent(Object source, IamAupSignature signature, String signedBy,
-      boolean isClient) {
-    super(IamEventCategory.AUP, source,
-        isClient
-            ? format("Client %s signed the AUP on behalf of %s user", signedBy,
-                signature.getAccount().getUsername())
-            : format("User %s signed the AUP on behalf of %s user", signedBy,
-                signature.getAccount().getUsername()),
-        isClient ? "client: " + signedBy : "user: " + signedBy);
+  public AupSignedOnBehalfEvent(Object source, String message, IamAupSignature signature) {
+    super(IamEventCategory.AUP, source, message);
     this.signature = signature;
   }
+
+  public static AupSignedOnBehalfEvent signedByClient(Object source, String clientId,
+      IamAupSignature signature) {
+    String message = String.format("Client %s signed the AUP on behalf of %s user", clientId,
+        signature.getAccount().getUsername());
+    return new AupSignedOnBehalfEvent(source, message, signature);
+  }
+
+  public static AupSignedOnBehalfEvent signedByUser(Object source, String userId,
+      IamAupSignature signature) {
+    String message = String.format("User %s signed the AUP on behalf of %s user", userId,
+        signature.getAccount().getUsername());
+    return new AupSignedOnBehalfEvent(source, message, signature);
+  }
+
 }


### PR DESCRIPTION
AUDIT logs are now:

```
// Client credentials flow (note that client-cred is the client id)
2024-07-15 14:10:46.479  INFO 30339 --- [nio-8080-exec-2] AUDIT                                    : {"@type":"AupSignedOnBehalfEvent","timestamp":1721045446477,"category":"AUP","principal":"client-cred","message":"Client client-cred signed the AUP on behalf of test user","signature":{"aupId":1,"username":"test","signatureTime":"2024-07-15T14:10:46.476+02:00"},"source":"AupSignatureController"}
2024-07-15 14:11:56.215  INFO 30339 --- [io-8080-exec-10] AUDIT                                    : {"@type":"AupSignatureDeletedEvent","timestamp":1721045516214,"category":"AUP","principal":"client-cred","message":"Client client-cred deleted the AUP signature of test user","signature":{"aupId":1,"username":"test","signatureTime":"2024-07-15T14:10:46.476+02:00"},"source":"AupSignatureController"}

// Other flows linked to user identity
2024-07-15 14:13:08.435  INFO 30339 --- [nio-8080-exec-3] AUDIT                                    : {"@type":"AupSignedOnBehalfEvent","timestamp":1721045588435,"category":"AUP","principal":"admin","message":"User admin signed the AUP on behalf of test_102 user","signature":{"aupId":1,"username":"test_102","signatureTime":"2024-07-15T14:13:08.434+02:00"},"source":"AupSignatureController"}
2024-07-15 14:13:20.677  INFO 30339 --- [nio-8080-exec-4] AUDIT                                    : {"@type":"AupSignatureDeletedEvent","timestamp":1721045600677,"category":"AUP","principal":"admin","message":"User admin deleted the AUP signature of test_102 user","signature":{"aupId":1,"username":"test_102","signatureTime":"2024-07-15T14:13:08.434+02:00"},"source":"AupSignatureController"}
```

