### PR TITLE
Fix logic of sending email for expired aup

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/TaskConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/TaskConfig.java
@@ -131,7 +131,8 @@ public class TaskConfig implements SchedulingConfigurer {
     deviceCodeService.clearExpiredDeviceCodes();
   }
 
-  @Scheduled(fixedRateString = "${task.aupReminder:14400}", timeUnit = TimeUnit.SECONDS)
+  @Scheduled(fixedRateString = "${task.aupReminder:14400}", timeUnit = TimeUnit.SECONDS,
+      initialDelay = ONE_MINUTE_MSEC)
   public void scheduledAupRemindersTask() {
     aupReminderTask.sendAupReminders();
   }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/web/aup/AupReminderTask.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/web/aup/AupReminderTask.java
@@ -54,23 +54,25 @@ public class AupReminderTask {
   public void sendAupReminders() {
     aupRepo.findDefaultAup().ifPresent(aup -> {
       LocalDate currentDate = LocalDate.now();
-      LocalDate expirationDate = currentDate.minusDays(aup.getSignatureValidityInDays());
-      Date expirationDateAsDate = toDate(expirationDate);
-      Date expirationDatePlusOneDayAsDate = toDate(expirationDate.plusDays(1));
-      List<Integer> reminderIntervals = parseReminderIntervals(aup.getAupRemindersInDays());
+      if (aup.getSignatureValidityInDays() > 0) {
+        LocalDate expirationDate = currentDate.minusDays(aup.getSignatureValidityInDays());
+        Date expirationDateAsDate = toDate(expirationDate);
+        Date expirationDatePlusOneDayAsDate = toDate(expirationDate.plusDays(1));
+        List<Integer> reminderIntervals = parseReminderIntervals(aup.getAupRemindersInDays());
 
-      reminderIntervals.forEach(
-          interval -> processRemindersForInterval(aup, currentDate, interval, expirationDate));
+        reminderIntervals.forEach(
+            interval -> processRemindersForInterval(aup, currentDate, interval, expirationDate));
 
-      List<IamAupSignature> expiredSignatures = aupSignatureRepo.findByAupAndSignatureTime(aup,
-          expirationDateAsDate, expirationDatePlusOneDayAsDate);
+        List<IamAupSignature> expiredSignatures = aupSignatureRepo.findByAupAndSignatureTime(aup,
+            expirationDateAsDate, expirationDatePlusOneDayAsDate);
 
-      // check if an email of type AUP_EXPIRATION does not already exist, because it is never deleted
-      expiredSignatures.forEach(s -> {
-        if (isExpiredSignatureEmailNotAlreadySentFor(s.getAccount())) {
-          notification.createAupSignatureExpMessage(s.getAccount());
-        }
-      });
+        // check if an email of type AUP_EXPIRATION does not already exist, because it is never deleted
+        expiredSignatures.forEach(s -> {
+          if (isExpiredSignatureEmailNotAlreadySentFor(s.getAccount())) {
+            notification.createAupSignatureExpMessage(s.getAccount());
+          }
+        });
+      }
     });
   }
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/aup/AupReminderTaskTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/aup/AupReminderTaskTests.java
@@ -85,7 +85,7 @@ public class AupReminderTaskTests extends AupTestSupport {
 
   @Test
   @WithMockUser(username = "admin", roles = {"ADMIN", "USER"})
-  public void aupReminderEmailWorks() {
+  public void aupReminderEmailWorks() throws InterruptedException {
     IamAup aup = buildDefaultAup();
     aup.setSignatureValidityInDays(30L);
     aupRepo.save(aup);
@@ -101,6 +101,8 @@ public class AupReminderTaskTests extends AupTestSupport {
     assertThat(service.needsAupSignature(testAccount), is(true));
 
     signatureRepo.createSignatureForAccount(aup, testAccount, now);
+
+    Thread.sleep(5000);
 
     assertThat(service.needsAupSignature(testAccount), is(false));
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/aup/AupReminderTaskTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/aup/AupReminderTaskTests.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.is;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.Test;
@@ -44,6 +45,7 @@ import it.infn.mw.iam.persistence.repository.IamEmailNotificationRepository;
 import it.infn.mw.iam.service.aup.DefaultAupSignatureCheckService;
 import it.infn.mw.iam.test.core.CoreControllerTestSupport;
 import it.infn.mw.iam.test.notification.NotificationTestConfig;
+import it.infn.mw.iam.test.util.MockTimeProvider;
 import it.infn.mw.iam.test.util.WithAnonymousUser;
 import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
 import it.infn.mw.iam.test.util.notification.MockNotificationDelivery;
@@ -77,6 +79,9 @@ public class AupReminderTaskTests extends AupTestSupport {
   @Autowired
   private IamAupRepository aupRepo;
 
+  @Autowired
+  private MockTimeProvider mockTimeProvider;
+
   @After
   public void tearDown() {
     notificationDelivery.clearDeliveredNotifications();
@@ -85,26 +90,30 @@ public class AupReminderTaskTests extends AupTestSupport {
 
   @Test
   @WithMockUser(username = "admin", roles = {"ADMIN", "USER"})
-  public void aupReminderEmailWorks() throws InterruptedException {
+  public void aupReminderEmailWorks() {
     IamAup aup = buildDefaultAup();
     aup.setSignatureValidityInDays(30L);
     aupRepo.save(aup);
 
     Date now = new Date();
+    mockTimeProvider.setTime(now.getTime());
     LocalDate today = LocalDate.now();
     LocalDate tomorrow = today.plusDays(1);
     Date tomorrowDate = Date.from(tomorrow.atStartOfDay(ZoneId.systemDefault()).toInstant());
 
-    IamAccount testAccount = accountRepo.findByUsername("test_100")
+    IamAccount testAccount = accountRepo.findByUsername("test")
       .orElseThrow(() -> new AssertionError("Expected test account not found"));
+
+    mockTimeProvider.setTime(now.getTime() + TimeUnit.MINUTES.toMillis(5));
 
     assertThat(service.needsAupSignature(testAccount), is(true));
 
-    signatureRepo.createSignatureForAccount(aup, testAccount, now);
-
-    Thread.sleep(5000);
+    signatureRepo.createSignatureForAccount(aup, testAccount,
+        new Date(mockTimeProvider.currentTimeMillis()));
 
     assertThat(service.needsAupSignature(testAccount), is(false));
+
+    mockTimeProvider.setTime(now.getTime() + TimeUnit.MINUTES.toMillis(10));
 
     assertThat(notificationRepo.countAupRemindersPerAccount(testAccount.getUserInfo().getEmail(),
         tomorrowDate), equalTo(0));

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/aup/AupReminderTaskTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/aup/AupReminderTaskTests.java
@@ -95,7 +95,7 @@ public class AupReminderTaskTests extends AupTestSupport {
     LocalDate tomorrow = today.plusDays(1);
     Date tomorrowDate = Date.from(tomorrow.atStartOfDay(ZoneId.systemDefault()).toInstant());
 
-    IamAccount testAccount = accountRepo.findByUsername("test")
+    IamAccount testAccount = accountRepo.findByUsername("test_100")
       .orElseThrow(() -> new AssertionError("Expected test account not found"));
 
     assertThat(service.needsAupSignature(testAccount), is(true));

--- a/iam-persistence/src/main/java/it/infn/mw/iam/persistence/repository/IamAupSignatureRepository.java
+++ b/iam-persistence/src/main/java/it/infn/mw/iam/persistence/repository/IamAupSignatureRepository.java
@@ -30,7 +30,7 @@ import it.infn.mw.iam.persistence.model.IamAupSignature;
 public interface IamAupSignatureRepository
     extends PagingAndSortingRepository<IamAupSignature, Long>, IamAupSignatureRepositoryCustom {
 
-  @Query("select ias from IamAupSignature ias where ias.aup = :aup and :signatureTime <= ias.signatureTime and ias.signatureTime < :plusOne")
+  @Query("select ias from IamAupSignature ias join ias.account a where a.active = TRUE and ias.aup = :aup and :signatureTime <= ias.signatureTime and ias.signatureTime < :plusOne")
   List<IamAupSignature> findByAupAndSignatureTime(@Param("aup") IamAup aup,
       @Param("signatureTime") Date signatureTime, @Param("plusOne") Date plusOne);
 


### PR DESCRIPTION
In particular, in case of AUP expired, send an email only if the user is active and exclude the logic in case of infinite AUP.
Of course, in case of infinite AUP, AUP reminders will also not be sent.