### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,37 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/java
+{
+	"name": "IAM Dev Container",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/java:1-17-bookworm",
+	"features": {
+		"ghcr.io/devcontainers/features/java:1": {
+			"version": "none",
+			"installMaven": "true",
+			"installGradle": "false"
+		}
+	},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [
+		8080
+	],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "java -version",
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"java.configuration.updateBuildConfiguration": "automatic",
+				"java.format.settings.url": "https://raw.githubusercontent.com/italiangrid/codestyle/master/eclipse-google-java-codestyle-formatter.xml",
+				"java.format.settings.profile": "GoogleStyle (CNAF)",
+				"maven.settingsFile": ".mvn/cnaf-mirror-settings.xml",
+				"java.configuration.maven.userSettings": ".mvn/cnaf-mirror-settings.xml"
+			},
+			"extensions": [
+				"vmware.vscode-boot-dev-pack"
+			]
+		}
+	},
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/h2/devcontainer.json
+++ b/.devcontainer/h2/devcontainer.json
@@ -1,40 +1,40 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/java
 {
-	"name": "IAM Dev Container - H2",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/java:1-17-bookworm",
-	"features": {
-		"ghcr.io/devcontainers/features/java:1": {
-			"version": "none",
-			"installMaven": "true",
-			"installGradle": "false"
-		}
-	},
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	"forwardPorts": [
-		8080
-	],
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "java -version",
-	// Configure tool-specific properties.
-	"customizations": {
-		"vscode": {
-			"settings": {
-				"java.configuration.updateBuildConfiguration": "automatic",
-				"java.format.settings.url": "https://raw.githubusercontent.com/italiangrid/codestyle/master/eclipse-google-java-codestyle-formatter.xml",
-				"java.format.settings.profile": "GoogleStyle (CNAF)",
-				"maven.settingsFile": ".mvn/cnaf-mirror-settings.xml",
-				"java.configuration.maven.userSettings": ".mvn/cnaf-mirror-settings.xml"
-			},
-			"extensions": [
-				"vmware.vscode-boot-dev-pack"
-			]
-		}
-	},
-	"containerEnv": {
-		"SPRING_PROFILES_ACTIVE": "h2-test,dev"
-	},
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+    "name": "IAM Dev Container - H2",
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "image": "mcr.microsoft.com/devcontainers/java:1-17-bookworm",
+    "features": {
+        "ghcr.io/devcontainers/features/java:1": {
+            "version": "none",
+            "installMaven": "true",
+            "installGradle": "false"
+        }
+    },
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    "forwardPorts": [
+        8080
+    ],
+    // Use 'postCreateCommand' to run commands after the container is created.
+    // "postCreateCommand": "java -version",
+    // Configure tool-specific properties.
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "java.configuration.updateBuildConfiguration": "automatic",
+                "java.format.settings.url": "https://raw.githubusercontent.com/italiangrid/codestyle/master/eclipse-google-java-codestyle-formatter.xml",
+                "java.format.settings.profile": "GoogleStyle (CNAF)",
+                "maven.settingsFile": ".mvn/cnaf-mirror-settings.xml",
+                "java.configuration.maven.userSettings": ".mvn/cnaf-mirror-settings.xml"
+            },
+            "extensions": [
+                "vmware.vscode-boot-dev-pack"
+            ]
+        }
+    },
+    "containerEnv": {
+        "SPRING_PROFILES_ACTIVE": "h2-test,dev"
+    },
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root"
 }

--- a/.devcontainer/h2/devcontainer.json
+++ b/.devcontainer/h2/devcontainer.json
@@ -1,0 +1,40 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/java
+{
+	"name": "IAM Dev Container - H2",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/java:1-17-bookworm",
+	"features": {
+		"ghcr.io/devcontainers/features/java:1": {
+			"version": "none",
+			"installMaven": "true",
+			"installGradle": "false"
+		}
+	},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [
+		8080
+	],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "java -version",
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"java.configuration.updateBuildConfiguration": "automatic",
+				"java.format.settings.url": "https://raw.githubusercontent.com/italiangrid/codestyle/master/eclipse-google-java-codestyle-formatter.xml",
+				"java.format.settings.profile": "GoogleStyle (CNAF)",
+				"maven.settingsFile": ".mvn/cnaf-mirror-settings.xml",
+				"java.configuration.maven.userSettings": ".mvn/cnaf-mirror-settings.xml"
+			},
+			"extensions": [
+				"vmware.vscode-boot-dev-pack"
+			]
+		}
+	},
+	"containerEnv": {
+		"SPRING_PROFILES_ACTIVE": "h2-test,dev"
+	},
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/mysql/compose.yaml
+++ b/.devcontainer/mysql/compose.yaml
@@ -2,7 +2,7 @@ services:
   devcontainer:
     image: mcr.microsoft.com/devcontainers/java:1-17-bookworm
     volumes:
-      - ../..:/workspaces/iam:cached
+      - ../..:/workspaces/iam
     network_mode: service:db
     user: vscode
     depends_on:

--- a/.devcontainer/mysql/compose.yaml
+++ b/.devcontainer/mysql/compose.yaml
@@ -1,0 +1,25 @@
+services:
+  devcontainer:
+    image: mcr.microsoft.com/devcontainers/java:1-17-bookworm
+    volumes:
+      - ../..:/workspaces/iam:cached
+    network_mode: service:db
+    user: vscode
+    depends_on:
+      - db
+    environment:
+      IAM_DB_HOST: db
+      IAM_DB_NAME: iam
+      IAM_DB_USERNAME: iam
+      IAM_DB_PASSWORD: pwd
+      SPRING_PROFILES_ACTIVE: mysql-test,dev
+    command: sleep infinity
+
+  db:
+    image: mariadb:latest
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: dev
+      MYSQL_DATABASE: iam
+      MYSQL_USER: iam
+      MYSQL_PASSWORD: pwd

--- a/.devcontainer/mysql/devcontainer.json
+++ b/.devcontainer/mysql/devcontainer.json
@@ -1,9 +1,12 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/java
 {
-	"name": "IAM Dev Container",
+	"name": "IAM Dev Container - MySQL",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/java:1-17-bookworm",
+	"dockerComposeFile": "compose.yaml",
+    "service": "devcontainer",
+    "workspaceFolder": "/workspaces/iam",
+	"shutdownAction": "stopCompose",
 	"features": {
 		"ghcr.io/devcontainers/features/java:1": {
 			"version": "none",

--- a/.devcontainer/mysql/devcontainer.json
+++ b/.devcontainer/mysql/devcontainer.json
@@ -1,40 +1,40 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/java
 {
-	"name": "IAM Dev Container - MySQL",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"dockerComposeFile": "compose.yaml",
+    "name": "IAM Dev Container - MySQL",
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "dockerComposeFile": "compose.yaml",
     "service": "devcontainer",
     "workspaceFolder": "/workspaces/iam",
-	"shutdownAction": "stopCompose",
-	"features": {
-		"ghcr.io/devcontainers/features/java:1": {
-			"version": "none",
-			"installMaven": "true",
-			"installGradle": "false"
-		}
-	},
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	"forwardPorts": [
-		8080
-	],
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "java -version",
-	// Configure tool-specific properties.
-	"customizations": {
-		"vscode": {
-			"settings": {
-				"java.configuration.updateBuildConfiguration": "automatic",
-				"java.format.settings.url": "https://raw.githubusercontent.com/italiangrid/codestyle/master/eclipse-google-java-codestyle-formatter.xml",
-				"java.format.settings.profile": "GoogleStyle (CNAF)",
-				"maven.settingsFile": ".mvn/cnaf-mirror-settings.xml",
-				"java.configuration.maven.userSettings": ".mvn/cnaf-mirror-settings.xml"
-			},
-			"extensions": [
-				"vmware.vscode-boot-dev-pack"
-			]
-		}
-	},
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+    "shutdownAction": "stopCompose",
+    "features": {
+        "ghcr.io/devcontainers/features/java:1": {
+            "version": "none",
+            "installMaven": "true",
+            "installGradle": "false"
+        }
+    },
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    "forwardPorts": [
+        8080
+    ],
+    // Use 'postCreateCommand' to run commands after the container is created.
+    // "postCreateCommand": "java -version",
+    // Configure tool-specific properties.
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "java.configuration.updateBuildConfiguration": "automatic",
+                "java.format.settings.url": "https://raw.githubusercontent.com/italiangrid/codestyle/master/eclipse-google-java-codestyle-formatter.xml",
+                "java.format.settings.profile": "GoogleStyle (CNAF)",
+                "maven.settingsFile": ".mvn/cnaf-mirror-settings.xml",
+                "java.configuration.maven.userSettings": ".mvn/cnaf-mirror-settings.xml"
+            },
+            "extensions": [
+                "vmware.vscode-boot-dev-pack"
+            ]
+        }
+    },
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root"
 }

--- a/.mvn/cnaf-mirror-settings.xml
+++ b/.mvn/cnaf-mirror-settings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<settings xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0  http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <!--<localRepository>/tmp/m2-repository</localRepository>-->
+    <interactiveMode>false</interactiveMode>
+    <mirrors>
+        <mirror>
+            <id>nexus</id>
+            <name>CNAF maven mirror</name>
+            <url>https://repo.cloud.cnaf.infn.it/repository/maven-public</url>
+            <mirrorOf>*</mirrorOf>
+        </mirror>
+    </mirrors>
+    <profiles>
+    <profile>
+      <id>nexus</id>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>http://central</url>
+          <releases><enabled>true</enabled></releases>
+          <snapshots><enabled>true</enabled></snapshots>
+        </repository>
+      </repositories>
+    </profile>
+    </profiles>
+    <activeProfiles>
+        <activeProfile>nexus</activeProfile>
+    </activeProfiles>
+</settings>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+--settings=./.mvn/cnaf-mirror-settings.xml


### PR DESCRIPTION
Add devcontainer configurations so that the development environment can easily be started on vscode. There are two devcontainers, one for the `h2` db and one for `mysql`.

They include:
- The `mcr.microsoft.com/devcontainers/java:1-17-bookworm` docker image
- Maven
- Forward port 8080 to the host
- VS code settings to use the Google Style (CNAF) formatter
- VS Code Spring Boot Application Development Extension Pack

On top of that, the mysql devcontainer is based on a compose file, which includes both the java dev image and a `mariadb` container. The DB connection is already configured and the `mysql-test,dev` spring profiles are selected.

Additionally, a repository-level maven settings file has been added to use the CNAF maven mirror. This applies to the``mvn`` command, even when run outside of the devcontainer.