### PR TITLE
Combine CERN HR logic with internal life-cycle

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/labels/AccountLabelsController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/labels/AccountLabelsController.java
@@ -94,7 +94,7 @@ public class AccountLabelsController {
     handleValidationError(validationResult);
     IamAccount account = service.findByUuid(id).orElseThrow(noSuchAccountError(id));
 
-    service.setLabel(account, converter.entityFromDto(label));
+    service.addLabel(account, converter.entityFromDto(label));
   }
 
   @RequestMapping(method = DELETE)

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/registration/cern/CernHrDBApiService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/registration/cern/CernHrDBApiService.java
@@ -22,8 +22,6 @@ import it.infn.mw.iam.api.registration.cern.dto.VOPersonDTO;
 @Profile("cern")
 public interface CernHrDBApiService {
 
-  boolean hasValidExperimentParticipation(String personId);
-
   VOPersonDTO getHrDbPersonRecord(String personId);
 
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/registration/cern/DefaultCernHrDBApiService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/registration/cern/DefaultCernHrDBApiService.java
@@ -20,7 +20,6 @@ import static java.lang.String.format;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -48,7 +47,6 @@ public class DefaultCernHrDBApiService implements CernHrDBApiService {
   final RestTemplateFactory rtFactory;
   final CernProperties properties;
 
-  @Autowired
   public DefaultCernHrDBApiService(RestTemplateFactory rtFactory, CernProperties properties) {
     this.rtFactory = rtFactory;
     this.properties = properties;
@@ -62,26 +60,6 @@ public class DefaultCernHrDBApiService implements CernHrDBApiService {
         properties.getHrApi().getPassword()));
 
     return headers;
-  }
-
-  @Override
-  public boolean hasValidExperimentParticipation(String personId) {
-    RestTemplate rt = rtFactory.newRestTemplate();
-
-    String personValidUrl = String.format("%s%s", properties.getHrApi().getUrl(),
-        format(PARTICIPATION_API_PATH_TEMPLATE, properties.getExperimentName(), personId));
-
-    LOG.debug("Querying HR db participation API for person {} at URL {}", personId, personValidUrl);
-
-    try {
-
-      ResponseEntity<Boolean> response = rt.exchange(personValidUrl, HttpMethod.GET,
-          new HttpEntity<>(buildAuthHeaders()), Boolean.class);
-      return response.getBody();
-    } catch (RestClientException e) {
-      final String errorMsg = "HR db api error: " + e.getMessage();
-      throw new CernHrDbApiError(errorMsg, e);
-    } 
   }
 
   @Override

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/registration/cern/mock/MockCernAuthController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/registration/cern/mock/MockCernAuthController.java
@@ -17,7 +17,6 @@ package it.infn.mw.iam.api.registration.cern.mock;
 
 import static it.infn.mw.iam.authn.ExternalAuthenticationHandlerSupport.EXT_AUTHN_UNREGISTERED_USER_AUTH;
 import static org.springframework.security.web.context.HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY;
-import static org.springframework.web.bind.annotation.RequestMethod.GET;
 
 import java.time.Instant;
 import java.util.Date;
@@ -30,7 +29,7 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 
 import it.infn.mw.iam.api.registration.cern.CernHrDBApiService;
 import it.infn.mw.iam.api.registration.cern.dto.InstituteDTO;
@@ -47,7 +46,7 @@ public class MockCernAuthController implements CernHrDBApiService {
   @Autowired
   CernProperties properties;
 
-  @RequestMapping(method = GET, path = "/mock-cern-auth")
+  @GetMapping("/mock-cern-auth")
   public String mockCernAuthentication(HttpSession session) {
 
     OidcSecurityContextBuilder builder = new OidcSecurityContextBuilder();
@@ -67,11 +66,6 @@ public class MockCernAuthController implements CernHrDBApiService {
     session.setAttribute(SPRING_SECURITY_CONTEXT_KEY, context);
 
     return "redirect:/start-registration";
-  }
-
-  @Override
-  public boolean hasValidExperimentParticipation(String personId) {
-    return false;
   }
 
   @Override

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/ExpiredAccountsHandler.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/ExpiredAccountsHandler.java
@@ -46,7 +46,7 @@ import it.infn.mw.iam.persistence.repository.IamAccountRepository;
 public class ExpiredAccountsHandler implements Runnable {
 
   public enum AccountLifecycleStatus {
-    OK, PENDING_SUSPENSION, PENDING_REMOVAL, SUSPENDED
+    PENDING_SUSPENSION, PENDING_REMOVAL, SUSPENDED
   }
 
   public static final String LIFECYCLE_TIMESTAMP_LABEL = "lifecycle.timestamp";

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/ExpiredAccountsHandler.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/ExpiredAccountsHandler.java
@@ -207,7 +207,7 @@ public class ExpiredAccountsHandler implements Runnable {
     accountsScheduledForRemoval.clear();
 
     checkTime = getTomorrowMidnight();
-    LOG.debug("Comparing end-time with {}", checkTime.toString());
+    LOG.debug("Comparing end-time with {}", checkTime);
 
     Pageable pageRequest = PageRequest.of(0, PAGE_SIZE, Sort.by(Direction.ASC, "endTime"));
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/ExpiredAccountsHandler.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/ExpiredAccountsHandler.java
@@ -202,10 +202,12 @@ public class ExpiredAccountsHandler implements Runnable {
 
   public void handleExpiredAccounts() {
 
+    LOG.info("Expired accounts handler ... [START]");
+
     accountsScheduledForRemoval.clear();
 
-    LOG.debug("Starting...");
     checkTime = getTomorrowMidnight();
+    LOG.debug("Comparing end-time with {}", checkTime.toString());
 
     Pageable pageRequest = PageRequest.of(0, PAGE_SIZE, Sort.by(Direction.ASC, "endTime"));
 
@@ -232,6 +234,9 @@ public class ExpiredAccountsHandler implements Runnable {
     for (IamAccount a : accountsScheduledForRemoval) {
       removeAccount(a);
     }
+
+    LOG.info("Expired accounts handler ... [END]");
+
   }
 
   @Override

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/ExpiredAccountsHandler.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/ExpiredAccountsHandler.java
@@ -96,7 +96,7 @@ public class ExpiredAccountsHandler implements Runnable {
   }
 
   private void addStatusLabel(IamAccount expiredAccount, AccountLifecycleStatus status) {
-    accountService.setLabel(expiredAccount,
+    accountService.addLabel(expiredAccount,
         IamLabel.builder().name(LIFECYCLE_STATUS_LABEL).value(status.name()).build());
   }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/ExpiredAccountsHandler.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/ExpiredAccountsHandler.java
@@ -190,13 +190,12 @@ public class ExpiredAccountsHandler implements Runnable {
     }
   }
 
-  private Instant getTomorrowMidnight() {
+  private Instant getLastMidnight() {
     ZonedDateTime zdt = ZonedDateTime.ofInstant(clock.instant(), ZoneId.systemDefault());
     Calendar c = GregorianCalendar.from(zdt);
     c.set(Calendar.HOUR_OF_DAY, 0);
     c.set(Calendar.MINUTE, 0);
     c.set(Calendar.SECOND, 0);
-    c.add(Calendar.DATE, 1);
     return c.toInstant();
   }
 
@@ -206,7 +205,7 @@ public class ExpiredAccountsHandler implements Runnable {
 
     accountsScheduledForRemoval.clear();
 
-    checkTime = getTomorrowMidnight();
+    checkTime = getLastMidnight();
     LOG.debug("Comparing end-time with {}", checkTime);
 
     Pageable pageRequest = PageRequest.of(0, PAGE_SIZE, Sort.by(Direction.ASC, "endTime"));

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/cern/CernHrLifecycleHandler.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/cern/CernHrLifecycleHandler.java
@@ -18,7 +18,6 @@ package it.infn.mw.iam.core.lifecycle.cern;
 import static it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler.LIFECYCLE_STATUS_LABEL;
 import static it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler.AccountLifecycleStatus.PENDING_REMOVAL;
 import static it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler.AccountLifecycleStatus.SUSPENDED;
-import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.Action.NO_ACTION;
 import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.Status.ERROR;
 import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.Status.EXPIRED;
 import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.Status.IGNORED;
@@ -76,10 +75,6 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
 
   public static final Logger LOG = LoggerFactory.getLogger(CernHrLifecycleHandler.class);
 
-  public enum Action {
-    NO_ACTION, DISABLE_ACCOUNT, RESTORE_ACCOUNT
-  }
-
   public enum Status {
     MEMBER, EXPIRED, IGNORED, ERROR
   }
@@ -107,11 +102,10 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
     this.hrDb = hrDb;
   }
 
-  private IamLabel buildActionLabel(Action action) {
+  private IamLabel buildActionLabel() {
     return IamLabel.builder()
       .prefix(LABEL_CERN_PREFIX)
       .name(LABEL_ACTION)
-      .value(action.name())
       .build();
   }
 
@@ -210,7 +204,7 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
     }
 
     // Clear old IAM versions labels
-    accountService.deleteLabel(account, buildActionLabel(NO_ACTION));
+    accountService.deleteLabel(account, buildActionLabel());
 
     // 2. Retrieve VO person data from HR database
     Optional<VOPersonDTO> voPerson = Optional.empty();

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/cern/CernHrLifecycleHandler.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/cern/CernHrLifecycleHandler.java
@@ -15,21 +15,26 @@
  */
 package it.infn.mw.iam.core.lifecycle.cern;
 
-import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.Action.DISABLE_ACCOUNT;
+import static it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler.LIFECYCLE_STATUS_LABEL;
+import static it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler.AccountLifecycleStatus.PENDING_REMOVAL;
+import static it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler.AccountLifecycleStatus.SUSPENDED;
 import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.Action.NO_ACTION;
-import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.Action.RESTORE_ACCOUNT;
-import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.Status.OK;
+import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.Status.ERROR;
+import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.Status.EXPIRED;
+import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.Status.IGNORED;
+import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.Status.MEMBER;
 import static java.lang.String.format;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.util.Date;
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Supplier;
 
+import org.joda.time.DateTimeComparator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -38,8 +43,12 @@ import org.springframework.scheduling.annotation.SchedulingConfigurer;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 import org.springframework.stereotype.Component;
 
+import com.google.common.collect.Lists;
+
 import it.infn.mw.iam.api.registration.cern.CernHrDBApiService;
+import it.infn.mw.iam.api.registration.cern.dto.ParticipationDTO;
 import it.infn.mw.iam.api.registration.cern.dto.VOPersonDTO;
+import it.infn.mw.iam.api.scim.exception.IllegalArgumentException;
 import it.infn.mw.iam.config.cern.CernProperties;
 import it.infn.mw.iam.core.user.IamAccountService;
 import it.infn.mw.iam.persistence.model.IamAccount;
@@ -50,23 +59,29 @@ import it.infn.mw.iam.persistence.repository.IamAccountRepository;
 @Profile("cern")
 public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
 
+  public static final String INVALID_ACCOUNT_MESSAGE = "Account has not the mandatory CERN person id label";
+
   public static final String IGNORE_MESSAGE = "Skipping account as requested by the 'ignore' label";
+  public static final String RESTORED_MESSAGE = "Account restored on %s";
+  public static final String NO_PARTICIPATION_MESSAGE = "Account end-time not updated: no participation to %s found";
+  public static final String EXPIRED_MESSAGE = "Account participation to the experiment is expired";
+  public static final String VALID_MESSAGE = "Account has a valid participation to the experiment";
+
   public static final String HR_DB_API_ERROR = "Account not updated: HR DB error";
-  public static final String PERSON_ID_NOT_FOUND_TEMPLATE = "%s not found";
 
   public static final int DEFAULT_PAGE_SIZE = 50;
+
+  protected static final List<String> SUSPENDED_STATUSES =
+      Lists.newArrayList(SUSPENDED.name(), PENDING_REMOVAL.name());
 
   public static final Logger LOG = LoggerFactory.getLogger(CernHrLifecycleHandler.class);
 
   public enum Action {
-    NO_ACTION,
-    DISABLE_ACCOUNT,
-    RESTORE_ACCOUNT
+    NO_ACTION, DISABLE_ACCOUNT, RESTORE_ACCOUNT
   }
 
   public enum Status {
-    OK,
-    ERROR
+    MEMBER, EXPIRED, IGNORED, ERROR
   }
 
   public static final String LABEL_CERN_PREFIX = "hr.cern";
@@ -83,7 +98,6 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
   private final IamAccountService accountService;
   private final CernHrDBApiService hrDb;
 
-  @Autowired
   public CernHrLifecycleHandler(Clock clock, CernProperties cernProperties,
       IamAccountRepository accountRepo, IamAccountService accountService, CernHrDBApiService hrDb) {
     this.clock = clock;
@@ -91,11 +105,6 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
     this.accountRepo = accountRepo;
     this.accountService = accountService;
     this.hrDb = hrDb;
-  }
-
-  private Supplier<IllegalArgumentException> personIdNotFound(IamAccount a) {
-    return () -> new IllegalArgumentException(
-        "CERN person id not found for account " + a.getUsername());
   }
 
   private IamLabel buildActionLabel(Action action) {
@@ -126,121 +135,120 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
     return IamLabel.builder().prefix(LABEL_CERN_PREFIX).name(LABEL_MESSAGE).value(message).build();
   }
 
-  public void addErrorMessage(IamAccount account, String message) {
-    account.getLabels().add(buildStatusLabel(Status.ERROR));
-    account.getLabels().add(buildMessageLabel(message));
+  private IamLabel buildIamStatusLabel() {
+    return IamLabel.builder().name(LIFECYCLE_STATUS_LABEL).build();
   }
 
-  private void syncMembershipInformation(IamAccount account) {
-    IamLabel cernPersonId = getPersonIdLabel(account).orElseThrow(personIdNotFound(account));
+  private Optional<ParticipationDTO> syncAccountInformation(IamAccount a, VOPersonDTO p) {
 
-    VOPersonDTO voPerson = hrDb.getHrDbPersonRecord(cernPersonId.getValue());
-    LOG.debug("Syncing IAM account {} information against CERN HR db record {}",
-        account.getUsername(), voPerson.getId());
+    LOG.debug("Syncing IAM account '{}' with CERN HR record id '{}'", a.getUsername(), p.getId());
 
-    account.getUserInfo().setGivenName(voPerson.getFirstName());
-    account.getUserInfo().setFamilyName((voPerson.getName()));
+    LOG.debug("Updating Given Name for {} to {} ...", a.getUsername(), p.getFirstName());
+    a.getUserInfo().setGivenName(p.getFirstName());
+    LOG.debug("Updating Family Name for {} to {} ...", a.getUsername(), p.getName());
+    a.getUserInfo().setFamilyName(p.getName());
 
     Optional<IamLabel> skipEmailSyncLabel =
-        account.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_SKIP_EMAIL_SYNCH);
+        a.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_SKIP_EMAIL_SYNCH);
 
     if (skipEmailSyncLabel.isPresent() && LOG.isInfoEnabled()) {
-      LOG.info(
-          "Skipping email synchronization for account '{} ({})' as requested by the label '{}'",
-          account.getUsername(), account.getUuid(), skipEmailSyncLabel.get().qualifiedName());
+      LOG.debug("Skipping email synchronization for '{}': label '{}' is present", a.getUsername(),
+          skipEmailSyncLabel.get().qualifiedName());
     } else {
-      Optional<IamAccount> otherAccount =
-          accountRepo.findByEmailWithDifferentUUID(voPerson.getEmail(), account.getUuid());
-      if (otherAccount.isPresent()) {
+      Optional<IamAccount> o = accountRepo.findByEmailWithDifferentUUID(p.getEmail(), a.getUuid());
+      if (o.isPresent()) {
         LOG.error(
-            "Email for VO person {} is already mapped to another account: '{}-{}'. Will skip syncing against that email",
-            voPerson.getId(), otherAccount.get().getUsername(), otherAccount.get().getUuid());
+            "Skipping email synchronization for '{}': email already bounded to another user ('{}')",
+            a.getUsername(), o.get().getUsername());
       } else {
-        account.getUserInfo().setEmail(voPerson.getEmail());
+        LOG.debug("Updating Email for {} to {} ...", a.getUsername(), p.getEmail());
+        a.getUserInfo().setEmail(p.getEmail());
       }
     }
 
-  }
+    Optional<ParticipationDTO> experimentParticipation =
+        getExperimentParticipation(p, cernProperties.getExperimentName());
 
-  private boolean accountWasSuspendedByCernHrLifecycleJob(IamAccount account) {
-    Optional<IamLabel> actionLabel =
-        account.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_ACTION);
-
-    return actionLabel.isPresent() && actionLabel.get().getValue().equals(DISABLE_ACCOUNT.name());
-  }
-
-  private void disableAccount(IamAccount account) {
-    LOG.info("No valid HR record found for account {} -> Disabling account", account.getUsername());
-
-    accountService.disableAccount(account);
-    accountService.setAccountEndTime(account, Date.from(clock.instant()));
-
-    accountService.setLabel(account, buildStatusLabel(OK));
-    accountService.setLabel(account, buildActionLabel(DISABLE_ACCOUNT));
-  }
-
-  private void restoreAccount(IamAccount account) {
-    LOG.info("A valid HR record was found for account {} -> restoring account",
-        account.getUsername());
-
-    accountService.restoreAccount(account);
-    accountService.setAccountEndTime(account, null);
-
-    accountService.setLabel(account, buildStatusLabel(OK));
-    accountService.setLabel(account, buildActionLabel(RESTORE_ACCOUNT));
-  }
-
-  public void handleValidAccount(IamAccount account) {
-    syncMembershipInformation(account);
-    if (!account.isActive() && accountWasSuspendedByCernHrLifecycleJob(account)) {
-      restoreAccount(account);
-    } else {
-      accountService.setLabel(account, buildStatusLabel(OK));
-      accountService.setLabel(account, buildActionLabel(NO_ACTION));
+    if (experimentParticipation.isPresent()) {
+      LOG.debug("Updating end-time for {} to {} ...", a.getUsername(),
+          experimentParticipation.get().getEndDate());
+      a.setEndTime(experimentParticipation.get().getEndDate());
     }
+    return experimentParticipation;
   }
 
-  public void handleInvalidAccount(IamAccount account) {
-    if (account.isActive()) {
-      disableAccount(account);
-    } else {
-      accountService.setLabel(account, buildStatusLabel(OK));
+  private boolean accountWasSuspendedByIamLifecycleJob(IamAccount a) {
+    Optional<IamLabel> statusLabel = a.getLabelByName(LIFECYCLE_STATUS_LABEL);
+    return statusLabel.isPresent() && SUSPENDED_STATUSES.contains(statusLabel.get().getValue());
+  }
+
+  private String getCernPersonId(IamAccount a) {
+    Optional<IamLabel> cernPersonIdLabel =
+        a.getLabelByPrefixAndName(LABEL_CERN_PREFIX, cernProperties.getPersonIdClaim());
+    if (cernPersonIdLabel.isEmpty()) {
+      LOG.error("Account '{}' should have CERN person id label set!", a.getUsername());
+      throw new IllegalArgumentException(INVALID_ACCOUNT_MESSAGE);
     }
-  }
-
-  public void handleIgnoredAccount(IamAccount account) {
-    accountService.setLabel(account, buildStatusLabel(OK));
-    accountService.setLabel(account, buildActionLabel(NO_ACTION));
-    accountService.setLabel(account, buildMessageLabel(IGNORE_MESSAGE));
-  }
-
-  private Optional<IamLabel> getPersonIdLabel(IamAccount account) {
-    return account.getLabelByPrefixAndName(LABEL_CERN_PREFIX, cernProperties.getPersonIdClaim());
+    return cernPersonIdLabel.get().getValue();
   }
 
   public void handleAccount(IamAccount account) {
+
     LOG.debug("Handling account: {}", account);
+    String cernPersonId = getCernPersonId(account);
+    LOG.debug("Account CERN person id: {}", cernPersonId);
+
+    // 0. Update time-stamp label
     Instant checkTime = clock.instant();
     accountService.setLabel(account, buildTimestampLabel(checkTime));
-    Optional<IamLabel> cernPersonId = getPersonIdLabel(account);
-    if (!cernPersonId.isPresent()) {
-      addErrorMessage(account,
-          format(PERSON_ID_NOT_FOUND_TEMPLATE, cernProperties.getPersonIdClaim()));
-    } else {
-      if (account.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_IGNORE).isPresent()) {
-        handleIgnoredAccount(account);
-      } else {
-        try {
-          if (hrDb.hasValidExperimentParticipation(cernPersonId.get().getValue())) {
-            handleValidAccount(account);
-          } else {
-            handleInvalidAccount(account);
-          }
-        } catch (RuntimeException e) {
-          LOG.error("Error contacting HR DB api: {}", e.getMessage(), e);
-          addErrorMessage(account, format(HR_DB_API_ERROR));
-        }
+
+    // 1. Ignore account if label is set
+    if (account.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_IGNORE).isPresent()) {
+      accountService.setLabel(account, buildStatusLabel(IGNORED));
+      accountService.setLabel(account, buildMessageLabel(IGNORE_MESSAGE));
+      return;
+    }
+
+    // Clear old IAM versions labels
+    accountService.deleteLabel(account, buildActionLabel(NO_ACTION));
+
+    // 2. Retrieve VO person data from HR database
+    Optional<VOPersonDTO> voPerson = Optional.empty();
+    try {
+      voPerson = Optional.ofNullable(hrDb.getHrDbPersonRecord(cernPersonId));
+    } catch (RuntimeException e) {
+      LOG.error("Error contacting HR DB api: {}", e.getMessage(), e);
+    }
+    if (Objects.isNull(voPerson) || voPerson.isEmpty()) {
+      accountService.setLabel(account, buildStatusLabel(ERROR));
+      accountService.setLabel(account, buildMessageLabel(format(HR_DB_API_ERROR)));
+      return;
+    }
+
+    // 3. Sync info: NAME, EndTime and|or EMAIL
+    Optional<ParticipationDTO> experimentParticipation = syncAccountInformation(account, voPerson.get());
+    if (experimentParticipation.isEmpty()) {
+      accountService.setLabel(account, buildStatusLabel(ERROR));
+      accountService.setLabel(account,
+          buildMessageLabel(format(NO_PARTICIPATION_MESSAGE, cernProperties.getExperimentName())));
+      return;
+    }
+
+    if (isValidExperimentParticipation(experimentParticipation.get())) {
+      accountService.setLabel(account, buildStatusLabel(MEMBER));
+      if (account.isActive()) {
+        // 4a. Valid participation and user is not suspended
+        accountService.setLabel(account, buildMessageLabel(format(VALID_MESSAGE)));
+      } else if (accountWasSuspendedByIamLifecycleJob(account)) {
+        // 4b. Valid participation and user has been suspended by IAM expired accounts handler: restore!
+        accountService.restoreAccount(account);
+        accountService.setLabel(account, buildMessageLabel(format(RESTORED_MESSAGE, checkTime)));
+        accountService.deleteLabel(account, buildIamStatusLabel());
       }
+    } else {
+      // 4c. Invalid participation found: let IAM expired accounts handler do its job
+      accountService.setLabel(account, buildStatusLabel(EXPIRED));
+      accountService.setLabel(account, buildMessageLabel(format(EXPIRED_MESSAGE)));
     }
   }
 
@@ -257,7 +265,11 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
 
       if (accountsPage.hasContent()) {
         for (IamAccount account : accountsPage.getContent()) {
-          handleAccount(account);
+          try {
+            handleAccount(account);
+          } catch (RuntimeException e) {
+            LOG.error("Error during CERN HR lifecycle handler: {}", e.getMessage());
+          }
         }
       }
 
@@ -279,5 +291,21 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
       LOG.info("Scheduling CERN HR DB lifecycle handler with schedule: {}", cronSchedule);
       taskRegistrar.addCronTask(this, cronSchedule);
     }
+  }
+
+  private Optional<ParticipationDTO> getExperimentParticipation(VOPersonDTO voPerson,
+      String experimentName) {
+    return voPerson.getParticipations()
+      .stream()
+      .filter(p -> p.getExperiment().equalsIgnoreCase(experimentName))
+      .findFirst();
+  }
+
+  private boolean isValidExperimentParticipation(ParticipationDTO participation) {
+    if (Objects.isNull(participation.getEndDate())) {
+      return true;
+    }
+    return DateTimeComparator.getDateOnlyInstance()
+      .compare(participation.getEndDate(), new Date()) >= 0;
   }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/cern/CernHrLifecycleHandler.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/cern/CernHrLifecycleHandler.java
@@ -108,7 +108,7 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
     this.hrDb = hrDb;
   }
 
-  private IamAccount syncAccountInformation(IamAccount a, VOPersonDTO p) {
+  private void syncAccountInformation(IamAccount a, VOPersonDTO p) {
 
     LOG.debug("Syncing IAM account '{}' with CERN HR record id '{}'", a.getUsername(), p.getId());
 
@@ -121,8 +121,10 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
         a.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_SKIP_EMAIL_SYNCH);
 
     if (skipEmailSyncLabel.isPresent()) {
-      LOG.debug("Skipping email synchronization for '{}': label '{}' is present", a.getUsername(),
-          skipEmailSyncLabel.get().qualifiedName());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Skipping email synchronization for '{}': label '{}' is present", a.getUsername(),
+            skipEmailSyncLabel.get().qualifiedName());
+      }
     } else {
       LOG.debug("Updating Email for {} to {} ...", a.getUsername(), p.getEmail());
       try {
@@ -131,7 +133,6 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
         LOG.error(e.getMessage());
       }
     }
-    return a;
   }
 
   private boolean accountWasSuspendedByIamLifecycleJob(IamAccount a) {
@@ -158,7 +159,7 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
 
     // 0. Update time-stamp label
     Instant checkTime = clock.instant();
-    account = accountService.addLabel(account, buildCernTimestampLabel(checkTime));
+    accountService.addLabel(account, buildCernTimestampLabel(checkTime));
 
     // 1. Ignore account if label is set
     if (account.hasLabel(buildCernIgnoreLabel())) {
@@ -184,7 +185,7 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
     }
 
     // 3a. Sync info: Given Name, Family Name and Email
-    account = syncAccountInformation(account, voPerson.get());
+    syncAccountInformation(account, voPerson.get());
 
     // 3b. Sync end-time
     Optional<ParticipationDTO> ep = getExperimentParticipation(voPerson.get(), experimentName);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/user/DefaultIamAccountService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/user/DefaultIamAccountService.java
@@ -439,6 +439,7 @@ public class DefaultIamAccountService implements IamAccountService, ApplicationE
   public IamAccount setAccountEmail(IamAccount account, String email)
       throws EmailAlreadyBoundException {
     checkNotNull(account, "Cannot set email on a null account");
+    checkNotNull(email, "Cannot set null email");
     if (ObjectUtils.notEqual(account.getUserInfo().getEmail(), email)) {
       Optional<IamAccount> o = accountRepo.findByEmailWithDifferentUUID(email, account.getUuid());
       if (o.isPresent()) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/user/IamAccountService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/user/IamAccountService.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import it.infn.mw.iam.core.user.exception.EmailAlreadyBoundException;
 import it.infn.mw.iam.persistence.model.IamAccount;
 import it.infn.mw.iam.persistence.model.IamAttribute;
 import it.infn.mw.iam.persistence.model.IamGroup;
@@ -77,13 +78,13 @@ public interface IamAccountService {
   List<IamAccount> deleteInactiveProvisionedUsersSinceTime(Date timestamp);
 
   /**
-   * Sets a label for a given account
+   * Add a label for a given account or replace the value of an existent one
    * 
    * @param account
    * @param label
    * @return the updated account
    */
-  IamAccount setLabel(IamAccount account, IamLabel label);
+  IamAccount addLabel(IamAccount account, IamLabel label);
 
   /**
    * Deletes a label for a given account
@@ -93,7 +94,32 @@ public interface IamAccountService {
    * @return the updated account
    */
   IamAccount deleteLabel(IamAccount account, IamLabel label);
-  
+
+  /**
+   * Sets Given Name for a given account
+   * @param account
+   * @param givenName
+   * @return the updated account
+   */
+  IamAccount setAccountGivenName(IamAccount account, String givenName);
+
+  /**
+   * Sets Family Name for a given account
+   * @param account
+   * @param familyName
+   * @return the updated account
+   */
+  IamAccount setAccountFamilyName(IamAccount account, String familyName);
+
+  /**
+   * Sets Email for a given account
+   * @param account
+   * @param email
+   * @throw EmailAlreadyBoundException
+   * @return the updated account
+   */
+  IamAccount setAccountEmail(IamAccount account, String email) throws EmailAlreadyBoundException;
+
   /**
    * Sets end time for a given account
    * @param account
@@ -101,7 +127,7 @@ public interface IamAccountService {
    * @return the updated account
    */
   IamAccount setAccountEndTime(IamAccount account, Date endTime);
-  
+
   /**
    * Disables account
    * @param account

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/user/exception/EmailAlreadyBoundException.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/user/exception/EmailAlreadyBoundException.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.core.user.exception;
+
+import static java.lang.String.format;
+
+public class EmailAlreadyBoundException extends IamAccountException {
+
+  /**
+   * 
+   */
+  private static final long serialVersionUID = 4103663720620113509L;
+
+  public EmailAlreadyBoundException(String email, String targetUser, String emailOwner) {
+    super(format(
+        "Unable to set email '%s' to user '%s': email already bounded to another user ('%s')",
+        email, targetUser, emailOwner));
+  }
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/registration/validation/CernHrDbRequestValidatorService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/registration/validation/CernHrDbRequestValidatorService.java
@@ -23,11 +23,11 @@ import static it.infn.mw.iam.registration.validation.RegistrationRequestValidati
 import static java.lang.String.format;
 import static java.util.Objects.isNull;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
@@ -45,14 +45,11 @@ import it.infn.mw.iam.registration.RegistrationRequestDto;
 @Profile("cern")
 public class CernHrDbRequestValidatorService implements RegistrationRequestValidationService {
 
-
-
   public static final Logger LOG = LoggerFactory.getLogger(CernHrDbRequestValidatorService.class);
 
   final CernHrDBApiService hrDbApi;
   final CernProperties cernProperties;
 
-  @Autowired
   public CernHrDbRequestValidatorService(CernHrDBApiService hrDbApi, CernProperties properties) {
     this.hrDbApi = hrDbApi;
     this.cernProperties = properties;
@@ -72,9 +69,7 @@ public class CernHrDbRequestValidatorService implements RegistrationRequestValid
     request.getLabels().add(label);
   }
 
-  public void synchronizeInfo(RegistrationRequestDto request, String personId) {
-
-    VOPersonDTO voPersonDTO = hrDbApi.getHrDbPersonRecord(personId);
+  public void synchronizeInfo(RegistrationRequestDto request, VOPersonDTO voPersonDTO) {
 
     request.setGivenname(voPersonDTO.getFirstName());
     request.setFamilyname(voPersonDTO.getName());
@@ -106,9 +101,10 @@ public class CernHrDbRequestValidatorService implements RegistrationRequestValid
     }
 
     try {
-      if (hrDbApi.hasValidExperimentParticipation(cernPersonId)) {
+      VOPersonDTO voPersonDTO = hrDbApi.getHrDbPersonRecord(cernPersonId);
+      if (hasValidParticipationToExperiment(voPersonDTO)) {
         addPersonIdLabel(registrationRequest, cernPersonId);
-        synchronizeInfo(registrationRequest, cernPersonId);
+        synchronizeInfo(registrationRequest, voPersonDTO);
         return ok();
       }
     } catch (CernHrDbApiError e) {
@@ -119,4 +115,12 @@ public class CernHrDbRequestValidatorService implements RegistrationRequestValid
         auth.getGivenName(), auth.getFamilyName(), cernPersonId));
   }
 
+  private boolean hasValidParticipationToExperiment(VOPersonDTO voPersonDTO) {
+    if (Objects.isNull(voPersonDTO)) {
+      return false;
+    }
+    return voPersonDTO.getParticipations()
+      .stream()
+      .anyMatch(p -> p.getExperiment().equalsIgnoreCase(cernProperties.getExperimentName()));
+  }
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/TestSupport.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/TestSupport.java
@@ -56,6 +56,9 @@ public class TestSupport {
   public static final String EXPECTED_ACCOUNT_NOT_FOUND = "Expected account not found";
   public static final String EXPECTED_GROUP_NOT_FOUND = "Expected group not found";
 
+  public static final String CERN_USER = "cern-user";
+  public static final String CERN_USER_UUID = "e7de071b-578f-46ec-a2f1-6f9844a50aa5";
+
   public static String LABEL_PREFIX = "indigo-iam.github.io";
   public static String LABEL_NAME = "example.label";
   public static String LABEL_VALUE = "example-label-value";

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/find/FindAccountIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/find/FindAccountIntegrationTests.java
@@ -130,7 +130,7 @@ public class FindAccountIntegrationTests extends TestSupport {
       .andExpect(jsonPath("$.Resources", emptyIterable()));
 
     IamLabel testLabel = IamLabel.builder().name("test").build();
-    accountService.setLabel(testAccount, testLabel);
+    accountService.addLabel(testAccount, testLabel);
 
     mvc.perform(get(FIND_BY_LABEL_RESOURCE).param("name", "test").param("value", "test"))
       .andExpect(OK)
@@ -139,7 +139,7 @@ public class FindAccountIntegrationTests extends TestSupport {
 
     testLabel = IamLabel.builder().name("test").value("test").build();
     testAccount.getLabels().add(testLabel);
-    accountService.setLabel(testAccount, testLabel);
+    accountService.addLabel(testAccount, testLabel);
 
     mvc.perform(get(FIND_BY_LABEL_RESOURCE).param("name", "test").param("value", "test"))
       .andExpect(OK)

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/AccountLifecycleTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/AccountLifecycleTests.java
@@ -73,6 +73,30 @@ public class AccountLifecycleTests extends TestSupport implements LifecycleTestS
   private ExpiredAccountsHandler handler;
 
   @Test
+  public void testUserIsNotPendingSuspensionWhenEndTimeIsToday() {
+
+    IamAccount testAccount =
+        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
+    assertThat(testAccount.isActive(), is(true));
+
+    testAccount.setEndTime(Date.from(ONE_MINUTE_AGO));
+    repo.save(testAccount);
+
+    Optional<IamLabel> statusLabel = testAccount.getLabelByName(LIFECYCLE_STATUS_LABEL);
+    assertThat(statusLabel.isPresent(), is(false));
+
+    handler.handleExpiredAccounts();
+
+    testAccount =
+        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
+
+    assertThat(testAccount.isActive(), is(true));
+    statusLabel = testAccount.getLabelByName(LIFECYCLE_STATUS_LABEL);
+    assertThat(statusLabel.isPresent(), is(false));
+
+  }
+
+  @Test
   public void testSuspensionGracePeriodWorks() {
     IamAccount testAccount =
         repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/AccountLifecycleTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/AccountLifecycleTests.java
@@ -23,7 +23,10 @@ import java.time.Clock;
 import java.time.ZoneId;
 import java.util.Date;
 import java.util.Optional;
+import java.util.UUID;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,13 +34,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import it.infn.mw.iam.IamLoginService;
 import it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler;
+import it.infn.mw.iam.core.user.IamAccountService;
 import it.infn.mw.iam.persistence.model.IamAccount;
 import it.infn.mw.iam.persistence.model.IamLabel;
 import it.infn.mw.iam.persistence.repository.IamAccountRepository;
@@ -70,81 +72,93 @@ public class AccountLifecycleTests extends TestSupport implements LifecycleTestS
   private IamAccountRepository repo;
 
   @Autowired
+  private IamAccountService accountService;
+
+  @Autowired
   private ExpiredAccountsHandler handler;
+
+  private static final String USER_UUID = UUID.randomUUID().toString();
+  private static final String USER_USERNAME = "test-account-lifecycle";
+  private IamAccount testAccount;
+  private Optional<IamLabel> statusLabel;
+
+  @Before
+  public void resetTestAccount() {
+
+    testAccount = IamAccount.newAccount();
+    testAccount.setUuid(USER_UUID);
+    testAccount.setUsername(USER_USERNAME);
+    testAccount.setActive(true);
+    testAccount.getUserInfo().setGivenName("Test");
+    testAccount.getUserInfo().setFamilyName("Test");
+    testAccount.getUserInfo().setEmail("test.lifecycle.account@cern.ch");
+    testAccount.setEndTime(null);
+    testAccount.getLabels().clear();
+    accountService.createAccount(testAccount);
+    testAccount = accountService.findByUuid(USER_UUID)
+      .orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
+    statusLabel = testAccount.getLabelByName(LIFECYCLE_STATUS_LABEL);
+    assertThat(testAccount.isActive(), is(true));
+    assertThat(statusLabel.isPresent(), is(false));
+  }
+
+  @After
+  public void deleteAccount() {
+
+    accountService.deleteAccount(testAccount);
+  }
 
   @Test
   public void testUserIsNotPendingSuspensionWhenEndTimeIsToday() {
 
-    IamAccount testAccount =
-        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
-    assertThat(testAccount.isActive(), is(true));
-
-    testAccount.setEndTime(Date.from(ONE_MINUTE_AGO));
-    repo.save(testAccount);
-
-    Optional<IamLabel> statusLabel = testAccount.getLabelByName(LIFECYCLE_STATUS_LABEL);
-    assertThat(statusLabel.isPresent(), is(false));
-
+    accountService.setAccountEndTime(testAccount, Date.from(ONE_MINUTE_AGO));
     handler.handleExpiredAccounts();
 
-    testAccount =
-        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
+    testAccount = accountService.findByUuid(USER_UUID)
+      .orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
+    statusLabel = testAccount.getLabelByName(LIFECYCLE_STATUS_LABEL);
 
     assertThat(testAccount.isActive(), is(true));
-    statusLabel = testAccount.getLabelByName(LIFECYCLE_STATUS_LABEL);
     assertThat(statusLabel.isPresent(), is(false));
-
   }
 
   @Test
   public void testSuspensionGracePeriodWorks() {
-    IamAccount testAccount =
-        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
 
-    assertThat(testAccount.isActive(), is(true));
-
-    testAccount.setEndTime(Date.from(FOUR_DAYS_AGO));
-    repo.save(testAccount);
+    accountService.setAccountEndTime(testAccount, Date.from(FOUR_DAYS_AGO));
     Date lastUpdateTime = testAccount.getLastUpdateTime();
 
     handler.handleExpiredAccounts();
 
-    testAccount =
-        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
+    testAccount = accountService.findByUuid(USER_UUID)
+      .orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
+    statusLabel = testAccount.getLabelByName(LIFECYCLE_STATUS_LABEL);
 
     assertThat(testAccount.isActive(), is(true));
     assertThat(testAccount.getLastUpdateTime().compareTo(lastUpdateTime) > 0, is(true));
     lastUpdateTime = testAccount.getLastUpdateTime();
-
-    Optional<IamLabel> statusLabel = testAccount.getLabelByName(LIFECYCLE_STATUS_LABEL);
     assertThat(statusLabel.isPresent(), is(true));
     assertThat(statusLabel.get().getValue(),
         is(ExpiredAccountsHandler.AccountLifecycleStatus.PENDING_SUSPENSION.name()));
 
     handler.handleExpiredAccounts();
 
-    testAccount =
-        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
-
+    testAccount = accountService.findByUuid(USER_UUID)
+      .orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
     assertThat(testAccount.isActive(), is(true));
     assertThat(testAccount.getLastUpdateTime().compareTo(lastUpdateTime) == 0, is(true));
-
   }
 
   @Test
   public void testRemovalGracePeriodWorks() {
-    IamAccount testAccount =
-        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
 
-    assertThat(testAccount.isActive(), is(true));
-    testAccount.setEndTime(Date.from(EIGHT_DAYS_AGO));
-    repo.save(testAccount);
+    accountService.setAccountEndTime(testAccount, Date.from(EIGHT_DAYS_AGO));
     Date lastUpdateTime = testAccount.getLastUpdateTime();
 
     handler.handleExpiredAccounts();
 
-    testAccount =
-        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
+    testAccount = accountService.findByUuid(USER_UUID)
+      .orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
 
     assertThat(testAccount.isActive(), is(false));
     assertThat(testAccount.getLastUpdateTime().compareTo(lastUpdateTime) > 0, is(true));
@@ -152,13 +166,13 @@ public class AccountLifecycleTests extends TestSupport implements LifecycleTestS
 
     handler.handleExpiredAccounts();
 
-    testAccount =
-        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
+    testAccount = accountService.findByUuid(USER_UUID)
+      .orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
 
     assertThat(testAccount.isActive(), is(false));
     assertThat(testAccount.getLastUpdateTime().compareTo(lastUpdateTime) == 0, is(true));
 
-    Optional<IamLabel> statusLabel = testAccount.getLabelByName(LIFECYCLE_STATUS_LABEL);
+    statusLabel = testAccount.getLabelByName(LIFECYCLE_STATUS_LABEL);
     assertThat(statusLabel.isPresent(), is(true));
     assertThat(statusLabel.get().getValue(),
         is(ExpiredAccountsHandler.AccountLifecycleStatus.PENDING_REMOVAL.name()));
@@ -166,18 +180,12 @@ public class AccountLifecycleTests extends TestSupport implements LifecycleTestS
 
   @Test
   public void testAccountRemovalWorks() {
-    IamAccount testAccount =
-        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
 
-    testAccount.setEndTime(Date.from(THIRTY_ONE_DAYS_AGO));
-
-    repo.save(testAccount);
+    accountService.setAccountEndTime(testAccount, Date.from(THIRTY_ONE_DAYS_AGO));
 
     handler.handleExpiredAccounts();
 
-    Optional<IamAccount> account = repo.findByUuid(TEST_USER_UUID);
-
-    assertThat(account.isPresent(), is(false));
+    assertThat(accountService.findByUuid(USER_UUID).isEmpty(), is(true));
   }
 
   @Test
@@ -191,33 +199,6 @@ public class AccountLifecycleTests extends TestSupport implements LifecycleTestS
 
     assertThat(accountBefore, is(accountAfter));
   }
-
-  @Test
-  public void testMultiplePagesOfAccountsRemoved() {
-
-    long accountBefore = repo.count();
-
-    Page<IamAccount> accountsPage = repo.findAll(PageRequest.of(0, 20));
-
-    long touchedAccounts = 0;
-
-    if (accountsPage.hasContent()) {
-      for (IamAccount a : accountsPage.getContent()) {
-        a.setEndTime(Date.from(THIRTY_ONE_DAYS_AGO));
-        repo.save(a);
-        touchedAccounts++;
-      }
-    }
-
-    assertThat(touchedAccounts, is(20L));
-
-    handler.handleExpiredAccounts();
-
-    long accountAfter = repo.count();
-
-    assertThat(accountAfter, is(accountBefore - 20));
-  }
-
 
 
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/cern/CernAccountLifecycleTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/cern/CernAccountLifecycleTests.java
@@ -141,7 +141,7 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
     cernUser.getUserInfo().setFamilyName("user");
     cernUser.getUserInfo().setEmailVerified(true);
     service.createAccount(cernUser);
-    service.setLabel(cernUser, cernPersonIdLabel(CERN_PERSON_ID));
+    service.addLabel(cernUser, cernPersonIdLabel(CERN_PERSON_ID));
   }
 
   @After
@@ -288,7 +288,7 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
 
     // suspend testAccount
     service.disableAccount(testAccount);
-    service.setLabel(testAccount, statusLabel(SUSPENDED));
+    service.addLabel(testAccount, statusLabel(SUSPENDED));
 
     // run CERN account life-cycle handler
     cernHrLifecycleHandler.run();
@@ -392,7 +392,7 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_MESSAGE);
 
     assertThat(statusLabel.isPresent(), is(true));
-    assertThat(statusLabel.get().getValue(), is(CernHrLifecycleHandler.Status.ERROR.name()));
+    assertThat(statusLabel.get().getValue(), is(CernHrLifecycleHandler.Status.NOT_FOUND.name()));
 
     assertThat(timestampLabel.isPresent(), is(true));
     assertThat(timestampLabel.get().getValue(), is(valueOf(clock.instant().toEpochMilli())));
@@ -434,7 +434,7 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
     IamAccount testAccount = loadAccount(CERN_USER_UUID);
     assertThat(testAccount.isActive(), is(true));
 
-    service.setLabel(testAccount, cernIgnoreLabel());
+    service.addLabel(testAccount, cernIgnoreLabel());
 
     cernHrLifecycleHandler.run();
 
@@ -468,7 +468,7 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
     Page<IamAccount> accountPage = repo.findAll(pageRequest);
 
     for (IamAccount account : accountPage.getContent()) {
-      service.setLabel(account, cernPersonIdLabel(UUID.randomUUID().toString()));
+      service.addLabel(account, cernPersonIdLabel(UUID.randomUUID().toString()));
     }
 
     cernHrLifecycleHandler.run();
@@ -506,7 +506,7 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
     assertThat(voPerson.getEmail().equals(preSyncEmail), is(false));
     assertThat(testAccount.isActive(), is(true));
 
-    service.setLabel(testAccount, skipEmailSyncLabel());
+    service.addLabel(testAccount, skipEmailSyncLabel());
     repo.save(testAccount);
 
     cernHrLifecycleHandler.run();

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/cern/CernAccountLifecycleTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/cern/CernAccountLifecycleTests.java
@@ -15,14 +15,23 @@
  */
 package it.infn.mw.iam.test.lifecycle.cern;
 
+import static it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler.LIFECYCLE_STATUS_LABEL;
+import static it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler.AccountLifecycleStatus.PENDING_REMOVAL;
+import static it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler.AccountLifecycleStatus.SUSPENDED;
+import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.EXPIRED_MESSAGE;
 import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.HR_DB_API_ERROR;
 import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.IGNORE_MESSAGE;
-import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.LABEL_ACTION;
 import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.LABEL_CERN_PREFIX;
 import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.LABEL_MESSAGE;
 import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.LABEL_STATUS;
 import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.LABEL_TIMESTAMP;
-import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.Action.DISABLE_ACCOUNT;
+import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.NO_PARTICIPATION_MESSAGE;
+import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.RESTORED_MESSAGE;
+import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.VALID_MESSAGE;
+import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.Status.EXPIRED;
+import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.Status.IGNORED;
+import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.Status.MEMBER;
+import static java.lang.String.format;
 import static java.lang.String.valueOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -33,11 +42,13 @@ import static org.mockito.Mockito.when;
 
 import java.time.Clock;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
 
 import org.junit.After;
-import org.junit.Ignore;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,6 +68,7 @@ import it.infn.mw.iam.IamLoginService;
 import it.infn.mw.iam.api.registration.cern.CernHrDBApiService;
 import it.infn.mw.iam.api.registration.cern.CernHrDbApiError;
 import it.infn.mw.iam.api.registration.cern.dto.VOPersonDTO;
+import it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler;
 import it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler;
 import it.infn.mw.iam.core.user.IamAccountService;
 import it.infn.mw.iam.persistence.model.IamAccount;
@@ -103,7 +115,10 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
   IamAccountService service;
 
   @Autowired
-  CernHrLifecycleHandler handler;
+  CernHrLifecycleHandler cernHrLifecycleHandler;
+
+  @Autowired
+  ExpiredAccountsHandler expiredAccountsHandler;
 
   @Autowired
   CernHrDBApiService hrDb;
@@ -111,270 +126,213 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
   @Autowired
   Clock clock;
 
+  IamAccount cernUser;
+
+  @Before
+  public void init() {
+
+    cernUser = IamAccount.newAccount();
+    cernUser.setUsername(CERN_USER);
+    cernUser.setUuid(CERN_USER_UUID);
+    cernUser.setActive(true);
+    cernUser.setEndTime(Date.from(NOW.plus(365, ChronoUnit.DAYS)));
+    cernUser.getUserInfo().setEmail(CERN_USER + "@example");
+    cernUser.getUserInfo().setGivenName("cern");
+    cernUser.getUserInfo().setFamilyName("user");
+    cernUser.getUserInfo().setEmailVerified(true);
+    service.createAccount(cernUser);
+    service.setLabel(cernUser, cernPersonIdLabel(CERN_PERSON_ID));
+  }
+
   @After
   public void teardown() {
     reset(hrDb);
+    service.deleteAccount(cernUser);
+  }
+
+  private IamAccount loadAccount(String username) {
+    return repo.findByUuid(username).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
   }
 
   @Test
-  public void testSuspendLifecycleWorks() {
+  public void testUserSuspensionWorksAfterCernHrEndTimeUpdate() {
 
-    when(hrDb.hasValidExperimentParticipation(anyString())).thenReturn(false);
-
-    IamAccount testAccount =
-        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
-
+    IamAccount testAccount = loadAccount(CERN_USER_UUID);
     assertThat(testAccount.isActive(), is(true));
 
-    service.setLabel(testAccount, cernPersonIdLabel());
-    repo.save(testAccount);
+    when(hrDb.getHrDbPersonRecord(CERN_PERSON_ID)).thenReturn(expiredVoPerson(CERN_PERSON_ID));
 
-    handler.run();
+    cernHrLifecycleHandler.run();
 
-    testAccount =
-        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
+    testAccount = loadAccount(CERN_USER_UUID);
+    assertThat(testAccount.isActive(), is(true));
+
+    Optional<IamLabel> cernStatusLabel =
+        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_STATUS);
+    assertThat(cernStatusLabel.isPresent(), is(true));
+    assertThat(cernStatusLabel.get().getValue(), is(EXPIRED.name()));
+
+    Optional<IamLabel> cernMessageLabel =
+        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_MESSAGE);
+    assertThat(cernMessageLabel.isPresent(), is(true));
+    assertThat(cernMessageLabel.get().getValue(), is(EXPIRED_MESSAGE));
+
+    Optional<IamLabel> cernTimestampLabel =
+        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
+    assertThat(cernTimestampLabel.isPresent(), is(true));
+    assertThat(cernTimestampLabel.get().getValue(), is(valueOf(clock.instant().toEpochMilli())));
+
+    expiredAccountsHandler.run();
+
+    testAccount = loadAccount(CERN_USER_UUID);
 
     assertThat(testAccount.isActive(), is(false));
-    Optional<IamLabel> statusLabel =
-        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_STATUS);
-    Optional<IamLabel> actionLabel =
-        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_ACTION);
-    Optional<IamLabel> timestampLabel =
-        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
 
-    assertThat(statusLabel.isPresent(), is(true));
-    assertThat(statusLabel.get().getValue(), is(CernHrLifecycleHandler.Status.OK.name()));
+    cernStatusLabel = testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_STATUS);
+    assertThat(cernStatusLabel.isPresent(), is(true));
+    assertThat(cernStatusLabel.get().getValue(), is(EXPIRED.name()));
 
-    assertThat(actionLabel.isPresent(), is(true));
-    assertThat(actionLabel.get().getValue(),
-        is(CernHrLifecycleHandler.Action.DISABLE_ACCOUNT.name()));
+    cernMessageLabel = testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_MESSAGE);
+    assertThat(cernMessageLabel.isPresent(), is(true));
+    assertThat(cernMessageLabel.get().getValue(), is(EXPIRED_MESSAGE));
 
-    assertThat(timestampLabel.isPresent(), is(true));
-    assertThat(timestampLabel.get().getValue(), is(valueOf(clock.instant().toEpochMilli())));
+    cernTimestampLabel = testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
+    assertThat(cernTimestampLabel.isPresent(), is(true));
+    assertThat(cernTimestampLabel.get().getValue(), is(valueOf(clock.instant().toEpochMilli())));
+
+    Optional<IamLabel> iamStatusLabel = testAccount.getLabelByName(LIFECYCLE_STATUS_LABEL);
+    assertThat(iamStatusLabel.isPresent(), is(true));
+    assertThat(iamStatusLabel.get().getValue(), is(PENDING_REMOVAL.name()));
+
   }
 
   @Test
-  public void testNoActionLifecycleWorksForValidAccounts() {
-    VOPersonDTO voPerson = voPerson("988211");
+  public void testUserRemovalWorksAfterCernHrEndTimeUpdate() {
 
-    when(hrDb.hasValidExperimentParticipation(anyString())).thenReturn(true);
-    when(hrDb.getHrDbPersonRecord(anyString())).thenReturn(voPerson);
+    IamAccount testAccount = loadAccount(CERN_USER_UUID);
+    assertThat(testAccount.isActive(), is(true));
 
-    IamAccount testAccount =
-        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
+    when(hrDb.getHrDbPersonRecord(CERN_PERSON_ID)).thenReturn(removedVoPerson(CERN_PERSON_ID));
+
+    cernHrLifecycleHandler.run();
+
+    testAccount = loadAccount(CERN_USER_UUID);
+    assertThat(testAccount.isActive(), is(true));
+
+    Optional<IamLabel> cernStatusLabel =
+        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_STATUS);
+    assertThat(cernStatusLabel.isPresent(), is(true));
+    assertThat(cernStatusLabel.get().getValue(), is(EXPIRED.name()));
+
+    Optional<IamLabel> cernMessageLabel =
+        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_MESSAGE);
+    assertThat(cernMessageLabel.isPresent(), is(true));
+    assertThat(cernMessageLabel.get().getValue(), is(EXPIRED_MESSAGE));
+
+    Optional<IamLabel> cernTimestampLabel =
+        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
+    assertThat(cernTimestampLabel.isPresent(), is(true));
+    assertThat(cernTimestampLabel.get().getValue(), is(valueOf(clock.instant().toEpochMilli())));
+
+    expiredAccountsHandler.run();
+
+    assertThat(repo.findByUuid(CERN_USER_UUID).isEmpty(), is(true));
+  }
+
+  @Test
+  public void testLifecycleWorksForValidAccounts() {
+
+    VOPersonDTO voPerson = voPerson(CERN_PERSON_ID);
+    when(hrDb.getHrDbPersonRecord(CERN_PERSON_ID)).thenReturn(voPerson);
+
+    IamAccount testAccount = loadAccount(CERN_USER_UUID);
 
     assertThat(testAccount.isActive(), is(true));
 
-    service.setLabel(testAccount, cernPersonIdLabel());
-    repo.save(testAccount);
+    cernHrLifecycleHandler.run();
 
-    handler.run();
-
-    testAccount =
-        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
+    testAccount = loadAccount(CERN_USER_UUID);
 
     assertThat(testAccount.getUserInfo().getGivenName(), is(voPerson.getFirstName()));
     assertThat(testAccount.getUserInfo().getFamilyName(), is(voPerson.getName()));
     assertThat(testAccount.getUserInfo().getEmail(), is(voPerson.getEmail()));
+    assertThat(testAccount.getEndTime(),
+        is(voPerson.getParticipations().iterator().next().getEndDate()));
 
     assertThat(testAccount.isActive(), is(true));
-    Optional<IamLabel> statusLabel =
+
+    Optional<IamLabel> cernStatusLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_STATUS);
-    Optional<IamLabel> actionLabel =
-        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_ACTION);
-    Optional<IamLabel> timestampLabel =
+    assertThat(cernStatusLabel.isPresent(), is(true));
+    assertThat(cernStatusLabel.get().getValue(), is(MEMBER.name()));
+
+    Optional<IamLabel> cernMessageLabel =
+        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_MESSAGE);
+    assertThat(cernMessageLabel.isPresent(), is(true));
+    assertThat(cernMessageLabel.get().getValue(), is(VALID_MESSAGE));
+
+    Optional<IamLabel> cernTimestampLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
-
-    assertThat(statusLabel.isPresent(), is(true));
-    assertThat(statusLabel.get().getValue(), is(CernHrLifecycleHandler.Status.OK.name()));
-
-    assertThat(actionLabel.isPresent(), is(true));
-    assertThat(actionLabel.get().getValue(), is(CernHrLifecycleHandler.Action.NO_ACTION.name()));
-
-    assertThat(timestampLabel.isPresent(), is(true));
-    assertThat(timestampLabel.get().getValue(), is(valueOf(clock.instant().toEpochMilli())));
-  }
-
-  @Test
-  public void testActionNotSetForDisabledInValidAccounts() {
-
-    when(hrDb.hasValidExperimentParticipation(anyString())).thenReturn(false);
-
-    IamAccount testAccount =
-        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
-
-    assertThat(testAccount.isActive(), is(true));
-
-    testAccount.setActive(false);
-    service.setLabel(testAccount, cernPersonIdLabel());
-
-    handler.run();
-
-    testAccount =
-        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
-
-    assertThat(testAccount.isActive(), is(false));
-    Optional<IamLabel> statusLabel =
-        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_STATUS);
-    Optional<IamLabel> actionLabel =
-        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_ACTION);
-    Optional<IamLabel> timestampLabel =
-        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
-
-    assertThat(statusLabel.isPresent(), is(true));
-    assertThat(statusLabel.get().getValue(), is(CernHrLifecycleHandler.Status.OK.name()));
-
-    assertThat(actionLabel.isPresent(), is(false));
-
-    assertThat(timestampLabel.isPresent(), is(true));
-    assertThat(timestampLabel.get().getValue(), is(valueOf(clock.instant().toEpochMilli())));
-  }
-
-  @Test
-  public void testLifecycleStates() {
-
-    when(hrDb.hasValidExperimentParticipation(anyString())).thenReturn(false);
-
-    IamAccount testAccount =
-        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
-
-    testAccount.setActive(true);
-    service.setLabel(testAccount, cernPersonIdLabel());
-
-    handler.run();
-
-    testAccount =
-        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
-
-    assertThat(testAccount.isActive(), is(false));
-    Optional<IamLabel> statusLabel =
-        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_STATUS);
-    Optional<IamLabel> actionLabel =
-        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_ACTION);
-    Optional<IamLabel> timestampLabel =
-        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
-
-    assertThat(statusLabel.isPresent(), is(true));
-    assertThat(statusLabel.get().getValue(), is(CernHrLifecycleHandler.Status.OK.name()));
-
-    assertThat(actionLabel.isPresent(), is(true));
-    assertThat(actionLabel.get().getValue(),
-        is(CernHrLifecycleHandler.Action.DISABLE_ACCOUNT.name()));
-
-    assertThat(timestampLabel.isPresent(), is(true));
-    assertThat(timestampLabel.get().getValue(), is(valueOf(clock.instant().toEpochMilli())));
-
-    handler.run();
-
-    statusLabel = testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_STATUS);
-    actionLabel = testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_ACTION);
-
-    assertThat(statusLabel.isPresent(), is(true));
-    assertThat(statusLabel.get().getValue(), is(CernHrLifecycleHandler.Status.OK.name()));
-
-    assertThat(actionLabel.isPresent(), is(true));
-    assertThat(actionLabel.get().getValue(),
-        is(CernHrLifecycleHandler.Action.DISABLE_ACCOUNT.name()));
-
-    when(hrDb.hasValidExperimentParticipation(anyString())).thenReturn(true);
-    when(hrDb.getHrDbPersonRecord(anyString())).thenReturn(voPerson("988211"));
-
-    assertThat(testAccount.isActive(), is(false));
-
-    handler.run();
-
-    statusLabel = testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_STATUS);
-    actionLabel = testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_ACTION);
-
-    assertThat(testAccount.isActive(), is(true));
-
-    assertThat(statusLabel.isPresent(), is(true));
-    assertThat(statusLabel.get().getValue(), is(CernHrLifecycleHandler.Status.OK.name()));
-
-    assertThat(actionLabel.isPresent(), is(true));
-    assertThat(actionLabel.get().getValue(),
-        is(CernHrLifecycleHandler.Action.RESTORE_ACCOUNT.name()));
-
-    handler.run();
-
-    assertThat(testAccount.isActive(), is(true));
-
-    statusLabel = testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_STATUS);
-    actionLabel = testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_ACTION);
-
-    assertThat(statusLabel.isPresent(), is(true));
-    assertThat(statusLabel.get().getValue(), is(CernHrLifecycleHandler.Status.OK.name()));
-
-    assertThat(actionLabel.isPresent(), is(true));
-    assertThat(actionLabel.get().getValue(), is(CernHrLifecycleHandler.Action.NO_ACTION.name()));
-
+    assertThat(cernTimestampLabel.isPresent(), is(true));
+    assertThat(cernTimestampLabel.get().getValue(), is(valueOf(clock.instant().toEpochMilli())));
   }
 
   @Test
   public void testRestoreLifecycleWorks() {
 
-    when(hrDb.hasValidExperimentParticipation(anyString())).thenReturn(true);
-    when(hrDb.getHrDbPersonRecord(anyString())).thenReturn(voPerson("988211"));
-    IamAccount testAccount =
-        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
+    when(hrDb.getHrDbPersonRecord(CERN_PERSON_ID)).thenReturn(voPerson(CERN_PERSON_ID));
+
+    IamAccount testAccount = loadAccount(CERN_USER_UUID);
 
     assertThat(testAccount.isActive(), is(true));
 
-    testAccount.setActive(false);
+    // suspend testAccount
+    service.disableAccount(testAccount);
+    service.setLabel(testAccount, statusLabel(SUSPENDED));
 
-    service.setLabel(testAccount, cernPersonIdLabel());
-    service.setLabel(testAccount, actionLabel(DISABLE_ACCOUNT));
+    // run CERN account life-cycle handler
+    cernHrLifecycleHandler.run();
 
-    handler.run();
-
-    testAccount =
-        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
+    testAccount = loadAccount(CERN_USER_UUID);
 
     assertThat(testAccount.isActive(), is(true));
-    Optional<IamLabel> statusLabel =
+    Optional<IamLabel> cernStatusLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_STATUS);
-    Optional<IamLabel> actionLabel =
-        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_ACTION);
-    Optional<IamLabel> timestampLabel =
+    Optional<IamLabel> cernTimestampLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
+    Optional<IamLabel> cernMessageLabel =
+        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_MESSAGE);
+    Optional<IamLabel> iamStatusLabel = testAccount.getLabelByName(LIFECYCLE_STATUS_LABEL);
 
-    assertThat(statusLabel.isPresent(), is(true));
-    assertThat(statusLabel.get().getValue(), is(CernHrLifecycleHandler.Status.OK.name()));
+    assertThat(cernStatusLabel.isPresent(), is(true));
+    assertThat(cernStatusLabel.get().getValue(), is(MEMBER.name()));
 
-    assertThat(actionLabel.isPresent(), is(true));
-    assertThat(actionLabel.get().getValue(),
-        is(CernHrLifecycleHandler.Action.RESTORE_ACCOUNT.name()));
+    assertThat(cernMessageLabel.isPresent(), is(true));
+    assertThat(cernMessageLabel.get().getValue(), is(format(RESTORED_MESSAGE, clock.instant())));
 
-    assertThat(timestampLabel.isPresent(), is(true));
-    assertThat(timestampLabel.get().getValue(), is(valueOf(clock.instant().toEpochMilli())));
+    assertThat(cernTimestampLabel.isPresent(), is(true));
+    assertThat(cernTimestampLabel.get().getValue(), is(valueOf(clock.instant().toEpochMilli())));
+
+    assertThat(iamStatusLabel.isPresent(), is(false));
   }
 
   @Test
   public void testApiErrorIsHandled() {
 
-    when(hrDb.hasValidExperimentParticipation(anyString()))
+    when(hrDb.getHrDbPersonRecord(anyString()))
       .thenThrow(new CernHrDbApiError("API is unreachable"));
 
-    IamAccount testAccount =
-        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
-    service.setLabel(testAccount, cernPersonIdLabel());
+    cernHrLifecycleHandler.run();
 
-    handler.run();
-
-    testAccount =
-        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
+    IamAccount testAccount = loadAccount(CERN_USER_UUID);
 
     assertThat(testAccount.isActive(), is(true));
     Optional<IamLabel> statusLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_STATUS);
-    Optional<IamLabel> actionLabel =
-        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_ACTION);
     Optional<IamLabel> timestampLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
     Optional<IamLabel> messageLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_MESSAGE);
-
-    assertThat(actionLabel.isPresent(), is(false));
 
     assertThat(statusLabel.isPresent(), is(true));
     assertThat(statusLabel.get().getValue(), is(CernHrLifecycleHandler.Status.ERROR.name()));
@@ -388,38 +346,84 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
   }
 
   @Test
-  public void testRestoreLifecycleDoesNotTouchSuspendedAccount() {
+  public void testApiReturnsNullVoPersonIsHandled() {
 
-    when(hrDb.hasValidExperimentParticipation(anyString())).thenReturn(true);
-    when(hrDb.getHrDbPersonRecord(anyString())).thenReturn(voPerson("988211"));
-    IamAccount testAccount =
-        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
+    when(hrDb.getHrDbPersonRecord(anyString())).thenReturn(null);
+
+    cernHrLifecycleHandler.run();
+
+    IamAccount testAccount = loadAccount(CERN_USER_UUID);
 
     assertThat(testAccount.isActive(), is(true));
-
-    testAccount.setActive(false);
-
-    service.setLabel(testAccount, cernPersonIdLabel());
-
-    handler.run();
-
-    testAccount =
-        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
-
-    assertThat(testAccount.isActive(), is(false));
     Optional<IamLabel> statusLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_STATUS);
-    Optional<IamLabel> actionLabel =
-        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_ACTION);
     Optional<IamLabel> timestampLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
+    Optional<IamLabel> messageLabel =
+        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_MESSAGE);
 
     assertThat(statusLabel.isPresent(), is(true));
-    assertThat(statusLabel.get().getValue(), is(CernHrLifecycleHandler.Status.OK.name()));
+    assertThat(statusLabel.get().getValue(), is(CernHrLifecycleHandler.Status.ERROR.name()));
 
-    assertThat(actionLabel.isPresent(), is(true));
-    assertThat(actionLabel.get().getValue(), is(CernHrLifecycleHandler.Action.NO_ACTION.name()));
+    assertThat(timestampLabel.isPresent(), is(true));
+    assertThat(timestampLabel.get().getValue(), is(valueOf(clock.instant().toEpochMilli())));
 
+    assertThat(messageLabel.isPresent(), is(true));
+    assertThat(messageLabel.get().getValue(), is(HR_DB_API_ERROR));
+
+  }
+
+  @Test
+  public void testApiReturnsVoPersonWithNoParticipationsIsHandled() {
+
+    when(hrDb.getHrDbPersonRecord(anyString()))
+      .thenReturn(noParticipationsVoPerson(CERN_PERSON_ID));
+
+    cernHrLifecycleHandler.run();
+
+    IamAccount testAccount = loadAccount(CERN_USER_UUID);
+
+    assertThat(testAccount.isActive(), is(true));
+    Optional<IamLabel> statusLabel =
+        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_STATUS);
+    Optional<IamLabel> timestampLabel =
+        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
+    Optional<IamLabel> messageLabel =
+        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_MESSAGE);
+
+    assertThat(statusLabel.isPresent(), is(true));
+    assertThat(statusLabel.get().getValue(), is(CernHrLifecycleHandler.Status.ERROR.name()));
+
+    assertThat(timestampLabel.isPresent(), is(true));
+    assertThat(timestampLabel.get().getValue(), is(valueOf(clock.instant().toEpochMilli())));
+
+    assertThat(messageLabel.isPresent(), is(true));
+    assertThat(messageLabel.get().getValue(), is(format(NO_PARTICIPATION_MESSAGE, "test")));
+
+  }
+
+  @Test
+  public void testLifecycleNotRestoreAccountsSuspendedByAdmins() {
+
+    when(hrDb.getHrDbPersonRecord(CERN_PERSON_ID)).thenReturn(voPerson(CERN_PERSON_ID));
+
+    IamAccount testAccount = loadAccount(CERN_USER_UUID);
+    assertThat(testAccount.isActive(), is(true));
+    service.disableAccount(testAccount);
+
+    cernHrLifecycleHandler.run();
+
+    testAccount = loadAccount(CERN_USER_UUID);
+
+    assertThat(testAccount.isActive(), is(false));
+
+    Optional<IamLabel> statusLabel =
+        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_STATUS);
+    assertThat(statusLabel.isPresent(), is(true));
+    assertThat(statusLabel.get().getValue(), is(MEMBER.name()));
+
+    Optional<IamLabel> timestampLabel =
+        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
     assertThat(timestampLabel.isPresent(), is(true));
     assertThat(timestampLabel.get().getValue(), is(valueOf(clock.instant().toEpochMilli())));
   }
@@ -427,35 +431,25 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
   @Test
   public void testIgnoreAccount() {
 
-    when(hrDb.hasValidExperimentParticipation(anyString())).thenReturn(false);
-    IamAccount testAccount =
-        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
-
+    IamAccount testAccount = loadAccount(CERN_USER_UUID);
     assertThat(testAccount.isActive(), is(true));
 
-    service.setLabel(testAccount, cernPersonIdLabel());
     service.setLabel(testAccount, cernIgnoreLabel());
 
-    handler.run();
+    cernHrLifecycleHandler.run();
 
-    testAccount =
-        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
+    testAccount = loadAccount(CERN_USER_UUID);
 
     assertThat(testAccount.isActive(), is(true));
     Optional<IamLabel> statusLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_STATUS);
-    Optional<IamLabel> actionLabel =
-        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_ACTION);
     Optional<IamLabel> timestampLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
     Optional<IamLabel> messageLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_MESSAGE);
 
     assertThat(statusLabel.isPresent(), is(true));
-    assertThat(statusLabel.get().getValue(), is(CernHrLifecycleHandler.Status.OK.name()));
-
-    assertThat(actionLabel.isPresent(), is(true));
-    assertThat(actionLabel.get().getValue(), is(CernHrLifecycleHandler.Action.NO_ACTION.name()));
+    assertThat(statusLabel.get().getValue(), is(IGNORED.name()));
 
     assertThat(timestampLabel.isPresent(), is(true));
     assertThat(timestampLabel.get().getValue(), is(valueOf(clock.instant().toEpochMilli())));
@@ -466,7 +460,9 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
 
   @Test
   public void testPaginationWorks() {
-    when(hrDb.hasValidExperimentParticipation(anyString())).thenReturn(false);
+
+    when(hrDb.getHrDbPersonRecord(anyString()))
+      .thenReturn(voPerson(String.valueOf((long) Math.random() * 100L)));
 
     Pageable pageRequest = PageRequest.of(0, 10, Direction.ASC, "username");
     Page<IamAccount> accountPage = repo.findAll(pageRequest);
@@ -475,26 +471,20 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
       service.setLabel(account, cernPersonIdLabel(UUID.randomUUID().toString()));
     }
 
-    handler.run();
+    cernHrLifecycleHandler.run();
 
     accountPage = repo.findAll(pageRequest);
 
     for (IamAccount account : accountPage.getContent()) {
 
-      assertThat(account.isActive(), is(false));
+      assertThat(account.isActive(), is(true));
       Optional<IamLabel> statusLabel =
           account.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_STATUS);
-      Optional<IamLabel> actionLabel =
-          account.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_ACTION);
       Optional<IamLabel> timestampLabel =
           account.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
 
       assertThat(statusLabel.isPresent(), is(true));
-      assertThat(statusLabel.get().getValue(), is(CernHrLifecycleHandler.Status.OK.name()));
-
-      assertThat(actionLabel.isPresent(), is(true));
-      assertThat(actionLabel.get().getValue(),
-          is(CernHrLifecycleHandler.Action.DISABLE_ACCOUNT.name()));
+      assertThat(statusLabel.get().getValue(), is(MEMBER.name()));
 
       assertThat(timestampLabel.isPresent(), is(true));
       assertThat(timestampLabel.get().getValue(), is(valueOf(clock.instant().toEpochMilli())));
@@ -505,26 +495,23 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
   @Test
   public void testEmailNotSynchronizedIfSkipEmailSyncIsPresent() {
 
-    VOPersonDTO voPerson = voPerson("988211");
+    VOPersonDTO voPerson = voPerson(CERN_PERSON_ID);
 
-    when(hrDb.hasValidExperimentParticipation(anyString())).thenReturn(true);
-    when(hrDb.getHrDbPersonRecord(anyString())).thenReturn(voPerson);
+    when(hrDb.getHrDbPersonRecord(CERN_PERSON_ID)).thenReturn(voPerson);
 
-    IamAccount testAccount =
-        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
+    IamAccount testAccount = loadAccount(CERN_USER_UUID);
 
     final String preSyncEmail = testAccount.getUserInfo().getEmail();
 
+    assertThat(voPerson.getEmail().equals(preSyncEmail), is(false));
     assertThat(testAccount.isActive(), is(true));
 
-    service.setLabel(testAccount, cernPersonIdLabel());
     service.setLabel(testAccount, skipEmailSyncLabel());
     repo.save(testAccount);
 
-    handler.run();
+    cernHrLifecycleHandler.run();
 
-    testAccount =
-        repo.findByUuid(TEST_USER_UUID).orElseThrow(assertionError(EXPECTED_ACCOUNT_NOT_FOUND));
+    testAccount = loadAccount(CERN_USER_UUID);
 
     assertThat(testAccount.getUserInfo().getGivenName(), is(voPerson.getFirstName()));
     assertThat(testAccount.getUserInfo().getFamilyName(), is(voPerson.getName()));

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/cern/CernAccountLifecycleTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/cern/CernAccountLifecycleTests.java
@@ -179,8 +179,7 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
 
     Optional<IamLabel> cernTimestampLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
-    assertThat(cernTimestampLabel.isPresent(), is(true));
-    assertThat(cernTimestampLabel.get().getValue(), is(valueOf(clock.instant().toEpochMilli())));
+    assertThat(cernTimestampLabel.isPresent(), is(false));
 
     expiredAccountsHandler.run();
 
@@ -197,8 +196,7 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
     assertThat(cernMessageLabel.get().getValue(), is(EXPIRED_MESSAGE));
 
     cernTimestampLabel = testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
-    assertThat(cernTimestampLabel.isPresent(), is(true));
-    assertThat(cernTimestampLabel.get().getValue(), is(valueOf(clock.instant().toEpochMilli())));
+    assertThat(cernTimestampLabel.isPresent(), is(false));
 
     Optional<IamLabel> iamStatusLabel = testAccount.getLabelByName(LIFECYCLE_STATUS_LABEL);
     assertThat(iamStatusLabel.isPresent(), is(true));
@@ -231,8 +229,7 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
 
     Optional<IamLabel> cernTimestampLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
-    assertThat(cernTimestampLabel.isPresent(), is(true));
-    assertThat(cernTimestampLabel.get().getValue(), is(valueOf(clock.instant().toEpochMilli())));
+    assertThat(cernTimestampLabel.isPresent(), is(false));
 
     expiredAccountsHandler.run();
 
@@ -273,8 +270,7 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
 
     Optional<IamLabel> cernTimestampLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
-    assertThat(cernTimestampLabel.isPresent(), is(true));
-    assertThat(cernTimestampLabel.get().getValue(), is(valueOf(clock.instant().toEpochMilli())));
+    assertThat(cernTimestampLabel.isPresent(), is(false));
   }
 
   @Test
@@ -310,9 +306,7 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
     assertThat(cernMessageLabel.isPresent(), is(true));
     assertThat(cernMessageLabel.get().getValue(), is(format(RESTORED_MESSAGE, clock.instant())));
 
-    assertThat(cernTimestampLabel.isPresent(), is(true));
-    assertThat(cernTimestampLabel.get().getValue(), is(valueOf(clock.instant().toEpochMilli())));
-
+    assertThat(cernTimestampLabel.isPresent(), is(false));
     assertThat(iamStatusLabel.isPresent(), is(false));
   }
 
@@ -337,8 +331,7 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
     assertThat(statusLabel.isPresent(), is(true));
     assertThat(statusLabel.get().getValue(), is(CernHrLifecycleHandler.Status.ERROR.name()));
 
-    assertThat(timestampLabel.isPresent(), is(true));
-    assertThat(timestampLabel.get().getValue(), is(valueOf(clock.instant().toEpochMilli())));
+    assertThat(timestampLabel.isPresent(), is(false));
 
     assertThat(messageLabel.isPresent(), is(true));
     assertThat(messageLabel.get().getValue(), is(HR_DB_API_ERROR));
@@ -365,8 +358,7 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
     assertThat(statusLabel.isPresent(), is(true));
     assertThat(statusLabel.get().getValue(), is(CernHrLifecycleHandler.Status.ERROR.name()));
 
-    assertThat(timestampLabel.isPresent(), is(true));
-    assertThat(timestampLabel.get().getValue(), is(valueOf(clock.instant().toEpochMilli())));
+    assertThat(timestampLabel.isPresent(), is(false));
 
     assertThat(messageLabel.isPresent(), is(true));
     assertThat(messageLabel.get().getValue(), is(HR_DB_API_ERROR));
@@ -394,8 +386,7 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
     assertThat(statusLabel.isPresent(), is(true));
     assertThat(statusLabel.get().getValue(), is(CernHrLifecycleHandler.Status.NOT_FOUND.name()));
 
-    assertThat(timestampLabel.isPresent(), is(true));
-    assertThat(timestampLabel.get().getValue(), is(valueOf(clock.instant().toEpochMilli())));
+    assertThat(timestampLabel.isPresent(), is(false));
 
     assertThat(messageLabel.isPresent(), is(true));
     assertThat(messageLabel.get().getValue(), is(format(NO_PARTICIPATION_MESSAGE, "test")));
@@ -424,8 +415,7 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
 
     Optional<IamLabel> timestampLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
-    assertThat(timestampLabel.isPresent(), is(true));
-    assertThat(timestampLabel.get().getValue(), is(valueOf(clock.instant().toEpochMilli())));
+    assertThat(timestampLabel.isPresent(), is(false));
   }
 
   @Test
@@ -451,8 +441,7 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
     assertThat(statusLabel.isPresent(), is(true));
     assertThat(statusLabel.get().getValue(), is(IGNORED.name()));
 
-    assertThat(timestampLabel.isPresent(), is(true));
-    assertThat(timestampLabel.get().getValue(), is(valueOf(clock.instant().toEpochMilli())));
+    assertThat(timestampLabel.isPresent(), is(false));
 
     assertThat(messageLabel.isPresent(), is(true));
     assertThat(messageLabel.get().getValue(), is(IGNORE_MESSAGE));
@@ -486,9 +475,7 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
       assertThat(statusLabel.isPresent(), is(true));
       assertThat(statusLabel.get().getValue(), is(MEMBER.name()));
 
-      assertThat(timestampLabel.isPresent(), is(true));
-      assertThat(timestampLabel.get().getValue(), is(valueOf(clock.instant().toEpochMilli())));
-
+      assertThat(timestampLabel.isPresent(), is(false));
     }
   }
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/cern/LifecycleTestSupport.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/cern/LifecycleTestSupport.java
@@ -43,6 +43,7 @@ public interface LifecycleTestSupport {
 
   Instant NOW = Instant.parse("2020-01-01T00:00:00.00Z");
 
+  Instant ONE_MINUTE_AGO = NOW.minus(1, ChronoUnit.MINUTES);
   Instant FOUR_DAYS_AGO = NOW.minus(4, ChronoUnit.DAYS);
   Instant EIGHT_DAYS_AGO = NOW.minus(8, ChronoUnit.DAYS);
   Instant THIRTY_ONE_DAYS_AGO = NOW.minus(31, ChronoUnit.DAYS);
@@ -77,32 +78,11 @@ public interface LifecycleTestSupport {
   }
 
   default VOPersonDTO voPerson(String personId, Date endDate) {
-    VOPersonDTO dto = new VOPersonDTO();
-    dto.setFirstName("TEST");
-    dto.setName("USER");
-    dto.setEmail("test@hr.cern");
-    dto.setParticipations(Sets.newHashSet());
-
-    dto.setId(Long.parseLong(personId));
-
-    ParticipationDTO p = new ParticipationDTO();
-
-    LocalDate startDate = LocalDate.now().minusDays(365);
-    
-    p.setExperiment("test");
-    p.setStartDate(startDate.toDate());
-    p.setEndDate(endDate);
-
-    InstituteDTO i = new InstituteDTO();
-    i.setId("000001");
-    i.setName("INFN");
-    i.setCountry("IT");
-    i.setTown("Bologna");
-    p.setInstitute(i);
-
-    dto.getParticipations().add(p);
-
-    return dto;
+    IamAccount account = IamAccount.newAccount();
+    account.getUserInfo().setGivenName("TEST");
+    account.getUserInfo().setFamilyName("USER");
+    account.getUserInfo().setEmail("test@hr.cern");
+    return voPerson(personId, account, "test", endDate);
   }
 
   default VOPersonDTO noParticipationsVoPerson(String personId) {

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/cern/LifecycleTestSupport.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/cern/LifecycleTestSupport.java
@@ -25,6 +25,8 @@ import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.function.Supplier;
 
+import org.joda.time.LocalDate;
+
 import com.google.common.collect.Sets;
 
 import it.infn.mw.iam.api.registration.cern.dto.InstituteDTO;
@@ -46,10 +48,7 @@ public interface LifecycleTestSupport {
   Instant THIRTY_ONE_DAYS_AGO = NOW.minus(31, ChronoUnit.DAYS);
 
   default IamLabel cernIgnoreLabel() {
-    return IamLabel.builder()
-      .prefix(LABEL_CERN_PREFIX)
-      .name(LABEL_IGNORE)
-      .build();
+    return IamLabel.builder().prefix(LABEL_CERN_PREFIX).name(LABEL_IGNORE).build();
   }
 
 
@@ -70,13 +69,14 @@ public interface LifecycleTestSupport {
   }
 
   default IamLabel statusLabel(AccountLifecycleStatus s) {
-    return IamLabel.builder()
-      .name(LIFECYCLE_STATUS_LABEL)
-      .value(s.name())
-      .build();
+    return IamLabel.builder().name(LIFECYCLE_STATUS_LABEL).value(s.name()).build();
   }
 
   default VOPersonDTO voPerson(String personId) {
+    return voPerson(personId, LocalDate.now().plusDays(365).toDate());
+  }
+
+  default VOPersonDTO voPerson(String personId, Date endDate) {
     VOPersonDTO dto = new VOPersonDTO();
     dto.setFirstName("TEST");
     dto.setName("USER");
@@ -87,8 +87,11 @@ public interface LifecycleTestSupport {
 
     ParticipationDTO p = new ParticipationDTO();
 
+    LocalDate startDate = LocalDate.now().minusDays(365);
+    
     p.setExperiment("test");
-    p.setStartDate(Date.from(Instant.parse("2020-01-01T00:00:00.00Z")));
+    p.setStartDate(startDate.toDate());
+    p.setEndDate(endDate);
 
     InstituteDTO i = new InstituteDTO();
     i.setId("000001");
@@ -110,7 +113,8 @@ public interface LifecycleTestSupport {
 
   default VOPersonDTO expiredVoPerson(String personId) {
     VOPersonDTO dto = voPerson(personId);
-    // Set endDate more than 7 days (suspension grace period) but less than 30 days (removal grace period)
+    // Set endDate more than 7 days (suspension grace period) but less than 30 days (removal grace
+    // period)
     dto.getParticipations().iterator().next().setEndDate(Date.from(NOW.minus(20, ChronoUnit.DAYS)));
     return dto;
   }
@@ -122,7 +126,8 @@ public interface LifecycleTestSupport {
     return dto;
   }
 
-  default VOPersonDTO voPerson(String personId, IamAccount account, String experiment, Date endDate) {
+  default VOPersonDTO voPerson(String personId, IamAccount account, String experiment,
+      Date endDate) {
     VOPersonDTO dto = new VOPersonDTO();
     dto.setFirstName(account.getUserInfo().getGivenName());
     dto.setName(account.getUserInfo().getName());
@@ -147,7 +152,7 @@ public interface LifecycleTestSupport {
 
     return dto;
   }
-  
+
   default Supplier<AssertionError> assertionError(String message) {
     return () -> new AssertionError(message);
   }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/cern/LifecycleTestSupport.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/cern/LifecycleTestSupport.java
@@ -41,8 +41,9 @@ public interface LifecycleTestSupport {
   String CERN_SSO_ISSUER = "https://auth.cern.ch/auth/realms/cern";
   String CERN_PERSON_ID = "12345678";
 
-  Instant NOW = Instant.parse("2020-01-01T00:00:00.00Z");
+  Instant NOW = Instant.parse("2020-01-01T12:00:00.00Z");
 
+  Instant DAY_BEFORE = NOW.minus(1, ChronoUnit.DAYS);
   Instant ONE_MINUTE_AGO = NOW.minus(1, ChronoUnit.MINUTES);
   Instant FOUR_DAYS_AGO = NOW.minus(4, ChronoUnit.DAYS);
   Instant EIGHT_DAYS_AGO = NOW.minus(8, ChronoUnit.DAYS);

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/cern/LifecycleTestSupport.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/cern/LifecycleTestSupport.java
@@ -41,9 +41,10 @@ public interface LifecycleTestSupport {
   String CERN_SSO_ISSUER = "https://auth.cern.ch/auth/realms/cern";
   String CERN_PERSON_ID = "12345678";
 
-  Instant NOW = Instant.parse("2020-01-01T12:00:00.00Z");
+  Instant LAST_MIDNIGHT = Instant.now().truncatedTo(ChronoUnit.DAYS);
+  Instant NOW = LAST_MIDNIGHT.plus(12, ChronoUnit.HOURS);
+  Instant DAY_BEFORE = LAST_MIDNIGHT.minus(1, ChronoUnit.SECONDS);
 
-  Instant DAY_BEFORE = NOW.minus(1, ChronoUnit.DAYS);
   Instant ONE_MINUTE_AGO = NOW.minus(1, ChronoUnit.MINUTES);
   Instant FOUR_DAYS_AGO = NOW.minus(4, ChronoUnit.DAYS);
   Instant EIGHT_DAYS_AGO = NOW.minus(8, ChronoUnit.DAYS);

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/labels/LabelsOAuthEncodingTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/labels/LabelsOAuthEncodingTests.java
@@ -91,7 +91,7 @@ public class LabelsOAuthEncodingTests extends EndpointsTestUtils {
     IamAccount testAccount =
         repo.findByUsername(TEST_USER).orElseThrow(assertionError(EXPECTED_USER_NOT_FOUND));
 
-    accountService.setLabel(testAccount, TEST_LABEL);
+    accountService.addLabel(testAccount, TEST_LABEL);
 
     AccessTokenGetter tg = buildAccessTokenGetter();
     tg.scope("openid profile");

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/cern/CernHrDbApiClientTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/cern/CernHrDbApiClientTests.java
@@ -15,7 +15,6 @@
  */
 package it.infn.mw.iam.test.registration.cern;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
@@ -27,7 +26,6 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withUnauthorizedRequest;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -70,7 +68,7 @@ public class CernHrDbApiClientTests extends CernTestSupport {
   public static class TestConfig {
     @Bean
     @Primary
-    public RestTemplateFactory mockRestTemplateFactory() {
+    RestTemplateFactory mockRestTemplateFactory() {
       return new MockRestTemplateFactory();
     }
   }
@@ -90,49 +88,6 @@ public class CernHrDbApiClientTests extends CernTestSupport {
   public void setup() {
     mockRtf = (MockRestTemplateFactory) rtf;
     mockRtf.resetTemplate();
-  }
-
-  @Test
-  public void checkMembershipSuccess() {
-    String personId = "12356789";
-    String apiValidationUrl = apiValidationUrl(personId);
-    mockRtf.getMockServer()
-      .expect(requestTo(apiValidationUrl))
-      .andExpect(method(GET))
-      .andExpect(header("Authorization", BASIC_AUTH_HEADER_VALUE))
-      .andRespond(withStatus(OK).contentType(APPLICATION_JSON).body("true"));
-
-    assertThat(hrDbService.hasValidExperimentParticipation(personId), is(true));
-  }
-
-  @Test
-  public void checkMembershipFailure() {
-    String personId = "12356789";
-    String apiValidationUrl = apiValidationUrl(personId);
-    mockRtf.getMockServer()
-      .expect(requestTo(apiValidationUrl))
-      .andExpect(method(GET))
-      .andExpect(header("Authorization", BASIC_AUTH_HEADER_VALUE))
-      .andRespond(withStatus(OK).contentType(APPLICATION_JSON).body("false"));
-
-    assertThat(hrDbService.hasValidExperimentParticipation(personId), is(false));
-  }
-
-  @Test(expected = CernHrDbApiError.class)
-  public void checkAuthorizationError() {
-    String personId = "12356789";
-    String apiValidationUrl = apiValidationUrl(personId);
-    mockRtf.getMockServer()
-      .expect(requestTo(apiValidationUrl))
-      .andExpect(method(GET))
-      .andExpect(header("Authorization", BASIC_AUTH_HEADER_VALUE))
-      .andRespond(withUnauthorizedRequest());
-    try {
-      hrDbService.hasValidExperimentParticipation(personId);
-    } catch (CernHrDbApiError e) {
-      assertThat(e.getMessage(), containsString("401"));
-      throw e;
-    }
   }
 
   @Test

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/converter/ScimAccountLabelConverterTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/converter/ScimAccountLabelConverterTests.java
@@ -91,7 +91,7 @@ public class ScimAccountLabelConverterTests {
       .andExpect(status().isOk())
       .andExpect(jsonPath("$." + ScimIndigoUser.INDIGO_USER_SCHEMA.LABELS).doesNotExist());
 
-    accountService.setLabel(testAccount, IAM_TEST_LABEL);
+    accountService.addLabel(testAccount, IAM_TEST_LABEL);
 
     mvc.perform(get(ScimUtils.getUserLocation(testAccount.getUuid())))
       .andExpect(status().isOk())
@@ -103,7 +103,7 @@ public class ScimAccountLabelConverterTests {
       .andExpect(
           jsonPath("$." + ScimIndigoUser.INDIGO_USER_SCHEMA.LABELS + "[0].prefix").value(IAM));
 
-    accountService.setLabel(testAccount, IAM_TOAST_LABEL);
+    accountService.addLabel(testAccount, IAM_TOAST_LABEL);
 
     mvc.perform(get(ScimUtils.getUserLocation(testAccount.getUuid())))
       .andExpect(status().isOk())

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/service/IamAccountServiceTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/service/IamAccountServiceTests.java
@@ -835,24 +835,39 @@ public class IamAccountServiceTests extends IamAccountServiceTestSupport {
   }
 
   @Test
-  public void testSetEndTimeWorksForNullDate() {
+  public void testSetSameNullEndTime() {
+
+    assertThat(CICCIO_ACCOUNT.getEndTime(), nullValue());
     accountService.setAccountEndTime(CICCIO_ACCOUNT, null);
-    verify(accountRepo, times(1)).save(CICCIO_ACCOUNT);
-    verify(eventPublisher, times(1)).publishEvent(eventCaptor.capture());
-
-    ApplicationEvent event = eventCaptor.getValue();
-    assertThat(event, instanceOf(AccountEndTimeUpdatedEvent.class));
-
-    AccountEndTimeUpdatedEvent e = (AccountEndTimeUpdatedEvent) event;
-    assertThat(e.getPreviousEndTime(), nullValue());
-    assertThat(e.getAccount().getEndTime(), nullValue());
+    verify(accountRepo, times(0)).save(CICCIO_ACCOUNT);
+    verify(eventPublisher, times(0)).publishEvent(eventCaptor.capture());
   }
 
   @Test
-  public void testSetEndTimeWorksForNonNullDate() {
+  public void testSetSameNotNullEndTime() {
 
-    Date newEndTime = new Date();
-    accountService.setAccountEndTime(CICCIO_ACCOUNT, newEndTime);
+    Date updatedEndTime = new Date();
+    accountService.setAccountEndTime(CICCIO_ACCOUNT, updatedEndTime);
+    assertThat(CICCIO_ACCOUNT.getEndTime(), is(updatedEndTime));
+    verify(accountRepo, times(1)).save(CICCIO_ACCOUNT);
+    verify(eventPublisher, times(1)).publishEvent(eventCaptor.capture());
+    ApplicationEvent event = eventCaptor.getValue();
+    assertThat(event, instanceOf(AccountEndTimeUpdatedEvent.class));
+
+    AccountEndTimeUpdatedEvent e = (AccountEndTimeUpdatedEvent) event;
+    assertThat(e.getPreviousEndTime(), nullValue());
+    assertThat(e.getAccount().getEndTime(), is(updatedEndTime));
+
+    accountService.setAccountEndTime(CICCIO_ACCOUNT, updatedEndTime);
+    verify(accountRepo, times(1)).save(CICCIO_ACCOUNT);
+    verify(eventPublisher, times(1)).publishEvent(eventCaptor.capture());
+  }
+
+  @Test
+  public void testSetEndTimeWorks() {
+
+    Date updatedEndTime = new Date();
+    accountService.setAccountEndTime(CICCIO_ACCOUNT, updatedEndTime);
     verify(accountRepo, times(1)).save(CICCIO_ACCOUNT);
     verify(eventPublisher, times(1)).publishEvent(eventCaptor.capture());
 
@@ -861,7 +876,18 @@ public class IamAccountServiceTests extends IamAccountServiceTestSupport {
 
     AccountEndTimeUpdatedEvent e = (AccountEndTimeUpdatedEvent) event;
     assertThat(e.getPreviousEndTime(), nullValue());
-    assertThat(e.getAccount().getEndTime(), is(newEndTime));
+    assertThat(e.getAccount().getEndTime(), is(updatedEndTime));
+
+    accountService.setAccountEndTime(CICCIO_ACCOUNT, null);
+    verify(accountRepo, times(2)).save(CICCIO_ACCOUNT);
+    verify(eventPublisher, times(2)).publishEvent(eventCaptor.capture());
+
+    event = eventCaptor.getValue();
+    assertThat(event, instanceOf(AccountEndTimeUpdatedEvent.class));
+
+    e = (AccountEndTimeUpdatedEvent) event;
+    assertThat(e.getPreviousEndTime(), is(updatedEndTime));
+    assertThat(e.getAccount().getEndTime(), nullValue());
   }
 
   @Test

--- a/iam-persistence/src/main/java/it/infn/mw/iam/persistence/model/IamAccount.java
+++ b/iam-persistence/src/main/java/it/infn/mw/iam/persistence/model/IamAccount.java
@@ -540,6 +540,13 @@ public class IamAccount implements Serializable {
     this.labels = labels;
   }
 
+  public boolean hasLabel(IamLabel label) {
+    return labels.stream().filter(l -> l.equals(label)).findFirst().isPresent();
+  }
+
+  public boolean hasLabelWithValue(IamLabel label) {
+    return labels.stream().filter(l -> l.equalsWithValue(label)).findFirst().isPresent();
+  }
 
   public Optional<IamLabel> getLabelByPrefixAndName(String prefix, String name) {
     for (IamLabel l : getLabels()) {

--- a/iam-persistence/src/main/java/it/infn/mw/iam/persistence/model/IamAccount.java
+++ b/iam-persistence/src/main/java/it/infn/mw/iam/persistence/model/IamAccount.java
@@ -541,11 +541,11 @@ public class IamAccount implements Serializable {
   }
 
   public boolean hasLabel(IamLabel label) {
-    return labels.stream().filter(l -> l.equals(label)).findFirst().isPresent();
+    return labels.stream().anyMatch(l -> l.equals(label));
   }
 
   public boolean hasLabelWithValue(IamLabel label) {
-    return labels.stream().filter(l -> l.equalsWithValue(label)).findFirst().isPresent();
+    return labels.stream().anyMatch(l -> l.equalsWithValue(label));
   }
 
   public Optional<IamLabel> getLabelByPrefixAndName(String prefix, String name) {

--- a/iam-persistence/src/main/java/it/infn/mw/iam/persistence/model/IamLabel.java
+++ b/iam-persistence/src/main/java/it/infn/mw/iam/persistence/model/IamLabel.java
@@ -112,7 +112,23 @@ public class IamLabel  implements Serializable{
       return false;
     return true;
   }
-  
+
+  public boolean equalsWithValue(Object obj) {
+
+    if (!this.equals(obj)) {
+      return false;
+    }
+    IamLabel other = (IamLabel) obj;
+    if (value == null) {
+      if (other.value != null) {
+        return false;
+      }
+    } else if (!value.equals(other.value)) {
+      return false;
+    }
+    return true;
+  }
+
   public static class Builder {
     String prefix;
     String name;


### PR DESCRIPTION
Updates on label logic:

- label `hr.cern.cern_person_id` contains CERN unique identifier of the user
- label `hr.cern.ignored` is used to exclude a user that has a `cern_person_id` from updating his personal data (given name, family name and optionally email) and his membership end-time from the data retrieved from HR database; this means, for example, that administrators have to manually manage his membership `endTime` to avoid suspension;
- label `hr.cern.timestamp` value was used to express the last time HR handler has run. Due to the fact it was updated each time the handler runs, also triggering an `AccountLabelSetEvent`, it was removed. We can rely on LOG to understand when the handler runs;
- label `hr.cern.status` contains the current status of contacting the API for that user; possible values are:
    - `IGNORED` used when label `hr.cern.ignore` is present;
    - `ERROR` in case of failed connections to HR API or null VOPerson record obtained;
    - `NOT_FOUND` in case HR API record is obtained but no experiment participation is found at all;
    - `MEMBER` when API returns a VOPerson record not null and the participation to the experiment is found and the expiration date is still valid (not expired);
    - `EXPIRED` when API returns a VOPerson record not null and the participation to the experiment is found but it has expired;
-  label `hr.cern.message` contains more details about status value;
-  label `hr.cern.skip-email-synch`, if set, is used to skip email update from HR record;
-  label `hr.cern.action` has been removed.

New CERN-HR-lifecycle-handler logic doesn't suspend users. It relies on the other internal `expired-accounts-handler` logic. But it still restores users those have been suspended by the `expired-accounts-handler` because of the end of suspension grace period.

This means a grace period is now applied for CERN profile.