### PR TITLE
Fix repeated suspensions

### DIFF
--- a/iam-common/pom.xml
+++ b/iam-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>it.infn.mw.iam-parent</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>1.10.0</version>
+    <version>1.10.1</version>
   </parent>
 
   <groupId>it.infn.mw.iam-common</groupId>

--- a/iam-login-service/pom.xml
+++ b/iam-login-service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>it.infn.mw.iam-parent</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>1.10.0</version>
+    <version>1.10.1</version>
   </parent>
 
   <groupId>it.infn.mw.iam-login-service</groupId>

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/ExpiredAccountsHandler.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/ExpiredAccountsHandler.java
@@ -16,11 +16,15 @@
 package it.infn.mw.iam.core.lifecycle;
 
 import static com.google.common.collect.Sets.newHashSet;
+import static it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler.AccountLifecycleStatus.PENDING_REMOVAL;
+import static it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler.AccountLifecycleStatus.PENDING_SUSPENSION;
+import static it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler.AccountLifecycleStatus.SUSPENDED;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
+import java.util.Optional;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -42,10 +46,7 @@ import it.infn.mw.iam.persistence.repository.IamAccountRepository;
 public class ExpiredAccountsHandler implements Runnable {
 
   public enum AccountLifecycleStatus {
-    OK,
-    PENDING_SUSPENSION,
-    PENDING_REMOVAL,
-    SUSPENDED
+    OK, PENDING_SUSPENSION, PENDING_REMOVAL, SUSPENDED
   }
 
   public static final String LIFECYCLE_TIMESTAMP_LABEL = "lifecycle.timestamp";
@@ -94,40 +95,71 @@ public class ExpiredAccountsHandler implements Runnable {
         properties.getAccount().getExpiredAccountPolicy().getRemovalGracePeriodDays());
   }
 
-  private void addLastCheckedLabel(IamAccount expiredAccount) {
-    accountService.setLabel(expiredAccount,
-        IamLabel.builder()
-          .name(LIFECYCLE_TIMESTAMP_LABEL)
-          .value(String.valueOf(checkTime.toEpochMilli()))
-          .build());
-  }
-
   private void addStatusLabel(IamAccount expiredAccount, AccountLifecycleStatus status) {
     accountService.setLabel(expiredAccount,
         IamLabel.builder().name(LIFECYCLE_STATUS_LABEL).value(status.name()).build());
   }
 
+  private boolean checkAccountStatusIs(IamAccount a, AccountLifecycleStatus status) {
+    Optional<IamLabel> lifecycleStatus = a.getLabelByName(LIFECYCLE_STATUS_LABEL);
+    if (lifecycleStatus.isEmpty()) {
+      return false;
+    }
+    return status.name().equals(lifecycleStatus.get().getValue());
+  }
+
   private void suspendAccount(IamAccount expiredAccount) {
 
-    LOG.info("Suspeding account {} expired on {} ({} days ago)", expiredAccount.getUsername(),
+    if (expiredAccount.isActive()) {
+      LOG.info("Suspeding account {} expired on {} ({} days ago)", expiredAccount.getUsername(),
         expiredAccount.getEndTime(),
         ChronoUnit.DAYS.between(expiredAccount.getEndTime().toInstant(), checkTime));
-    accountService.disableAccount(expiredAccount);
+      accountService.disableAccount(expiredAccount);
+    } else {
+      // nothing to do
+      LOG.debug("Account {} expired on {} has been already suspended", expiredAccount.getUsername(), expiredAccount.getEndTime());
+    }
     if (properties.getAccount().getExpiredAccountPolicy().isRemoveExpiredAccounts()) {
-      addStatusLabel(expiredAccount, AccountLifecycleStatus.PENDING_REMOVAL);
+      markAsPendingRemoval(expiredAccount);
+    } else {
+      markAsSuspended(expiredAccount);
     }
-    else {
-      addStatusLabel(expiredAccount, AccountLifecycleStatus.SUSPENDED);
-    }
-    addLastCheckedLabel(expiredAccount);
   }
 
   private void markAsPendingSuspension(IamAccount expiredAccount) {
+    if (checkAccountStatusIs(expiredAccount, PENDING_SUSPENSION)) {
+      LOG.debug("Account {} expired on {} has been already marked as pending suspension",
+          expiredAccount.getUsername(), expiredAccount.getEndTime());
+      return;
+    }
     LOG.info("Marking account {} (expired on {} ({} days ago)) as pending suspension",
         expiredAccount.getUsername(), expiredAccount.getEndTime(),
         ChronoUnit.DAYS.between(expiredAccount.getEndTime().toInstant(), checkTime));
-    addStatusLabel(expiredAccount, AccountLifecycleStatus.PENDING_SUSPENSION);
-    addLastCheckedLabel(expiredAccount);
+    addStatusLabel(expiredAccount, PENDING_SUSPENSION);
+  }
+
+  private void markAsPendingRemoval(IamAccount expiredAccount) {
+    if (checkAccountStatusIs(expiredAccount, PENDING_REMOVAL)) {
+      LOG.debug("Account {} expired on {} has been already marked as pending removal",
+          expiredAccount.getUsername(), expiredAccount.getEndTime());
+      return;
+    }
+    LOG.info("Marking account {} (expired on {} ({} days ago)) as pending removal",
+        expiredAccount.getUsername(), expiredAccount.getEndTime(),
+        ChronoUnit.DAYS.between(expiredAccount.getEndTime().toInstant(), checkTime));
+    addStatusLabel(expiredAccount, PENDING_REMOVAL);
+  }
+
+  private void markAsSuspended(IamAccount expiredAccount) {
+    if (checkAccountStatusIs(expiredAccount, SUSPENDED)) {
+      LOG.debug("Account {} expired on {} has been already marked as suspended",
+          expiredAccount.getUsername(), expiredAccount.getEndTime());
+      return;
+    }
+    LOG.info("Marking account {} (expired on {} ({} days ago)) as suspended",
+        expiredAccount.getUsername(), expiredAccount.getEndTime(),
+        ChronoUnit.DAYS.between(expiredAccount.getEndTime().toInstant(), checkTime));
+    addStatusLabel(expiredAccount, SUSPENDED);
   }
 
   private void removeAccount(IamAccount expiredAccount) {
@@ -136,7 +168,6 @@ public class ExpiredAccountsHandler implements Runnable {
         ChronoUnit.DAYS.between(expiredAccount.getEndTime().toInstant(), checkTime));
     accountService.deleteAccount(expiredAccount);
   }
-
 
   private void scheduleAccountRemoval(IamAccount expiredAccount) {
     accountsScheduledForRemoval.add(expiredAccount);
@@ -148,9 +179,7 @@ public class ExpiredAccountsHandler implements Runnable {
         && properties.getAccount().getExpiredAccountPolicy().isRemoveExpiredAccounts()) {
       scheduleAccountRemoval(expiredAccount);
     } else if (pastSuspensionGracePeriod(expiredAccount)) {
-      if (expiredAccount.isActive()) {
-        suspendAccount(expiredAccount);
-      }
+      suspendAccount(expiredAccount);
     } else {
       markAsPendingSuspension(expiredAccount);
     }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/ExpiredAccountsHandler.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/ExpiredAccountsHandler.java
@@ -25,7 +25,6 @@ import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -67,7 +66,6 @@ public class ExpiredAccountsHandler implements Runnable {
 
   private Set<IamAccount> accountsScheduledForRemoval = newHashSet();
 
-  @Autowired
   public ExpiredAccountsHandler(Clock clock, LifecycleProperties properties,
       IamAccountRepository repo, IamAccountService service) {
     this.clock = clock;
@@ -150,7 +148,9 @@ public class ExpiredAccountsHandler implements Runnable {
         && properties.getAccount().getExpiredAccountPolicy().isRemoveExpiredAccounts()) {
       scheduleAccountRemoval(expiredAccount);
     } else if (pastSuspensionGracePeriod(expiredAccount)) {
-      suspendAccount(expiredAccount);
+      if (expiredAccount.isActive()) {
+        suspendAccount(expiredAccount);
+      }
     } else {
       markAsPendingSuspension(expiredAccount);
     }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/AccountLifecycleNoRemovalExpiredAccountTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/AccountLifecycleNoRemovalExpiredAccountTests.java
@@ -62,6 +62,7 @@ public class AccountLifecycleNoRemovalExpiredAccountTests extends TestSupport im
     assertThat(testAccount.isActive(), is(true));
     testAccount.setEndTime(Date.from(EIGHT_DAYS_AGO));
     repo.save(testAccount);
+    Date lastUpdateTime = testAccount.getLastUpdateTime();
 
     handler.handleExpiredAccounts();
 
@@ -69,6 +70,16 @@ public class AccountLifecycleNoRemovalExpiredAccountTests extends TestSupport im
         repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
 
     assertThat(testAccount.isActive(), is(false));
+    assertThat(testAccount.getLastUpdateTime().compareTo(lastUpdateTime) > 0, is(true));
+    lastUpdateTime = testAccount.getLastUpdateTime();
+
+    handler.handleExpiredAccounts();
+
+    testAccount =
+        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
+
+    assertThat(testAccount.isActive(), is(false));
+    assertThat(testAccount.getLastUpdateTime().compareTo(lastUpdateTime) == 0, is(true));
 
     Optional<IamLabel> statusLabel = testAccount.getLabelByName(LIFECYCLE_STATUS_LABEL);
     assertThat(statusLabel.isPresent(), is(true));

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/AccountLifecycleNoRemovalExpiredAccountTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/AccountLifecycleNoRemovalExpiredAccountTests.java
@@ -16,8 +16,6 @@
 package it.infn.mw.iam.test.lifecycle;
 
 import static it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler.LIFECYCLE_STATUS_LABEL;
-import static it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler.LIFECYCLE_TIMESTAMP_LABEL;
-import static java.lang.String.valueOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -72,11 +70,6 @@ public class AccountLifecycleNoRemovalExpiredAccountTests extends TestSupport im
 
     assertThat(testAccount.isActive(), is(false));
 
-    Optional<IamLabel> timestampLabel = testAccount.getLabelByName(LIFECYCLE_TIMESTAMP_LABEL);
-
-    assertThat(timestampLabel.isPresent(), is(true));
-    assertThat(timestampLabel.get().getValue(), is(valueOf(NOW.toEpochMilli())));
-
     Optional<IamLabel> statusLabel = testAccount.getLabelByName(LIFECYCLE_STATUS_LABEL);
     assertThat(statusLabel.isPresent(), is(true));
     assertThat(statusLabel.get().getValue(),
@@ -98,11 +91,6 @@ public class AccountLifecycleNoRemovalExpiredAccountTests extends TestSupport im
         repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
 
     assertThat(testAccount.isActive(), is(false));
-
-    Optional<IamLabel> timestampLabel = testAccount.getLabelByName(LIFECYCLE_TIMESTAMP_LABEL);
-
-    assertThat(timestampLabel.isPresent(), is(true));
-    assertThat(timestampLabel.get().getValue(), is(valueOf(NOW.toEpochMilli())));
 
     Optional<IamLabel> statusLabel = testAccount.getLabelByName(LIFECYCLE_STATUS_LABEL);
     assertThat(statusLabel.isPresent(), is(true));

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/AccountLifecycleNoSuspensionGracePeriodTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/AccountLifecycleNoSuspensionGracePeriodTests.java
@@ -16,10 +16,8 @@
 package it.infn.mw.iam.test.lifecycle;
 
 import static it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler.LIFECYCLE_STATUS_LABEL;
-import static it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler.LIFECYCLE_TIMESTAMP_LABEL;
 import static it.infn.mw.iam.test.api.TestSupport.EXPECTED_ACCOUNT_NOT_FOUND;
 import static it.infn.mw.iam.test.api.TestSupport.TEST_USER_UUID;
-import static java.lang.String.valueOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -91,11 +89,6 @@ public class AccountLifecycleNoSuspensionGracePeriodTests implements LifecycleTe
         repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
 
     assertThat(testAccount.isActive(), is(false));
-
-    Optional<IamLabel> timestampLabel = testAccount.getLabelByName(LIFECYCLE_TIMESTAMP_LABEL);
-
-    assertThat(timestampLabel.isPresent(), is(true));
-    assertThat(timestampLabel.get().getValue(), is(valueOf(NOW.toEpochMilli())));
 
     Optional<IamLabel> statusLabel = testAccount.getLabelByName(LIFECYCLE_STATUS_LABEL);
     assertThat(statusLabel.isPresent(), is(true));

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/AccountLifecycleTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/AccountLifecycleTests.java
@@ -16,8 +16,6 @@
 package it.infn.mw.iam.test.lifecycle;
 
 import static it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler.LIFECYCLE_STATUS_LABEL;
-import static it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler.LIFECYCLE_TIMESTAMP_LABEL;
-import static java.lang.String.valueOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -91,11 +89,6 @@ public class AccountLifecycleTests extends TestSupport implements LifecycleTestS
 
     assertThat(testAccount.isActive(), is(true));
 
-    Optional<IamLabel> timestampLabel = testAccount.getLabelByName(LIFECYCLE_TIMESTAMP_LABEL);
-
-    assertThat(timestampLabel.isPresent(), is(true));
-    assertThat(timestampLabel.get().getValue(), is(valueOf(NOW.toEpochMilli())));
-
     Optional<IamLabel> statusLabel = testAccount.getLabelByName(LIFECYCLE_STATUS_LABEL);
     assertThat(statusLabel.isPresent(), is(true));
     assertThat(statusLabel.get().getValue(),
@@ -128,11 +121,6 @@ public class AccountLifecycleTests extends TestSupport implements LifecycleTestS
 
     assertThat(testAccount.isActive(), is(false));
     assertThat(testAccount.getLastUpdateTime().compareTo(lastUpdateTime) == 0, is(true));
-
-    Optional<IamLabel> timestampLabel = testAccount.getLabelByName(LIFECYCLE_TIMESTAMP_LABEL);
-
-    assertThat(timestampLabel.isPresent(), is(true));
-    assertThat(timestampLabel.get().getValue(), is(valueOf(NOW.toEpochMilli())));
 
     Optional<IamLabel> statusLabel = testAccount.getLabelByName(LIFECYCLE_STATUS_LABEL);
     assertThat(statusLabel.isPresent(), is(true));

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/AccountLifecycleTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/AccountLifecycleTests.java
@@ -81,6 +81,7 @@ public class AccountLifecycleTests extends TestSupport implements LifecycleTestS
 
     testAccount.setEndTime(Date.from(FOUR_DAYS_AGO));
     repo.save(testAccount);
+    Date lastUpdateTime = testAccount.getLastUpdateTime();
 
     handler.handleExpiredAccounts();
 
@@ -88,11 +89,22 @@ public class AccountLifecycleTests extends TestSupport implements LifecycleTestS
         repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
 
     assertThat(testAccount.isActive(), is(true));
+    assertThat(testAccount.getLastUpdateTime().compareTo(lastUpdateTime) > 0, is(true));
+    lastUpdateTime = testAccount.getLastUpdateTime();
 
     Optional<IamLabel> statusLabel = testAccount.getLabelByName(LIFECYCLE_STATUS_LABEL);
     assertThat(statusLabel.isPresent(), is(true));
     assertThat(statusLabel.get().getValue(),
         is(ExpiredAccountsHandler.AccountLifecycleStatus.PENDING_SUSPENSION.name()));
+
+    handler.handleExpiredAccounts();
+
+    testAccount =
+        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
+
+    assertThat(testAccount.isActive(), is(true));
+    assertThat(testAccount.getLastUpdateTime().compareTo(lastUpdateTime) == 0, is(true));
+
   }
 
   @Test

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/AccountLifecycleTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/AccountLifecycleTests.java
@@ -110,6 +110,7 @@ public class AccountLifecycleTests extends TestSupport implements LifecycleTestS
     assertThat(testAccount.isActive(), is(true));
     testAccount.setEndTime(Date.from(EIGHT_DAYS_AGO));
     repo.save(testAccount);
+    Date lastUpdateTime = testAccount.getLastUpdateTime();
 
     handler.handleExpiredAccounts();
 
@@ -117,6 +118,16 @@ public class AccountLifecycleTests extends TestSupport implements LifecycleTestS
         repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
 
     assertThat(testAccount.isActive(), is(false));
+    assertThat(testAccount.getLastUpdateTime().compareTo(lastUpdateTime) > 0, is(true));
+    lastUpdateTime = testAccount.getLastUpdateTime();
+
+    handler.handleExpiredAccounts();
+
+    testAccount =
+        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
+
+    assertThat(testAccount.isActive(), is(false));
+    assertThat(testAccount.getLastUpdateTime().compareTo(lastUpdateTime) == 0, is(true));
 
     Optional<IamLabel> timestampLabel = testAccount.getLabelByName(LIFECYCLE_TIMESTAMP_LABEL);
 

--- a/iam-persistence/pom.xml
+++ b/iam-persistence/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>it.infn.mw.iam-parent</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>1.10.0</version>
+    <version>1.10.1</version>
   </parent>
 
   <groupId>it.infn.mw.iam-persistence</groupId>

--- a/iam-test-client/pom.xml
+++ b/iam-test-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>it.infn.mw.iam-parent</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>1.10.0</version>
+    <version>1.10.1</version>
   </parent>
 
   <groupId>it.infn.mw.iam-test-client</groupId>

--- a/iam-voms-aa/pom.xml
+++ b/iam-voms-aa/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>it.infn.mw.iam-parent</groupId>
     <artifactId>iam-parent</artifactId>
-    <version>1.10.0</version>
+    <version>1.10.1</version>
   </parent>
 
   <groupId>it.infn.mw.iam-voms-aa</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
 	<groupId>it.infn.mw.iam-parent</groupId>
 	<artifactId>iam-parent</artifactId>
-	<version>1.10.0</version>
+	<version>1.10.1</version>
 	<packaging>pom</packaging>
 
 	<name>INDIGO Identity and Access Manager (IAM) - Parent POM</name>


### PR DESCRIPTION
The internal IAM lifecycle handler sets status label values and disable users multiple times, generating useless AUDIT events and also email notifications. This PR fixes this behavior and also makes useless the usage of lifecycle.timestamp label which has to be removed in future releases