### PR TITLE
Grant admin scopes to admin-approved clients only

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/AccountUtils.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/AccountUtils.java
@@ -19,7 +19,6 @@ import static java.util.Objects.isNull;
 
 import java.util.Optional;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -35,7 +34,6 @@ import it.infn.mw.iam.persistence.repository.IamAccountRepository;
 public class AccountUtils {
   IamAccountRepository accountRepo;
 
-  @Autowired
   public AccountUtils(IamAccountRepository accountRepo) {
     this.accountRepo = accountRepo;
   }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/IamOAuthConfirmationController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/IamOAuthConfirmationController.java
@@ -25,6 +25,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.http.client.utils.URIBuilder;
 import org.mitre.oauth2.model.ClientDetailsEntity;
@@ -103,6 +104,8 @@ public class IamOAuthConfirmationController {
    */
   private static final Logger logger =
       LoggerFactory.getLogger(IamOAuthConfirmationController.class);
+
+  private static final Set<String> adminScopes = Set.of("iam:admin.read", "iam:admin.write");
 
   public IamOAuthConfirmationController() {
 
@@ -187,6 +190,12 @@ public class IamOAuthConfirmationController {
 
     Set<String> filteredScopes = pdp.filterScopes(scopeService.toStrings(scopes), account);
 
+    // admin scopes are not allowed to clients approved by regular users
+    if (!accountUtils.isAdmin(authUser)) {
+      filteredScopes =
+          filteredScopes.stream().filter(s -> !adminScopes.contains(s)).collect(Collectors.toSet());
+    }
+
     // sort scopes for display based on the inherent order of system scopes
     for (SystemScope s : systemScopes) {
       if (scopeService.fromStrings(filteredScopes).contains(s)) {
@@ -195,7 +204,7 @@ public class IamOAuthConfirmationController {
     }
 
     // add in any scopes that aren't system scopes to the end of the list
-    sortedScopes.addAll(Sets.difference(scopes, systemScopes));
+    sortedScopes.addAll(Sets.difference(scopeService.fromStrings(filteredScopes), systemScopes));
 
     model.put("scopes", sortedScopes);
 
@@ -230,7 +239,7 @@ public class IamOAuthConfirmationController {
 
 
     // contacts
-    if (client.getContacts() != null) {
+    if (!client.getContacts().isEmpty()) {
       String contacts = Joiner.on(", ").join(client.getContacts());
       model.put("contacts", contacts);
     }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/authzcode/AuthorizationCodeIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/authzcode/AuthorizationCodeIntegrationTests.java
@@ -444,28 +444,28 @@ public class AuthorizationCodeIntegrationTests {
     .when()
         .get("/iam/group/c617d586-54e6-411d-8e38-649677980001/attributes")
     .then()
-        .statusCode(HttpStatus.OK.value());
+        .statusCode(HttpStatus.FORBIDDEN.value());
 
     RestAssured.given()
         .header("Authorization", "Bearer " + refreshedToken)
     .when()
         .get("/iam/me/authorities")
     .then()
-        .statusCode(HttpStatus.OK.value());
+        .statusCode(HttpStatus.FORBIDDEN.value());
 
     RestAssured.given()
         .header("Authorization", "Bearer " + refreshedToken)
     .when()
         .get("/iam/api/clients")
     .then()
-        .statusCode(HttpStatus.OK.value());
+        .statusCode(HttpStatus.FORBIDDEN.value());
 
     RestAssured.given()
         .header("Authorization", "Bearer " + refreshedToken)
     .when()
         .get("/iam/scope_policies")
     .then()
-        .statusCode(HttpStatus.OK.value());    
+        .statusCode(HttpStatus.FORBIDDEN.value());
         // @formatter:on
 
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/scope/ScopesFilterTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/scope/ScopesFilterTests.java
@@ -18,10 +18,9 @@ package it.infn.mw.iam.test.oauth.scope;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
-import static org.junit.Assert.assertThat;
 
-import java.io.IOException;
 import java.util.List;
 
 import javax.persistence.EntityManager;
@@ -38,9 +37,6 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-
-import freemarker.core.ParseException;
 import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
 import it.infn.mw.iam.IamLoginService;
@@ -63,6 +59,7 @@ public class ScopesFilterTests extends ScopePolicyTestUtils {
   public static final String RESPONSE_TYPE_CODE = "code";
   public static final String EMAIL = "email";
   public static final String SCOPE = "openid email";
+  public static final String SCOPE_ADMIN = "iam:admin.write";
   public static final String LOCALHOST_URL_TEMPLATE = "http://localhost:%d";
   public static final String TEST_CLIENT_REDIRECT_URI =
       "https://iam.local.io/iam-test-client/openid_connect_login";
@@ -103,8 +100,7 @@ public class ScopesFilterTests extends ScopePolicyTestUtils {
   }
 
   @Test
-  public void testConsentPageReturnsFilteredScopes()
-      throws JsonProcessingException, IOException, ParseException {
+  public void testConsentPageReturnsFilteredScopes() {
 
     IamAccount testAccount = findTestAccount();
 
@@ -175,6 +171,116 @@ public class ScopesFilterTests extends ScopePolicyTestUtils {
     } finally {
       policyScopeRepo.delete(up);
     }
+
+  }
+
+  @Test
+  public void testConsentPageDoesNotReturnAdminScopeToRegularUser() {
+
+    // @formatter:off
+    ValidatableResponse authzResponse = RestAssured.given()
+      .queryParam("response_type", RESPONSE_TYPE_CODE)
+      .queryParam("client_id", "admin-client-rw")
+      .queryParam("redirect_uri", TEST_CLIENT_REDIRECT_URI)
+      .queryParam("scope", SCOPE_ADMIN)
+      .queryParam("nonce", "1")
+      .queryParam("state", "1")
+      .redirects().follow(false)
+    .when()
+      .get(authorizeUrl)
+    .then()
+      .log().all()
+      .statusCode(HttpStatus.FOUND.value());
+    // @formatter:on
+
+    // @formatter:off
+    ValidatableResponse loginResponse = RestAssured.given()
+      .cookie(authzResponse.extract().detailedCookie(SESSION))
+      .formParam("username", "test")
+      .formParam("password", "password")
+      .formParam("submit", "Login")
+      .redirects().follow(false)
+    .when()
+      .post(loginUrl)
+    .then()
+      .log().all()
+      .statusCode(HttpStatus.FOUND.value());
+    // @formatter:on
+
+    // @formatter:off
+    String responseBody = RestAssured.given()
+      .cookie(loginResponse.extract().detailedCookie(SESSION))
+      .queryParam("response_type", RESPONSE_TYPE_CODE)
+      .queryParam("client_id", "admin-client-rw")
+      .queryParam("redirect_uri", TEST_CLIENT_REDIRECT_URI)
+      .queryParam("scope", SCOPE_ADMIN)
+      .queryParam("nonce", "1")
+      .queryParam("state", "1")
+      .redirects().follow(false)
+    .when()
+      .get(authorizeUrl)
+    .then()
+      .log().all()
+      .statusCode(HttpStatus.OK.value())
+      .extract().body().asString();
+    // @formatter:on
+
+    assertThat(responseBody, not(containsString("iam:admin.write")));
+
+  }
+
+  @Test
+  public void testConsentPageReturnsAdminScopeToAdmins() {
+
+    // @formatter:off
+    ValidatableResponse authzResponse = RestAssured.given()
+      .queryParam("response_type", RESPONSE_TYPE_CODE)
+      .queryParam("client_id", TEST_CLIENT_ID)
+      .queryParam("redirect_uri", TEST_CLIENT_REDIRECT_URI)
+      .queryParam("scope", SCOPE_ADMIN)
+      .queryParam("nonce", "1")
+      .queryParam("state", "1")
+      .redirects().follow(false)
+    .when()
+      .get(authorizeUrl)
+    .then()
+      .log().all()
+      .statusCode(HttpStatus.FOUND.value());
+    // @formatter:on
+
+    // @formatter:off
+    ValidatableResponse loginResponse = RestAssured.given()
+      .cookie(authzResponse.extract().detailedCookie(SESSION))
+      .formParam("username", "admin")
+      .formParam("password", "password")
+      .formParam("submit", "Login")
+      .redirects().follow(false)
+    .when()
+      .post(loginUrl)
+    .then()
+      .log().all()
+      .statusCode(HttpStatus.FOUND.value());
+    // @formatter:on
+
+    // @formatter:off
+    String responseBody = RestAssured.given()
+      .cookie(loginResponse.extract().detailedCookie(SESSION))
+      .queryParam("response_type", RESPONSE_TYPE_CODE)
+      .queryParam("client_id", TEST_CLIENT_ID)
+      .queryParam("redirect_uri", TEST_CLIENT_REDIRECT_URI)
+      .queryParam("scope", SCOPE_ADMIN)
+      .queryParam("nonce", "1")
+      .queryParam("state", "1")
+      .redirects().follow(false)
+    .when()
+      .get(authorizeUrl)
+    .then()
+      .log().all()
+      .statusCode(HttpStatus.OK.value())
+      .extract().body().asString();
+    // @formatter:on
+
+    assertThat(responseBody, containsString("iam:admin.write"));
 
   }
 

--- a/iam-persistence/src/main/resources/db/migration/test/V100000___test_data.sql
+++ b/iam-persistence/src/main/resources/db/migration/test/V100000___test_data.sql
@@ -145,7 +145,8 @@ INSERT INTO client_redirect_uri (owner_id, redirect_uri) VALUES
   (3, 'http://localhost:4000/callback'),
   (4, 'http://localhost:5000/callback'),
   (11, 'http://localhost:1234/callback'),
-  (13, 'http://localhost:9876/implicit');
+  (13, 'http://localhost:9876/implicit'),
+  (18, 'https://iam.local.io/iam-test-client/openid_connect_login');
 
 INSERT INTO client_grant_type (owner_id, grant_type) VALUES
   (1, 'authorization_code'),
@@ -188,6 +189,7 @@ INSERT INTO client_grant_type (owner_id, grant_type) VALUES
   (19, 'client_credentials');
 
 INSERT INTO client_contact (owner_id, contact) VALUES
+  (1, 'admin@example.com'),
   (12, 'test@example.com');
     
 INSERT INTO iam_user_info(ID, GIVENNAME, FAMILYNAME, EMAIL, EMAILVERIFIED, BIRTHDATE, GENDER, NICKNAME) VALUES


### PR DESCRIPTION
Users those use clients authorized to get admin scopes cannot get them.