### PR TITLE
 Redirect to login page when signing AUP 

### DIFF
--- a/iam-login-service/src/main/webapp/WEB-INF/views/iam/noAup.jsp
+++ b/iam-login-service/src/main/webapp/WEB-INF/views/iam/noAup.jsp
@@ -19,6 +19,6 @@
 <t:page title="No Acceptable Usage Policy">
   <h2 class="text-center">No AUP defined for this organization!</h2>
   <div id="register-confirm-back-btn" class="row text-center">
-    <a class="btn btn-primary" href='/login'>Back to Login Page</a>
+    <a class="btn btn-primary" href='/'>Back to Home Page</a>
   </div>
 </t:page>


### PR DESCRIPTION
In case the user is not authenticated, the `/iam/aup/sign` endpoint redirects to the login page.
This should solve issue #855.