### PR TITLE
Fix AUP signature validity

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/aup/model/AupConverter.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/aup/model/AupConverter.java
@@ -32,7 +32,11 @@ public class AupConverter implements Converter<AupDTO, IamAup> {
     aup.setSignatureValidityInDays(dto.getSignatureValidityInDays());
     aup.setUrl(dto.getUrl());
     aup.setText(dto.getText());
-    aup.setAupRemindersInDays(dto.getAupRemindersInDays());
+    if (dto.getAupRemindersInDays() == null) {
+      aup.setAupRemindersInDays("");
+    } else {
+      aup.setAupRemindersInDays(dto.getAupRemindersInDays());
+    }
     return aup;
   }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/aup/model/AupRemindersAndSignatureValidator.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/aup/model/AupRemindersAndSignatureValidator.java
@@ -63,50 +63,57 @@ public class AupRemindersAndSignatureValidator
       return true;
     }
 
-    if (aupRemindersInDays != null) {
-      try {
-        List<Integer> numbers = Arrays.stream(aupRemindersInDays.split(","))
-          .map(String::trim)
-          .map(Integer::parseInt)
-          .collect(Collectors.toList());
+    if (aupRemindersInDays == null) {
+      context.disableDefaultConstraintViolation();
+      context.buildConstraintViolationWithTemplate(
+          "Invalid AUP: aupRemindersInDays must be set when signatureValidityInDays is greater than 0")
+        .addConstraintViolation();
+      return false;
+    }
 
-        if (numbers.stream().anyMatch(i -> i <= 0)) {
-          context.disableDefaultConstraintViolation();
-          context
-            .buildConstraintViolationWithTemplate(
-                "Invalid AUP: zero or negative values for reminders are not allowed")
-            .addConstraintViolation();
-          return false;
-        }
+    try {
+      List<Integer> numbers = Arrays.stream(aupRemindersInDays.split(","))
+        .map(String::trim)
+        .map(Integer::parseInt)
+        .collect(Collectors.toList());
 
-        if (numbers.stream().anyMatch(i -> i >= signatureValidityInDays)) {
-          context.disableDefaultConstraintViolation();
-          context
-            .buildConstraintViolationWithTemplate(
-                "Invalid AUP: aupRemindersInDays must be smaller than signatureValidityInDays")
-            .addConstraintViolation();
-          return false;
-        }
-
-        Set<Integer> uniqueNumbers = new HashSet<>(numbers);
-        if (uniqueNumbers.size() != numbers.size()) {
-          context.disableDefaultConstraintViolation();
-          context
-            .buildConstraintViolationWithTemplate(
-                "Invalid AUP: duplicate values for reminders are not allowed")
-            .addConstraintViolation();
-          return false;
-        }
-
-        return true;
-      } catch (NumberFormatException e) {
+      if (numbers.stream().anyMatch(i -> i <= 0)) {
         context.disableDefaultConstraintViolation();
-        context.buildConstraintViolationWithTemplate("Invalid AUP: non-integer value found for aupRemindersInDays")
+        context
+          .buildConstraintViolationWithTemplate(
+              "Invalid AUP: zero or negative values for reminders are not allowed")
           .addConstraintViolation();
         return false;
       }
+
+      if (numbers.stream().anyMatch(i -> i >= signatureValidityInDays)) {
+        context.disableDefaultConstraintViolation();
+        context
+          .buildConstraintViolationWithTemplate(
+              "Invalid AUP: aupRemindersInDays must be smaller than signatureValidityInDays")
+          .addConstraintViolation();
+        return false;
+      }
+
+      Set<Integer> uniqueNumbers = new HashSet<>(numbers);
+      if (uniqueNumbers.size() != numbers.size()) {
+        context.disableDefaultConstraintViolation();
+        context
+          .buildConstraintViolationWithTemplate(
+              "Invalid AUP: duplicate values for reminders are not allowed")
+          .addConstraintViolation();
+        return false;
+      }
+
+      return true;
+    } catch (NumberFormatException e) {
+      context.disableDefaultConstraintViolation();
+      context
+        .buildConstraintViolationWithTemplate(
+            "Invalid AUP: non-integer value found for aupRemindersInDays")
+        .addConstraintViolation();
+      return false;
     }
-    return true;
   }
 
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/aup/model/AupRemindersAndSignatureValidator.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/aup/model/AupRemindersAndSignatureValidator.java
@@ -50,6 +50,11 @@ public class AupRemindersAndSignatureValidator implements ConstraintValidator<Au
       return false;
     }
 
+    if (signatureValidityInDays == 0) {
+      value.setAupRemindersInDays("30,15,1");
+      return true;
+  }
+
     if (aupRemindersInDays == null || aupRemindersInDays.isEmpty()) {
       context.disableDefaultConstraintViolation();
       context

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/aup/aup.component.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/aup/aup.component.html
@@ -67,7 +67,7 @@
                             If set to zero, the AUP signature will be asked only at registration time.
                         </span>
                     </div>
-                    <div class="form-group">
+                    <div class="form-group" ng-if="$ctrl.aup.data.signatureValidityInDays > 0">
                         <label>AUP reminders (in days)</label>
                         <p class="aup-text">
                             {{$ctrl.aup.data.aupRemindersInDays}}

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/aup/aup.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/aup/aup.component.js
@@ -83,6 +83,9 @@
         self.doSaveAup = function() {
             self.error = undefined;
             self.enabled = false;
+            if(self.aupVal.signatureValidityInDays == 0 || !self.aupVal.aupRemindersInDays) {
+                self.aupVal.aupRemindersInDays = "";
+            }
             AupService.updateAup(self.aupVal)
                 .then(function(res) {
                     $uibModalInstance.close('AUP updated succesfully');
@@ -106,7 +109,7 @@
             self.aupVal = {
                 url: "",
                 signatureValidityInDays: 0,
-                aupRemindersInDays: "30,15,1"
+                aupRemindersInDays: ""
             };
         };
 
@@ -115,6 +118,9 @@
         self.doCreateAup = function() {
             self.error = undefined;
             self.enabled = false;
+            if(self.aupVal.signatureValidityInDays == 0 || !self.aupVal.aupRemindersInDays) {
+                self.aupVal.aupRemindersInDays = "";
+            }
             AupService.createAup(self.aupVal)
                 .then(function(res) {
                     $uibModalInstance.close('AUP created succesfully');

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/aup/aup.create.dialog.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/aup/aup.create.dialog.html
@@ -45,7 +45,7 @@
                 If set to zero, the AUP signature will be asked only at registration time.
             </span>
         </div>
-        <div class="form-group" ng-class="{'has-error': $ctrl.error || createAup.aupReminder.$dirty && !createAup.aupReminder.$valid}">
+        <div class="form-group" ng-if="$ctrl.aupVal.signatureValidityInDays > 0" ng-class="{'has-error': $ctrl.error || createAup.aupReminder.$dirty && !createAup.aupReminder.$valid}">
             <label>AUP signature reminders (in days)</label>
             <input name="aupReminder" class="form-control" type="text" ng-model="$ctrl.aupVal.aupRemindersInDays" placeholder="30,15,1" required="true">
             <span class="help-block">

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/aup/aup.create.dialog.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/aup/aup.create.dialog.html
@@ -22,19 +22,23 @@
 </div>
 <div class="modal-body">
     <form name="createAup">
-        <div class="form-group" ng-class="{'has-error': $ctrl.error || createAup.url.$dirty && !createAup.url.$valid}">
+        <div class="form-group has-error" ng-if="$ctrl.error">
+            <span class="help-block">
+                {{ $ctrl.error }}
+            </span>
+        </div>
+        <div class="form-group">
             <label>Acceptable Usage Policy URL</label>
-            <input name="url" class="form-control" type="url" value="http://" ng-model="$ctrl.aupVal.url" required="true">
+            <input name="url" class="form-control" value="http://" ng-model="$ctrl.aupVal.url" required="true">
             <span class="help-block">
                     The URL above is presented to users at registration time or periodically
                     if the AUP is configured for periodic reacceptance
             </span>
-            <span class="help-block" ng-if="createAup.url.$dirty && createAup.url.$error.required">
-                    Please provide a valid URL for the AUP
-            </span>
-            <span class="help-block" ng-if="$ctrl.error">
-                    {{ $ctrl.error }}
-            </span>
+            <div class="form-group has-error" ng-if="createAup.url.$dirty && createAup.url.$error.required">
+                <span class="help-block">
+                        Please provide a valid URL for the AUP
+                </span>
+            </div>
         </div>
         <div class="form-group">
             <label>AUP signature validity (in days)</label>
@@ -45,20 +49,22 @@
                 If set to zero, the AUP signature will be asked only at registration time.
             </span>
         </div>
-        <div class="form-group" ng-if="$ctrl.aupVal.signatureValidityInDays > 0" ng-class="{'has-error': $ctrl.error || createAup.aupReminder.$dirty && !createAup.aupReminder.$valid}">
+        <div class="form-group" ng-if="$ctrl.aupVal.signatureValidityInDays > 0">
             <label>AUP signature reminders (in days)</label>
-            <input name="aupReminder" class="form-control" type="text" ng-model="$ctrl.aupVal.aupRemindersInDays" placeholder="30,15,1" required="true">
+            <input name="aupReminder" class="form-control" type="text" ng-model="$ctrl.aupVal.aupRemindersInDays" placeholder="30,15,1" ng-required="$ctrl.aupVal.signatureValidityInDays > 0">
             <span class="help-block">
                 Indicate a sequence of comma-separated numbers representing how many days before the AUP expiration reminder messages must be sent.
             </span>
-            <span class="help-block" ng-if="createAup.aupReminder.$dirty && createAup.aupReminder.$error.required">
-                Required input
-            </span>
+            <div class="form-group has-error" ng-if="createAup.aupReminder.$dirty && createAup.aupReminder.$error.required">
+                <span class="help-block">
+                    Required input
+                </span>
+            </div>
         </div>
     </form>
 </div>
 <div class="modal-footer">
-    <button class="btn btn-primary" type="button" id="modal-btn-confirm" ng-disabled="!$ctrl.aupVal.url || !$ctrl.aupVal.aupRemindersInDays || !$ctrl.enabled" ng-click="$ctrl.doCreateAup()">Create AUP</button>
+    <button class="btn btn-primary" type="button" id="modal-btn-confirm" ng-disabled="!$ctrl.enabled" ng-click="$ctrl.doCreateAup()">Create AUP</button>
 
     <button class="btn btn-warning" type="button" id="modal-btn-reset" ng-click="$ctrl.reset()">Reset form</button>
 

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/aup/aup.edit.dialog.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/aup/aup.edit.dialog.html
@@ -22,9 +22,14 @@
 </div>
 <div class="modal-body">
     <form name="createAup">
-        <div class="form-group" ng-class="{'has-error': $ctrl.error || createAup.url.$dirty && !createAup.url.$valid}">
+        <div class="form-group has-error" ng-if="$ctrl.error">
+            <span class="help-block">
+                {{ $ctrl.error }}
+            </span>
+        </div>
+        <div class="form-group">
             <label>Acceptable Usage Policy URL</label>
-            <input name="url" class="form-control" type="url" value="http://" ng-model="$ctrl.aupVal.url"
+            <input name="url" class="form-control" value="http://" ng-model="$ctrl.aupVal.url"
                 required="true">
             <span class="help-block" ng-if="$ctrl.aup.text">
                 Since v1.6.0, IAM has moved to external AUP documents. Please provide a valid URL pointing to your AUP
@@ -34,14 +39,12 @@
                 The URL above is presented to users at registration time or periodically
                 if the AUP is configured for periodic reacceptance
             </span>
-            <span class="help-block" ng-if="createAup.url.$dirty && createAup.url.$error.required">
-                Please provide a valid URL pointing to your AUP document.
-            </span>
-            <span class="help-block" ng-if="$ctrl.error">
-                {{ $ctrl.error }}
-            </span>
+            <div class="form-group has-error" ng-if="createAup.url.$dirty && createAup.url.$error.required">
+                <span class="help-block">
+                        Please provide a valid URL for the AUP
+                </span>
+            </div>
         </div>
-
         <div class="form-group">
             <label>AUP signature validity (in days)</label>
             <input name="signatureValidity" class="form-control" type="number" value="365"
@@ -52,15 +55,17 @@
                 If set to zero, the AUP signature will be asked only at registration time.
             </span>
         </div>
-        <div class="form-group" ng-if="$ctrl.aupVal.signatureValidityInDays > 0" ng-class="{'has-error': $ctrl.error || createAup.aupReminder.$dirty && !createAup.aupReminder.$valid}">
+        <div class="form-group" ng-if="$ctrl.aupVal.signatureValidityInDays > 0">
             <label>AUP signature reminders (in days)</label>
-            <input name="aupReminder" class="form-control" type="text" ng-model="$ctrl.aupVal.aupRemindersInDays" placeholder="30,15,1" required="true">
+            <input name="aupReminder" class="form-control" type="text" ng-model="$ctrl.aupVal.aupRemindersInDays" placeholder="30,15,1" ng-required="$ctrl.aupVal.signatureValidityInDays > 0">
             <span class="help-block">
                 Indicate a sequence of comma-separated numbers representing how many days before the AUP expiration reminder messages must be sent.
             </span>
-            <span class="help-block" ng-if="createAup.aupReminder.$dirty && createAup.aupReminder.$error.required">
-                Required input
-            </span>
+            <div class="form-group has-error" ng-if="createAup.aupReminder.$dirty && createAup.aupReminder.$error.required">
+                <span class="help-block">
+                    Required input
+                </span>
+            </div>
         </div>
         <div class="form-group">
             <div class="bs-callout bs-callout-primary">
@@ -74,7 +79,7 @@
 </div>
 <div class="modal-footer">
     <button class="btn btn-primary" type="button" id="modal-btn-confirm"
-        ng-disabled="!$ctrl.aupVal.url || !$ctrl.enabled" ng-click="$ctrl.doSaveAup()">Edit AUP</button>
+        ng-disabled="!$ctrl.enabled" ng-click="$ctrl.doSaveAup()">Edit AUP</button>
 
     <button class="btn btn-warning" type="button" id="modal-btn-reset" ng-click="$ctrl.reset()">Reset form</button>
 

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/aup/aup.edit.dialog.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/aup/aup.edit.dialog.html
@@ -52,7 +52,7 @@
                 If set to zero, the AUP signature will be asked only at registration time.
             </span>
         </div>
-        <div class="form-group" ng-class="{'has-error': $ctrl.error || createAup.aupReminder.$dirty && !createAup.aupReminder.$valid}">
+        <div class="form-group" ng-if="$ctrl.aupVal.signatureValidityInDays > 0" ng-class="{'has-error': $ctrl.error || createAup.aupReminder.$dirty && !createAup.aupReminder.$valid}">
             <label>AUP signature reminders (in days)</label>
             <input name="aupReminder" class="form-control" type="text" ng-model="$ctrl.aupVal.aupRemindersInDays" placeholder="30,15,1" required="true">
             <span class="help-block">

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/aup/AupIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/aup/AupIntegrationTests.java
@@ -122,8 +122,7 @@ public class AupIntegrationTests extends AupTestSupport {
     assertThat(createdAup.getAupRemindersInDays(), equalTo(""));
   }
 
-  private void aupCreationCausesBadRequest(AupDTO aup, String errorMessage)
-      throws JsonProcessingException, Exception {
+  private void aupCreationCausesBadRequest(AupDTO aup, String errorMessage) throws Exception {
     mvc
       .perform(
           post("/iam/aup").contentType(APPLICATION_JSON).content(mapper.writeValueAsString(aup)))
@@ -262,7 +261,8 @@ public class AupIntegrationTests extends AupTestSupport {
 
   @Test
   @WithMockUser(username = "admin", roles = {"ADMIN", "USER"})
-  public void aupCreationSetsEmptyValueForRemindersIfNullAndSignatureValidityIsZero() throws Exception {
+  public void aupCreationSetsEmptyValueForRemindersIfNullAndSignatureValidityIsZero()
+      throws Exception {
     AupDTO aup = new AupDTO(DEFAULT_AUP_URL, DEFAULT_AUP_TEXT, null, 0L, null, null, null);
 
     Date now = new Date();
@@ -295,8 +295,7 @@ public class AupIntegrationTests extends AupTestSupport {
 
   @Test
   @WithMockUser(username = "admin", roles = {"ADMIN", "USER"})
-  public void aupCreationSetsEmptyRemindersWhenEmptyAndSignatureValidityIsZero()
-      throws Exception {
+  public void aupCreationSetsEmptyRemindersWhenEmptyAndSignatureValidityIsZero() throws Exception {
     AupDTO aup = new AupDTO(DEFAULT_AUP_URL, DEFAULT_AUP_TEXT, null, 0L, null, null, "");
     Date now = new Date();
     mockTimeProvider.setTime(now.getTime());

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/aup/AupIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/aup/AupIntegrationTests.java
@@ -263,8 +263,7 @@ public class AupIntegrationTests extends AupTestSupport {
 
   @Test
   @WithMockUser(username = "admin", roles = {"ADMIN", "USER"})
-  public void aupCreationIgnoresRemindersIfSignatureValidityIsZero()
-      throws JsonProcessingException, Exception {
+  public void aupCreationIgnoresRemindersIfSignatureValidityIsZero() throws Exception {
     String reminders = "1,15,30";
     AupDTO aup = new AupDTO(DEFAULT_AUP_URL, DEFAULT_AUP_TEXT, null, 0L, null, null, reminders);
     Date now = new Date();


### PR DESCRIPTION
The custom validator for AUP signature validity and AUP reminders, introduced within IAM v1.10.0, checks that the value of the AUP reminders is less than the AUP signature validity. This PR fixes the case AUP signature validity is equal to 0. In particular:
* if AUP signature validity is set to 0, AUP reminders are set to an empty string
* when the AUP signature validity is 0, AUP reminders are also hidden from the interface