### PR TITLE
Track refresh tokens in access token AUDIT logs

### DIFF
--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/RefreshTokenGranterTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/RefreshTokenGranterTests.java
@@ -15,28 +15,41 @@
  */
 package it.infn.mw.iam.test.oauth;
 
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.text.ParseException;
 import java.util.Date;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mitre.oauth2.model.AuthenticationHolderEntity;
 import org.mitre.oauth2.model.ClientDetailsEntity;
+import org.mitre.oauth2.model.OAuth2AccessTokenEntity;
+import org.mitre.oauth2.model.OAuth2RefreshTokenEntity;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Request;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jwt.JWT;
 
 import it.infn.mw.iam.IamLoginService;
 import it.infn.mw.iam.api.client.service.ClientService;
 import it.infn.mw.iam.api.client.util.ClientSuppliers;
+import it.infn.mw.iam.audit.events.tokens.AccessTokenIssuedEvent;
 import it.infn.mw.iam.persistence.model.IamAup;
 import it.infn.mw.iam.persistence.repository.IamAccountRepository;
 import it.infn.mw.iam.persistence.repository.IamAupRepository;
@@ -206,6 +219,32 @@ public class RefreshTokenGranterTests {
 
     client.setActive(true);
     clientService.updateClient(client);
+  }
+
+  @Test
+  public void testRefreshTokenParsingThrowsParseException() throws Exception {
+    OAuth2AccessTokenEntity accessToken = Mockito.mock(OAuth2AccessTokenEntity.class);
+    OAuth2RefreshTokenEntity refreshToken = Mockito.mock(OAuth2RefreshTokenEntity.class);
+    AuthenticationHolderEntity authnHolder = Mockito.mock(AuthenticationHolderEntity.class);
+    OAuth2Authentication authn = Mockito.mock(OAuth2Authentication.class);
+    OAuth2Request req = Mockito.mock(OAuth2Request.class);
+
+    JWT jwt = Mockito.mock(JWT.class);
+
+    when(accessToken.getRefreshToken()).thenReturn(refreshToken);
+    when(accessToken.getAuthenticationHolder()).thenReturn(authnHolder);
+    when(accessToken.getAuthenticationHolder().getAuthentication()).thenReturn(authn);
+    when(authn.getOAuth2Request()).thenReturn(req);
+    when(accessToken.getJwt()).thenReturn(jwt);
+    JWSHeader header = new JWSHeader(JWSAlgorithm.HS256);
+    when(jwt.getHeader()).thenReturn(header);
+    when(accessToken.getRefreshToken().getJwt()).thenReturn(jwt);
+    when(jwt.getJWTClaimsSet()).thenThrow(new ParseException("parse error", 0));
+
+    AccessTokenIssuedEvent event = new AccessTokenIssuedEvent(this, accessToken);
+
+    assertNull(event.getRefreshTokenJti());
+
   }
 
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/RefreshTokenGranterTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/RefreshTokenGranterTests.java
@@ -15,8 +15,8 @@
  */
 package it.infn.mw.iam.test.oauth;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -262,7 +262,7 @@ public class RefreshTokenGranterTests extends TestTokensUtils {
     String refreshTokenJti = accessToken.getRefreshToken().getJwt().getJWTClaimsSet().getJWTID();
 
     AccessTokenIssuedEvent event = new AccessTokenIssuedEvent(this, accessToken);
-    assertThat(event.getRefreshTokenJti().equals(refreshTokenJti));
+    assertTrue(event.getRefreshTokenJti().equals(refreshTokenJti));
 
   }
 


### PR DESCRIPTION
In particular, expose the `jti` (JWT ID) of the refresh token.
We'll see the `refreshTokenJti` claim in the access token AUDIT log.

Example:
```
2024-09-02 15:29:00.687  INFO 81282 --- [io-8080-exec-10] AUDIT                                    : {"@type":"AccessTokenIssuedEvent","timestamp":1725283740682,"category":"TOKEN","principal":"client","message":"Issue access token","scopes":["openid","profile","offline_access","scim:read","scim:write","iam:admin.read","iam:admin.write"],"subject":"admin","grantType":"authorization_code","header":{"kid":"rsa1","alg":"RS256"},"payload":{"iss":"http://localhost:8080","iat":1725283740633,"exp":1725287340609,"sub":"73f16d93-2441-4a50-88ff-85360d78c6b5","jti":"f3b6255d-f8f3-48fe-8eba-92139ae35abf","client_id":"client","groups":[],"preferred_username":"admin","organisation_name":"indigo-dc","name":"Admin User"},"refreshTokenJti":"2c2583ab-0e9e-4c4d-a329-a449509782b1","source":"IamTokenService"}
```