### PR TITLE
Specify the organization name in the email subject

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/aup/AupSignatureController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/aup/AupSignatureController.java
@@ -48,6 +48,7 @@ import it.infn.mw.iam.audit.events.aup.AupSignatureDeletedEvent;
 import it.infn.mw.iam.audit.events.aup.AupSignedEvent;
 import it.infn.mw.iam.audit.events.aup.AupSignedOnBehalfEvent;
 import it.infn.mw.iam.core.time.TimeProvider;
+import it.infn.mw.iam.notification.NotificationFactory;
 import it.infn.mw.iam.persistence.model.IamAccount;
 import it.infn.mw.iam.persistence.model.IamAup;
 import it.infn.mw.iam.persistence.model.IamAupSignature;
@@ -69,15 +70,17 @@ public class AupSignatureController {
   private final IamAupRepository aupRepo;
   private final TimeProvider timeProvider;
   private final ApplicationEventPublisher eventPublisher;
+  private final NotificationFactory notificationFactory;
   public AupSignatureController(AupSignatureConverter conv, AccountUtils utils,
       IamAupSignatureRepository signatureRepo, IamAupRepository aupRepo, TimeProvider timeProvider,
-      ApplicationEventPublisher publisher) {
+      ApplicationEventPublisher publisher, NotificationFactory notificationFactory) {
     this.signatureConverter = conv;
     this.accountUtils = utils;
     this.signatureRepo = signatureRepo;
     this.aupRepo = aupRepo;
     this.timeProvider = timeProvider;
     this.eventPublisher = publisher;
+    this.notificationFactory = notificationFactory;
   }
 
   private Supplier<AupNotFoundError> aupNotFoundException() {
@@ -194,6 +197,7 @@ public class AupSignatureController {
         eventPublisher
           .publishEvent(AupSignatureDeletedEvent.deletedByClient(this, principal, signature.get()));
       }
+      notificationFactory.createAupSignatureRequestMessage(signatureAccount);
     }
   }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/notification/TransientNotificationFactory.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/notification/TransientNotificationFactory.java
@@ -206,7 +206,7 @@ public class TransientNotificationFactory implements NotificationFactory {
     model.put("indigoDashboardUrl", String.format("%s/dashboard#!/requests", baseUrl));
     model.put(ORGANISATION_NAME, organisationName);
 
-    String subject = String.format("New membership request for group %s", groupName);
+    String subject = String.format("[%s IAM] New membership request for group %s", organisationName, groupName);
 
     LOG.debug("Create group membership admin notification for request {}", groupRequest.getUuid());
     return createMessage("adminHandleGroupRequest.ftl", model, IamNotificationType.GROUP_MEMBERSHIP,
@@ -227,7 +227,7 @@ public class TransientNotificationFactory implements NotificationFactory {
     model.put(ORGANISATION_NAME, organisationName);
 
     String subject =
-        String.format("Membership request for group %s has been %s", groupName, status);
+        String.format("[%s IAM] Membership request for group %s has been %s", organisationName, groupName, status);
 
     IamEmailNotification notification =
         createMessage("groupMembershipApproved.ftl", model, IamNotificationType.GROUP_MEMBERSHIP,
@@ -251,7 +251,7 @@ public class TransientNotificationFactory implements NotificationFactory {
     model.put(ORGANISATION_NAME, organisationName);
 
     String subject =
-        String.format("Membership request for group %s has been %s", groupName, status);
+        String.format("[%s IAM] Membership request for group %s has been %s", organisationName, groupName, status);
 
     IamEmailNotification notification =
         createMessage("groupMembershipRejected.ftl", model, IamNotificationType.GROUP_MEMBERSHIP,

--- a/iam-login-service/src/main/java/it/infn/mw/iam/notification/TransientNotificationFactory.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/notification/TransientNotificationFactory.java
@@ -272,7 +272,7 @@ public class TransientNotificationFactory implements NotificationFactory {
     model.put("isClientActive", client.isActive());
     model.put(ORGANISATION_NAME, organisationName);
 
-    String subject = "Changed client status";
+    String subject = String.format("[%s IAM] Changed client status", organisationName);
 
     for (IamAccount a : accounts) {
       recipients.add(a.getUserInfo().getEmail());
@@ -314,7 +314,7 @@ public class TransientNotificationFactory implements NotificationFactory {
     model.put(ORGANISATION_NAME, organisationName);
     model.put("missingDays", missingDays);
 
-    String subject = "AUP signature reminder";
+    String subject = String.format("[%s IAM] AUP signature reminder", organisationName);
 
     IamEmailNotification notification = createMessage("signAupReminder.ftl", model,
         IamNotificationType.AUP_REMINDER, subject, asList(account.getUserInfo().getEmail()));
@@ -335,7 +335,7 @@ public class TransientNotificationFactory implements NotificationFactory {
     model.put(AUP_URL, aupUrl);
     model.put(ORGANISATION_NAME, organisationName);
 
-    String subject = "AUP signature expiration";
+    String subject = String.format("[%s IAM] AUP signature expiration", organisationName);
 
     IamEmailNotification notification = createMessage("aupExpirationMessage.ftl", model,
         IamNotificationType.AUP_EXPIRATION, subject, asList(account.getUserInfo().getEmail()));
@@ -357,7 +357,7 @@ public class TransientNotificationFactory implements NotificationFactory {
     model.put(AUP_URL, aupUrl);
     model.put(ORGANISATION_NAME, organisationName);
 
-    String subject = "AUP signature request";
+    String subject = String.format("[%s IAM] AUP signature request", organisationName);
 
     IamEmailNotification notification =
         createMessage("aupSignatureRequest.ftl", model, IamNotificationType.AUP_SIGNATURE_REQUEST,
@@ -377,7 +377,7 @@ public class TransientNotificationFactory implements NotificationFactory {
     model.put(RECIPIENT_FIELD, recipient);
     model.put(ORGANISATION_NAME, organisationName);
 
-    String subject = "Account suspended";
+    String subject = String.format("[%s IAM] Account suspended", organisationName);
 
     IamEmailNotification notification = createMessage("accountSuspended.ftl", model,
         IamNotificationType.ACCOUNT_SUSPENDED, subject, asList(account.getUserInfo().getEmail()));
@@ -395,7 +395,7 @@ public class TransientNotificationFactory implements NotificationFactory {
     model.put(RECIPIENT_FIELD, recipient);
     model.put(ORGANISATION_NAME, organisationName);
 
-    String subject = "Account restored";
+    String subject = String.format("[%s IAM] Account restored", organisationName);
 
     IamEmailNotification notification = createMessage("accountRestored.ftl", model,
         IamNotificationType.ACCOUNT_RESTORED, subject, asList(account.getUserInfo().getEmail()));

--- a/iam-login-service/src/main/java/it/infn/mw/iam/notification/TransientNotificationFactory.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/notification/TransientNotificationFactory.java
@@ -206,7 +206,7 @@ public class TransientNotificationFactory implements NotificationFactory {
     model.put("indigoDashboardUrl", String.format("%s/dashboard#!/requests", baseUrl));
     model.put(ORGANISATION_NAME, organisationName);
 
-    String subject = String.format("[%s IAM] New membership request for group %s", organisationName, groupName);
+    String subject = String.format("New membership request for group %s", groupName);
 
     LOG.debug("Create group membership admin notification for request {}", groupRequest.getUuid());
     return createMessage("adminHandleGroupRequest.ftl", model, IamNotificationType.GROUP_MEMBERSHIP,
@@ -227,7 +227,7 @@ public class TransientNotificationFactory implements NotificationFactory {
     model.put(ORGANISATION_NAME, organisationName);
 
     String subject =
-        String.format("[%s IAM] Membership request for group %s has been %s", organisationName, groupName, status);
+        String.format("Membership request for group %s has been %s", groupName, status);
 
     IamEmailNotification notification =
         createMessage("groupMembershipApproved.ftl", model, IamNotificationType.GROUP_MEMBERSHIP,
@@ -251,7 +251,7 @@ public class TransientNotificationFactory implements NotificationFactory {
     model.put(ORGANISATION_NAME, organisationName);
 
     String subject =
-        String.format("[%s IAM] Membership request for group %s has been %s", organisationName, groupName, status);
+        String.format("Membership request for group %s has been %s", groupName, status);
 
     IamEmailNotification notification =
         createMessage("groupMembershipRejected.ftl", model, IamNotificationType.GROUP_MEMBERSHIP,
@@ -272,7 +272,7 @@ public class TransientNotificationFactory implements NotificationFactory {
     model.put("isClientActive", client.isActive());
     model.put(ORGANISATION_NAME, organisationName);
 
-    String subject = String.format("[%s IAM] Changed client status", organisationName);
+    String subject = "Changed client status";
 
     for (IamAccount a : accounts) {
       recipients.add(a.getUserInfo().getEmail());
@@ -314,7 +314,7 @@ public class TransientNotificationFactory implements NotificationFactory {
     model.put(ORGANISATION_NAME, organisationName);
     model.put("missingDays", missingDays);
 
-    String subject = String.format("[%s IAM] AUP signature reminder", organisationName);
+    String subject = "AUP signature reminder";
 
     IamEmailNotification notification = createMessage("signAupReminder.ftl", model,
         IamNotificationType.AUP_REMINDER, subject, asList(account.getUserInfo().getEmail()));
@@ -335,7 +335,7 @@ public class TransientNotificationFactory implements NotificationFactory {
     model.put(AUP_URL, aupUrl);
     model.put(ORGANISATION_NAME, organisationName);
 
-    String subject = String.format("[%s IAM] AUP signature expiration", organisationName);
+    String subject = "AUP signature expiration";
 
     IamEmailNotification notification = createMessage("aupExpirationMessage.ftl", model,
         IamNotificationType.AUP_EXPIRATION, subject, asList(account.getUserInfo().getEmail()));
@@ -357,7 +357,7 @@ public class TransientNotificationFactory implements NotificationFactory {
     model.put(AUP_URL, aupUrl);
     model.put(ORGANISATION_NAME, organisationName);
 
-    String subject = String.format("[%s IAM] AUP signature request", organisationName);
+    String subject = "AUP signature request";
 
     IamEmailNotification notification =
         createMessage("aupSignatureRequest.ftl", model, IamNotificationType.AUP_SIGNATURE_REQUEST,
@@ -377,7 +377,7 @@ public class TransientNotificationFactory implements NotificationFactory {
     model.put(RECIPIENT_FIELD, recipient);
     model.put(ORGANISATION_NAME, organisationName);
 
-    String subject = String.format("[%s IAM] Account suspended", organisationName);
+    String subject = "Account suspended";
 
     IamEmailNotification notification = createMessage("accountSuspended.ftl", model,
         IamNotificationType.ACCOUNT_SUSPENDED, subject, asList(account.getUserInfo().getEmail()));
@@ -410,6 +410,7 @@ public class TransientNotificationFactory implements NotificationFactory {
       IamNotificationType messageType, String subject, List<String> receiverAddress) {
 
     try {
+      String formattedSubject = String.format("[%s IAM] %s", organisationName, subject);
       Template template = freeMarkerConfiguration.getTemplate(templateName);
       String body = FreeMarkerTemplateUtils.processTemplateIntoString(template, model);
 
@@ -417,7 +418,7 @@ public class TransientNotificationFactory implements NotificationFactory {
 
       message.setUuid(UUID.randomUUID().toString());
       message.setType(messageType);
-      message.setSubject(subject);
+      message.setSubject(formattedSubject);
       message.setBody(body);
       message.setCreationTime(new Date());
       message.setDeliveryStatus(IamDeliveryStatus.PENDING);

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/notification/RegistrationFlowNotificationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/notification/RegistrationFlowNotificationTests.java
@@ -110,6 +110,10 @@ public class RegistrationFlowNotificationTests {
     notificationDelivery.clearDeliveredNotifications();
   }
 
+  public String formatSubject(String key) {
+    return String.format("[%s IAM] %s", organisationName, properties.getSubject().get(key));
+  }
+
   @Test
   public void testSendWithEmptyQueue() {
 
@@ -145,7 +149,7 @@ public class RegistrationFlowNotificationTests {
 
     IamEmailNotification message = notificationDelivery.getDeliveredNotifications().get(0);
 
-    assertThat(message.getSubject(), equalTo(properties.getSubject().get("confirmation")));
+    assertThat(message.getSubject(), equalTo(formatSubject("confirmation")));
 
     notificationDelivery.clearDeliveredNotifications();
 
@@ -161,7 +165,7 @@ public class RegistrationFlowNotificationTests {
 
     message = notificationDelivery.getDeliveredNotifications().get(0);
 
-    assertThat(message.getSubject(), equalTo(properties.getSubject().get("adminHandleRequest")));
+    assertThat(message.getSubject(), equalTo(formatSubject("adminHandleRequest")));
 
     assertThat(message.getReceivers(), hasSize(1));
     assertThat(message.getReceivers().get(0).getEmailAddress(),
@@ -180,7 +184,7 @@ public class RegistrationFlowNotificationTests {
 
     message = notificationDelivery.getDeliveredNotifications().get(0);
 
-    assertThat(message.getSubject(), equalTo(properties.getSubject().get("activated")));
+    assertThat(message.getSubject(), equalTo(formatSubject("activated")));
     assertThat(message.getBody(), containsString(request.getUsername()));
 
   }
@@ -212,7 +216,7 @@ public class RegistrationFlowNotificationTests {
 
     IamEmailNotification message = notificationDelivery.getDeliveredNotifications().get(0);
 
-    assertThat(message.getSubject(), equalTo(properties.getSubject().get("confirmation")));
+    assertThat(message.getSubject(), equalTo(formatSubject("confirmation")));
 
     notificationDelivery.clearDeliveredNotifications();
 
@@ -228,7 +232,7 @@ public class RegistrationFlowNotificationTests {
 
     message = notificationDelivery.getDeliveredNotifications().get(0);
 
-    assertThat(message.getSubject(), equalTo(properties.getSubject().get("adminHandleRequest")));
+    assertThat(message.getSubject(), equalTo(formatSubject("adminHandleRequest")));
 
     assertThat(message.getReceivers(), hasSize(1));
     assertThat(message.getReceivers().get(0).getEmailAddress(),
@@ -247,7 +251,7 @@ public class RegistrationFlowNotificationTests {
 
     message = notificationDelivery.getDeliveredNotifications().get(0);
 
-    assertThat(message.getSubject(), equalTo(properties.getSubject().get("rejected")));
+    assertThat(message.getSubject(), equalTo(formatSubject("rejected")));
     assertThat(message.getBody(),
         not(containsString("The administrator has provided the following motivation")));
 
@@ -280,7 +284,7 @@ public class RegistrationFlowNotificationTests {
 
     IamEmailNotification message = notificationDelivery.getDeliveredNotifications().get(0);
 
-    assertThat(message.getSubject(), equalTo(properties.getSubject().get("confirmation")));
+    assertThat(message.getSubject(), equalTo(formatSubject("confirmation")));
 
     notificationDelivery.clearDeliveredNotifications();
 
@@ -296,7 +300,7 @@ public class RegistrationFlowNotificationTests {
 
     message = notificationDelivery.getDeliveredNotifications().get(0);
 
-    assertThat(message.getSubject(), equalTo(properties.getSubject().get("adminHandleRequest")));
+    assertThat(message.getSubject(), equalTo(formatSubject("adminHandleRequest")));
 
     assertThat(message.getReceivers(), hasSize(1));
     assertThat(message.getReceivers().get(0).getEmailAddress(),
@@ -317,11 +321,10 @@ public class RegistrationFlowNotificationTests {
 
     message = notificationDelivery.getDeliveredNotifications().get(0);
 
-    assertThat(message.getSubject(), equalTo(properties.getSubject().get("rejected")));
+    assertThat(message.getSubject(), equalTo(formatSubject("rejected")));
     assertThat(message.getBody(),
         containsString("The administrator has provided the following motivation"));
-    assertThat(message.getBody(),
-        containsString("We hate you"));
+    assertThat(message.getBody(), containsString("We hate you"));
 
   }
 


### PR DESCRIPTION
This PR ensures that all the subjects of the various emails have a prefix, equal to `[VO name + IAM]`, e.g.
in case of ATLAS VO all email subjects will be `[atlas IAM] ...`