### PR TITLE
Exclude IAM optional groups from VOMS AC

### DIFF
--- a/iam-voms-aa/src/main/java/it/infn/mw/voms/aa/impl/IamVOMSAttributeResolver.java
+++ b/iam-voms-aa/src/main/java/it/infn/mw/voms/aa/impl/IamVOMSAttributeResolver.java
@@ -38,10 +38,12 @@ public class IamVOMSAttributeResolver implements AttributeResolver {
   public static final Logger LOG = LoggerFactory.getLogger(IamVOMSAttributeResolver.class);
 
   private final IamLabel vomsRoleLabel;
+  private final IamLabel optionalGroupLabel;
   private final FQANEncoding fqanEncoding;
 
   public IamVOMSAttributeResolver(VomsProperties properties, FQANEncoding fqanEncoding) {
-    vomsRoleLabel = IamLabel.builder().name(properties.getAa().getOptionalGroupLabel()).build();
+    vomsRoleLabel = IamLabel.builder().name(properties.getAa().getVomsRoleLabel()).build();
+    optionalGroupLabel = IamLabel.builder().name(properties.getAa().getOptionalGroupLabel()).build();
     this.fqanEncoding = fqanEncoding;
   }
 
@@ -49,7 +51,7 @@ public class IamVOMSAttributeResolver implements AttributeResolver {
     final String voName = context.getVOName();
     final boolean nameMatches = g.getName().equals(voName) || g.getName().startsWith(voName + "/");
 
-    return nameMatches && !g.getLabels().contains(vomsRoleLabel);
+    return nameMatches && !g.getLabels().contains(vomsRoleLabel) && !g.getLabels().contains(optionalGroupLabel);
   }
 
   protected void noSuchUserError(VOMSRequestContext context) {

--- a/iam-voms-aa/src/main/java/it/infn/mw/voms/properties/VomsProperties.java
+++ b/iam-voms-aa/src/main/java/it/infn/mw/voms/properties/VomsProperties.java
@@ -115,8 +115,10 @@ public class VomsProperties {
     private long maxAcLifetimeInSeconds = TimeUnit.HOURS.toSeconds(12);
 
     private Boolean useLegacyFqanEncoding = Boolean.FALSE;
-    
+
     private String optionalGroupLabel = "wlcg.optional-group";
+
+    private String vomsRoleLabel = "voms.role";
 
     public String getVoName() {
       return voName;
@@ -149,19 +151,27 @@ public class VomsProperties {
     public void setMaxAcLifetimeInSeconds(long maxAcLifetimeInSeconds) {
       this.maxAcLifetimeInSeconds = maxAcLifetimeInSeconds;
     }
-    
+
     public String getOptionalGroupLabel() {
       return optionalGroupLabel;
     }
-    
+
     public void setOptionalGroupLabel(String optionalGroupLabel) {
       this.optionalGroupLabel = optionalGroupLabel;
     }
-    
+
+    public String getVomsRoleLabel() {
+      return vomsRoleLabel;
+    }
+
+    public void setVomsRoleLabel(String vomsRoleLabel) {
+      this.vomsRoleLabel = vomsRoleLabel;
+    }
+
     public void setUseLegacyFqanEncoding(Boolean useLegacyFqanEncoding) {
       this.useLegacyFqanEncoding = useLegacyFqanEncoding;
     }
-    
+
     public Boolean getUseLegacyFqanEncoding() {
       return useLegacyFqanEncoding;
     }

--- a/iam-voms-aa/src/main/resources/application.yml
+++ b/iam-voms-aa/src/main/resources/application.yml
@@ -41,5 +41,6 @@ voms:
     host: ${server.address}
     port: ${server.port}
     vo-name: test
-    optional-group-label: voms.role
+    optional-group-label: wlcg.optional-group
+    voms-role-label: voms.role
     use-legacy-fqan-encoding: false

--- a/iam-voms-aa/src/test/java/it/infn/mw/voms/TestSupport.java
+++ b/iam-voms-aa/src/test/java/it/infn/mw/voms/TestSupport.java
@@ -55,7 +55,7 @@ import it.infn.mw.voms.properties.VomsProperties;
 public class TestSupport {
 
   public static final String VOMS_ROLE_LABEL = "voms.role";
-  public static final String OPTIONAL_GROUP_LABEL = "voms.role";
+  public static final String OPTIONAL_GROUP_LABEL = "wlcg.optional-group";
 
   public static final String SERVER_NAME = "voms.example";
   public static final String TLS_PROTOCOL = "TLSv1.2";

--- a/iam-voms-aa/src/test/java/it/infn/mw/voms/TestSupport.java
+++ b/iam-voms-aa/src/test/java/it/infn/mw/voms/TestSupport.java
@@ -55,6 +55,7 @@ import it.infn.mw.voms.properties.VomsProperties;
 public class TestSupport {
 
   public static final String VOMS_ROLE_LABEL = "voms.role";
+  public static final String OPTIONAL_GROUP_LABEL = "voms.role";
 
   public static final String SERVER_NAME = "voms.example";
   public static final String TLS_PROTOCOL = "TLSv1.2";
@@ -249,6 +250,13 @@ public class TestSupport {
   protected IamGroup createRoleGroup(IamGroup parent, String name) {
     IamGroup g = createChildGroup(parent, name);
     g.getLabels().add(IamLabel.builder().name(VOMS_ROLE_LABEL).build());
+    groupRepo.save(g);
+    return g;
+  }
+
+  protected IamGroup createOptionalGroup(IamGroup parent, String name) {
+    IamGroup g = createChildGroup(parent, name);
+    g.getLabels().add(IamLabel.builder().name(OPTIONAL_GROUP_LABEL).build());
     groupRepo.save(g);
     return g;
   }

--- a/iam-voms-aa/src/test/java/it/infn/mw/voms/VomsAcTests.java
+++ b/iam-voms-aa/src/test/java/it/infn/mw/voms/VomsAcTests.java
@@ -269,6 +269,33 @@ public class VomsAcTests extends TestSupport {
     assertThat(attrs.getNotAfter(), lessThanOrEqualTo(Date.from(NOW_PLUS_12_HOURS)));
   }
 
+  @Test
+  public void optionalGroupIsReturnedForUserIfRequested() throws Exception {
+    IamAccount testAccount = setupTestUser();
+    IamGroup rootGroup = createVomsRootGroup();
+    IamGroup subGroup = createChildGroup(rootGroup, "sub");
+    IamGroup optionalGroup = createOptionalGroup(subGroup, "optional");
+
+    addAccountToGroup(testAccount, rootGroup);
+    addAccountToGroup(testAccount, subGroup);
+    addAccountToGroup(testAccount, optionalGroup);
+
+    byte[] xmlResponse = mvc
+      .perform(get("/generate-ac").headers(test0VOMSHeaders()).param("fqans", "/test/sub/optional"))
+      .andExpect(status().isOk())
+      .andReturn()
+      .getResponse()
+      .getContentAsByteArray();
+
+    VOMSResponse response = parser.parse(new ByteArrayInputStream(xmlResponse));
+    assertThat(response.hasErrors(), is(false));
+    VOMSAttribute attrs = getAttributeCertificate(response);
+    assertThat(attrs.getFQANs(), hasSize(3));
+    assertThat(attrs.getFQANs(), hasItem("/test"));
+    assertThat(attrs.getFQANs(), hasItem("/test/sub"));
+    assertThat(attrs.getFQANs(), hasItem("/test/sub/optional"));
+    assertThat(attrs.getNotAfter(), lessThanOrEqualTo(Date.from(NOW_PLUS_12_HOURS)));
+  }
 
   @Test
   public void requestedFqanOrderEnforced() throws Exception {
@@ -326,6 +353,34 @@ public class VomsAcTests extends TestSupport {
     assertThat(attrs.getFQANs(), hasSize(4));
     assertThat(attrs.getFQANs(),
         contains("/test/Role=VO-Admin", "/test", "/test/sub", "/test/sub/subsub"));
+    assertThat(attrs.getNotAfter(), lessThanOrEqualTo(Date.from(NOW_PLUS_12_HOURS)));
+
+  }
+
+  @Test
+  public void roleRequestInAnOptionalGroupWorks() throws Exception {
+    IamAccount testAccount = setupTestUser();
+    IamGroup rootGroup = createVomsRootGroup();
+    IamGroup optionalGroup = createOptionalGroup(rootGroup, "optional");
+    IamGroup roleGroup = createRoleGroup(optionalGroup, "VO-Admin");
+
+    addAccountToGroup(testAccount, rootGroup);
+    addAccountToGroup(testAccount, optionalGroup);
+    addAccountToGroup(testAccount, roleGroup);
+
+    byte[] xmlResponse = mvc
+      .perform(get("/generate-ac").headers(test0VOMSHeaders())
+        .param("fqans", "/test/optional/Role=VO-Admin"))
+      .andExpect(status().isOk())
+      .andReturn()
+      .getResponse()
+      .getContentAsByteArray();
+
+    VOMSResponse response = parser.parse(new ByteArrayInputStream(xmlResponse));
+    assertThat(response.hasErrors(), is(false));
+    VOMSAttribute attrs = getAttributeCertificate(response);
+    assertThat(attrs.getFQANs(), hasSize(2));
+    assertThat(attrs.getFQANs(), contains("/test/optional/Role=VO-Admin", "/test"));
     assertThat(attrs.getNotAfter(), lessThanOrEqualTo(Date.from(NOW_PLUS_12_HOURS)));
 
   }


### PR DESCRIPTION
In the context of WLCG profile, this PR removes from VOMS attribute certificate the groups those have "wlcg.optional-group" label set.