### PR TITLE
Handle HEAD requests for /registration/verify/{token} endpoint

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamApiSecurityConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamApiSecurityConfig.java
@@ -16,6 +16,7 @@
 package it.infn.mw.iam.config.security;
 
 import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.HEAD;
 import static org.springframework.http.HttpMethod.POST;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -136,6 +137,7 @@ public class IamApiSecurityConfig {
             .antMatchers(GET, "/registration/config").permitAll()
             .antMatchers(GET, "/registration/confirm/**").permitAll()
             .antMatchers(GET, "/registration/verify/**").permitAll()
+            .antMatchers(HEAD, "/registration/verify/**").permitAll()
             .antMatchers(GET, "/registration/submitted").permitAll()
             .antMatchers(GET, "/iam/config/**").permitAll()
             .antMatchers(GET, AUP_PATH).permitAll()

--- a/iam-login-service/src/main/java/it/infn/mw/iam/registration/RegistrationApiController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/registration/RegistrationApiController.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -141,6 +142,11 @@ public class RegistrationApiController {
   public RegistrationRequestDto confirmRequest(@PathVariable("token") String token) {
 
     return service.confirmRequest(token);
+  }
+
+  @RequestMapping(value = "/registration/verify/{token}", method = RequestMethod.HEAD)
+  public ResponseEntity<String> handleHeadRequest() {
+    return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).build();
   }
 
   @RequestMapping(value = "/registration/verify/{token}", method = RequestMethod.GET)

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/notification/RegistrationFlowNotificationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/notification/RegistrationFlowNotificationTests.java
@@ -25,6 +25,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.head;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -154,6 +155,9 @@ public class RegistrationFlowNotificationTests {
     notificationDelivery.clearDeliveredNotifications();
 
     String confirmationKey = generator.getLastToken();
+    
+    mvc.perform(head("/registration/verify/{token}", confirmationKey).contentType(APPLICATION_JSON))
+    .andExpect(status().isMethodNotAllowed());
 
     mvc.perform(get("/registration/confirm/{token}", confirmationKey).contentType(APPLICATION_JSON))
       .andExpect(status().isOk());


### PR DESCRIPTION
Other endpoints are ok, `/iam/aup/sign` endpoint fixed in PR https://github.com/indigo-iam/iam/pull/870.