### PR TITLE
Fix CERN lifecycle logic

### DIFF
--- a/iam-login-service/pom.xml
+++ b/iam-login-service/pom.xml
@@ -34,7 +34,6 @@
 
   <properties>
     <test-clock.version>1.0.2</test-clock.version>
-    <threeten-extra.version>1.8.0</threeten-extra.version>
     <eclipselink.version>2.7.9</eclipselink.version>
     <javax.persistence.version>2.2.1</javax.persistence.version>
 
@@ -405,12 +404,6 @@
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.threeten</groupId>
-      <artifactId>threeten-extra</artifactId>
-      <version>${threeten-extra.version}</version>
     </dependency>
 
   </dependencies>

--- a/iam-login-service/pom.xml
+++ b/iam-login-service/pom.xml
@@ -34,6 +34,7 @@
 
   <properties>
     <test-clock.version>1.0.2</test-clock.version>
+    <threeten-extra.version>1.8.0</threeten-extra.version>
     <eclipselink.version>2.7.9</eclipselink.version>
     <javax.persistence.version>2.2.1</javax.persistence.version>
 
@@ -404,6 +405,12 @@
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.threeten</groupId>
+      <artifactId>threeten-extra</artifactId>
+      <version>${threeten-extra.version}</version>
     </dependency>
 
   </dependencies>

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/cern/CernProperties.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/cern/CernProperties.java
@@ -100,10 +100,6 @@ public class CernProperties {
     }
   }
 
-  public enum CernHrActionsOnUser {
-    NO_ACTION, DISABLE_USER;
-  }
-
   @NotBlank
   private String ssoIssuer = "https://auth.cern.ch/auth/realms/cern";
 
@@ -112,10 +108,6 @@ public class CernProperties {
 
   @NotBlank
   private String experimentName = "test";
-
-  private CernHrActionsOnUser onPersonIdNotFound = CernHrActionsOnUser.NO_ACTION;
-
-  private CernHrActionsOnUser onParticipationNotFound = CernHrActionsOnUser.NO_ACTION;
 
   @Valid
   private HrDbApiProperties hrApi = new HrDbApiProperties();
@@ -161,22 +153,6 @@ public class CernProperties {
 
   public void setTask(HrSynchTaskProperties task) {
     this.task = task;
-  }
-
-  public CernHrActionsOnUser getOnPersonIdNotFound() {
-    return onPersonIdNotFound;
-  }
-
-  public void setOnPersonIdNotFound(CernHrActionsOnUser onPersonIdNotFound) {
-    this.onPersonIdNotFound = onPersonIdNotFound;
-  }
-
-  public CernHrActionsOnUser getOnParticipationNotFound() {
-    return onParticipationNotFound;
-  }
-
-  public void setOnParticipationNotFound(CernHrActionsOnUser onParticipationNotFound) {
-    this.onParticipationNotFound = onParticipationNotFound;
   }
 
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/cern/CernHrLifecycleHandler.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/cern/CernHrLifecycleHandler.java
@@ -15,16 +15,9 @@
  */
 package it.infn.mw.iam.core.lifecycle.cern;
 
-import static it.infn.mw.iam.config.cern.CernProperties.CernHrActionsOnUser.DISABLE_USER;
 import static it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler.LIFECYCLE_STATUS_LABEL;
 import static it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler.AccountLifecycleStatus.PENDING_REMOVAL;
 import static it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler.AccountLifecycleStatus.SUSPENDED;
-import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.Status.ERROR;
-import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.Status.EXPIRED;
-import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.Status.EXP_NOT_FOUND;
-import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.Status.ID_NOT_FOUND;
-import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.Status.IGNORED;
-import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.Status.MEMBER;
 import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleUtils.LABEL_CERN_PREFIX;
 import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleUtils.LABEL_SKIP_EMAIL_SYNCH;
 import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleUtils.LABEL_SKIP_END_DATE_SYNCH;
@@ -48,11 +41,11 @@ import com.google.common.collect.Lists;
 
 import it.infn.mw.iam.api.registration.cern.CernHrDBApiService;
 import it.infn.mw.iam.api.registration.cern.CernHrDbApiError;
+import it.infn.mw.iam.api.registration.cern.dto.InstituteDTO;
 import it.infn.mw.iam.api.registration.cern.dto.ParticipationDTO;
 import it.infn.mw.iam.api.registration.cern.dto.VOPersonDTO;
 import it.infn.mw.iam.api.scim.exception.IllegalArgumentException;
 import it.infn.mw.iam.config.cern.CernProperties;
-import it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler.AccountLifecycleStatus;
 import it.infn.mw.iam.core.user.IamAccountService;
 import it.infn.mw.iam.core.user.exception.EmailAlreadyBoundException;
 import it.infn.mw.iam.persistence.model.IamAccount;
@@ -70,8 +63,8 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
   public static final String NO_PERSON_FOUND_MESSAGE = "No person id %s found on HR DB";
   public static final String NO_PARTICIPATION_MESSAGE =
       "Account end-time not updated: no participation to %s found";
-  public static final String EXPIRED_MESSAGE = "Account participation to the experiment is expired";
-  public static final String VALID_MESSAGE = "Account has a valid participation to the experiment";
+  public static final String SYNCHRONIZED_MESSAGE =
+      "Account's membership to the experiment synchronized";
 
   public static final String HR_DB_API_ERROR = "Account not updated: HR DB error";
 
@@ -82,8 +75,8 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
 
   public static final Logger LOG = LoggerFactory.getLogger(CernHrLifecycleHandler.class);
 
-  public enum Status {
-    IGNORED, ERROR, ID_NOT_FOUND, EXP_NOT_FOUND, EXPIRED, MEMBER
+  public enum CernStatus {
+    IGNORED, ERROR, NOT_FOUND, NOT_MEMBER, OK
   }
 
   private final CernProperties cernProperties;
@@ -99,52 +92,53 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
     this.hrDb = hrDb;
   }
 
-  public void handleAccount(String cernPersonId, IamAccount account) {
+  public void handleAccount(String cernPersonId, String experiment, IamAccount a) {
 
-    LOG.debug("Handling account {}", account.getUsername());
-    LOG.debug("Account CERN person id {} for experiment {}", cernPersonId,
-        cernProperties.getExperimentName());
+    LOG.debug("Handling IAM account (username: {} , uuid: {})", a.getUsername(), a.getUuid());
+    LOG.debug("Synchronize with CERN person id {} ({})", cernPersonId, experiment);
 
-    if (isAccountIgnored(account)) {
-      ignoreAccount(account);
+    deleteDeprecatedLabels(a);
+
+    if (CernHrLifecycleUtils.isAccountIgnored(a)) {
+      LOG.debug("Ignoring account '{}'", a.getUsername());
+      setCernStatusLabel(a, CernStatus.IGNORED, IGNORE_MESSAGE);
       return;
     }
-
-    /* remove deprecated labels: to be removed with a migration into next IAM release */
-    accountService.deleteLabel(account, CernHrLifecycleUtils.buildCernTimestampLabel());
-    accountService.deleteLabel(account, CernHrLifecycleUtils.buildCernActionLabel());
 
     Optional<VOPersonDTO> voPerson = Optional.empty();
     try {
       voPerson = hrDb.getHrDbPersonRecord(cernPersonId);
     } catch (CernHrDbApiError e) {
-      handleApiError(account, e);
+      LOG.error("Error contacting HR DB api: {}", e.getMessage(), e);
+      setCernStatusLabel(a, CernStatus.ERROR, format(HR_DB_API_ERROR));
       return;
     }
     if (voPerson.isEmpty()) {
-      handleNoPersonIdFound(account, cernPersonId);
+      LOG.debug("No record found for person id {}", cernPersonId);
+      setCernStatusLabel(a, CernStatus.NOT_FOUND, format(NO_PERSON_FOUND_MESSAGE, cernPersonId));
+      expireIfActiveAndValid(a);
       return;
     }
 
-    syncAccountInformation(account, voPerson.get());
+    syncAccountInformation(a, voPerson.get());
 
-    Optional<ParticipationDTO> ep = CernHrLifecycleUtils.getMostRecentMembership(
-        voPerson.get().getParticipations(), cernProperties.getExperimentName());
+    Optional<ParticipationDTO> ep = CernHrLifecycleUtils
+      .getMostRecentMembership(voPerson.get().getParticipations(), experiment);
 
     if (ep.isEmpty()) {
-      handleNoParticipation(account, cernPersonId);
+      LOG.warn("No membership to '{}' found for person id {}", experiment, cernPersonId);
+      setCernStatusLabel(a, CernStatus.NOT_MEMBER, format(NO_PARTICIPATION_MESSAGE, experiment));
+      expireIfActiveAndValid(a);
       return;
     }
 
-    syncAccountEndTime(account, ep.get().getEndDate());
+    syncInstitute(a, ep.get().getInstitute());
+    syncAccountEndTime(a, ep.get().getEndDate());
+    setCernStatusLabel(a, CernStatus.OK, format(SYNCHRONIZED_MESSAGE));
 
-    if (CernHrLifecycleUtils.isActiveMembership(account.getEndTime())) {
-      setCernStatusLabel(account, MEMBER, format(VALID_MESSAGE));
-      if (!account.isActive() && accountWasSuspendedByIamLifecycleJob(account)) {
-        restoreAccount(account);
-      }
-    } else {
-      setCernStatusLabel(account, EXPIRED, format(EXPIRED_MESSAGE));
+    if (CernHrLifecycleUtils.isActiveMembership(a.getEndTime()) && !a.isActive()
+        && accountWasSuspendedByIamLifecycleJob(a)) {
+      restoreAccount(a);
     }
   }
 
@@ -164,7 +158,7 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
       if (accountsPage.hasContent()) {
         for (IamAccount account : accountsPage.getContent()) {
           try {
-            handleAccount(getCernPersonId(account), account);
+            handleAccount(getCernPersonId(account), cernProperties.getExperimentName(), account);
           } catch (RuntimeException e) {
             LOG.error("Error during CERN HR lifecycle handler: {}", e.getMessage());
           }
@@ -191,6 +185,12 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
       LOG.info("Scheduling CERN HR DB lifecycle handler with schedule: {}", cronSchedule);
       taskRegistrar.addCronTask(this, cronSchedule);
     }
+  }
+
+  private void deleteDeprecatedLabels(IamAccount a) {
+    /* remove deprecated labels: to be removed with a migration into next IAM release */
+    accountService.deleteLabel(a, CernHrLifecycleUtils.buildCernTimestampLabel());
+    accountService.deleteLabel(a, CernHrLifecycleUtils.buildCernActionLabel());
   }
 
   private void syncAccountInformation(IamAccount a, VOPersonDTO p) {
@@ -227,10 +227,6 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
     return cernPersonIdLabel.get().getValue();
   }
 
-  private boolean isAccountIgnored(IamAccount a) {
-    return a.hasLabel(CernHrLifecycleUtils.buildCernIgnoreLabel());
-  }
-
   private boolean isSkipEmailSynch(IamAccount a) {
     return a.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_SKIP_EMAIL_SYNCH).isPresent();
   }
@@ -239,26 +235,13 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
     return a.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_SKIP_END_DATE_SYNCH).isPresent();
   }
 
-  private void setCernStatusLabel(IamAccount a, Status status, String message) {
+  private void setCernStatusLabel(IamAccount a, CernStatus status, String message) {
     IamLabel statusLabel = CernHrLifecycleUtils.buildCernStatusLabel(status);
     IamLabel messageLabel = CernHrLifecycleUtils.buildCernMessageLabel(message);
     LOG.debug("Setting CERN label {} to account '{}' ...", statusLabel, a.getUsername());
     accountService.addLabel(a, statusLabel);
     LOG.debug("Setting CERN label {} to account '{}' ...", statusLabel, a.getUsername());
     accountService.addLabel(a, messageLabel);
-  }
-
-  private void ignoreAccount(IamAccount a) {
-    LOG.debug("Ignoring account '{}'", a.getUsername());
-    setCernStatusLabel(a, IGNORED, IGNORE_MESSAGE);
-  }
-
-  private void disableAccount(IamAccount a) {
-    LOG.debug("Disabling account '{}'", a.getUsername());
-    accountService.disableAccount(a);
-    IamLabel statusLabel =
-        CernHrLifecycleUtils.buildLifecycleStatusLabel(AccountLifecycleStatus.SUSPENDED);
-    accountService.addLabel(a, statusLabel);
   }
 
   private void restoreAccount(IamAccount a) {
@@ -268,6 +251,12 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
     accountService.deleteLabel(a, statusLabel);
   }
 
+  private void syncInstitute(IamAccount a, InstituteDTO institute) {
+    IamLabel instituteLabel = CernHrLifecycleUtils.buildInstituteLabel(institute);
+    LOG.debug("Setting CERN label {} to account '{}' ...", instituteLabel, a.getUsername());
+    accountService.addLabel(a, instituteLabel);
+  }
+
   private void syncAccountEndTime(IamAccount a, Date endDate) {
     if (!isSkipEndDateSynch(a)) {
       LOG.debug("Updating end-time for '{}' to {} ...", a.getUsername(), endDate);
@@ -275,32 +264,12 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
     }
   }
 
-  private void handleApiError(IamAccount account, CernHrDbApiError e) {
-    LOG.error("Error contacting HR DB api: {}", e.getMessage(), e);
-    setCernStatusLabel(account, ERROR, format(HR_DB_API_ERROR));
-  }
-
-  private void handleNoPersonIdFound(IamAccount a, String cernPersonId) {
-    LOG.warn("No record found for person id {}", cernPersonId);
-    setCernStatusLabel(a, ID_NOT_FOUND, format(NO_PERSON_FOUND_MESSAGE, cernPersonId));
-    if (DISABLE_USER.equals(cernProperties.getOnPersonIdNotFound())) {
-      disableAccount(a);
-    }
-  }
-
-  private void handleNoParticipation(IamAccount a, String cernPersonId) {
-    LOG.warn("No membership to '{}' found for person id {}", cernProperties.getExperimentName(),
-        cernPersonId);
-    setCernStatusLabel(a, EXP_NOT_FOUND,
-        format(NO_PARTICIPATION_MESSAGE, cernProperties.getExperimentName()));
-    switch (cernProperties.getOnParticipationNotFound()) {
-      case DISABLE_USER:
-        if (a.isActive()) {
-          disableAccount(a);
-        }
-        break;
-      case NO_ACTION:
-      default:
+  private void expireIfActiveAndValid(IamAccount a) {
+    Date currentDate = new Date();
+    if (a.isActive() && a.getEndTime().after(currentDate)) {
+      LOG.warn("User {} has a valid membership but cannot be found on HR db", a.getUsername());
+      LOG.debug("Updating end-time for '{}' to {} ...", a.getUsername(), currentDate);
+      accountService.setAccountEndTime(a, currentDate);
     }
   }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/cern/CernHrLifecycleHandler.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/cern/CernHrLifecycleHandler.java
@@ -194,16 +194,9 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
   }
 
   private void syncAccountInformation(IamAccount a, VOPersonDTO p) {
-
-    LOG.debug("Syncing IAM account '{}' with CERN HR record id '{}'", a.getUsername(), p.getId());
-
-    LOG.debug("Updating Given Name for {} to {} ...", a.getUsername(), p.getFirstName());
     accountService.setAccountGivenName(a, p.getFirstName());
-    LOG.debug("Updating Family Name for {} to {} ...", a.getUsername(), p.getName());
     accountService.setAccountFamilyName(a, p.getName());
-
     if (!isSkipEmailSynch(a)) {
-      LOG.debug("Updating Email for {} to {} ...", a.getUsername(), p.getEmail());
       try {
         accountService.setAccountEmail(a, p.getEmail());
       } catch (EmailAlreadyBoundException e) {
@@ -238,14 +231,11 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
   private void setCernStatusLabel(IamAccount a, CernStatus status, String message) {
     IamLabel statusLabel = CernHrLifecycleUtils.buildCernStatusLabel(status);
     IamLabel messageLabel = CernHrLifecycleUtils.buildCernMessageLabel(message);
-    LOG.debug("Setting CERN label {} to account '{}' ...", statusLabel, a.getUsername());
     accountService.addLabel(a, statusLabel);
-    LOG.debug("Setting CERN label {} to account '{}' ...", statusLabel, a.getUsername());
     accountService.addLabel(a, messageLabel);
   }
 
   private void restoreAccount(IamAccount a) {
-    LOG.debug("Restoring account '{}'", a.getUsername());
     accountService.restoreAccount(a);
     IamLabel statusLabel = CernHrLifecycleUtils.buildLifecycleStatusLabel();
     accountService.deleteLabel(a, statusLabel);
@@ -253,13 +243,11 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
 
   private void syncInstitute(IamAccount a, InstituteDTO institute) {
     IamLabel instituteLabel = CernHrLifecycleUtils.buildInstituteLabel(institute);
-    LOG.debug("Setting CERN label {} to account '{}' ...", instituteLabel, a.getUsername());
     accountService.addLabel(a, instituteLabel);
   }
 
   private void syncAccountEndTime(IamAccount a, Date endDate) {
     if (!isSkipEndDateSynch(a)) {
-      LOG.debug("Updating end-time for '{}' to {} ...", a.getUsername(), endDate);
       accountService.setAccountEndTime(a, endDate);
     }
   }
@@ -268,7 +256,6 @@ public class CernHrLifecycleHandler implements Runnable, SchedulingConfigurer {
     Date currentDate = new Date();
     if (a.isActive() && a.getEndTime().after(currentDate)) {
       LOG.warn("User {} has a valid membership but cannot be found on HR db", a.getUsername());
-      LOG.debug("Updating end-time for '{}' to {} ...", a.getUsername(), currentDate);
       accountService.setAccountEndTime(a, currentDate);
     }
   }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/cern/CernHrLifecycleUtils.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/lifecycle/cern/CernHrLifecycleUtils.java
@@ -27,10 +27,12 @@ import java.util.Set;
 
 import org.joda.time.DateTimeComparator;
 
+import it.infn.mw.iam.api.registration.cern.dto.InstituteDTO;
 import it.infn.mw.iam.api.registration.cern.dto.ParticipationDTO;
 import it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler;
 import it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler.AccountLifecycleStatus;
-import it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.Status;
+import it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.CernStatus;
+import it.infn.mw.iam.persistence.model.IamAccount;
 import it.infn.mw.iam.persistence.model.IamLabel;
 
 public class CernHrLifecycleUtils {
@@ -43,6 +45,7 @@ public class CernHrLifecycleUtils {
   public static final String LABEL_IGNORE = "ignore";
   public static final String LABEL_SKIP_EMAIL_SYNCH = "skip-email-synch";
   public static final String LABEL_SKIP_END_DATE_SYNCH = "skip-end-date-synch";
+  public static final String LABEL_INSTITUTE = "institute";
 
   private CernHrLifecycleUtils() {}
 
@@ -51,7 +54,7 @@ public class CernHrLifecycleUtils {
     return IamLabel.builder().prefix(LABEL_CERN_PREFIX).name(LABEL_ACTION).build();
   }
 
-  public static IamLabel buildCernStatusLabel(Status status) {
+  public static IamLabel buildCernStatusLabel(CernStatus status) {
 
     return IamLabel.builder()
       .prefix(LABEL_CERN_PREFIX)
@@ -101,5 +104,18 @@ public class CernHrLifecycleUtils {
       return true;
     }
     return DateTimeComparator.getDateOnlyInstance().compare(endTime, new Date()) >= 0;
+  }
+
+  public static boolean isAccountIgnored(IamAccount a) {
+    return a.hasLabel(buildCernIgnoreLabel());
+  }
+
+  public static IamLabel buildInstituteLabel(InstituteDTO i) {
+    String fullInstitute = String.format("%s, %s, %s", i.getName(), i.getTown(), i.getCountry());
+    return IamLabel.builder()
+      .prefix(LABEL_CERN_PREFIX)
+      .name(LABEL_INSTITUTE)
+      .value(fullInstitute)
+      .build();
   }
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/cern/CernAccountLifecycleDisableUserTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/cern/CernAccountLifecycleDisableUserTests.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
 import java.time.Clock;
+import java.time.Duration;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
@@ -48,8 +49,8 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.threeten.extra.Hours;
-import org.threeten.extra.MutableClock;
+
+import com.mercateo.test.clock.TestClock;
 
 import it.infn.mw.iam.IamLoginService;
 import it.infn.mw.iam.api.registration.cern.CernHrDBApiService;
@@ -71,9 +72,8 @@ import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
 @SpringBootTest(classes = {IamLoginService.class, CoreControllerTestSupport.class,
     CernAccountLifecycleDisableUserTests.TestConfig.class})
 @TestPropertySource(properties = {
-// @formatter:off
+  // @formatter:off
     "cern.task.pageSize=5",
-    "cern.on-participation-not-found=disable_user"
   // @formatter:on
 })
 @ActiveProfiles(value = {"h2-test", "cern"})
@@ -85,7 +85,7 @@ public class CernAccountLifecycleDisableUserTests extends TestSupport
     @Bean
     @Primary
     Clock mockClock() {
-      return MutableClock.of(NOW, ZoneId.systemDefault());
+      return TestClock.fixed(NOW, ZoneId.systemDefault());
     }
 
     @Bean
@@ -169,7 +169,7 @@ public class CernAccountLifecycleDisableUserTests extends TestSupport
     assertThat(messageLabel.isPresent(), is(true));
     assertThat(messageLabel.get().getValue(), is(format(NO_PERSON_FOUND_MESSAGE, CERN_PERSON_ID)));
 
-    ((MutableClock) clock).add(Hours.of(36));
+    ((TestClock) clock).fastForward(Duration.ofHours(36));
 
     expiredAccountsHandler.run();
  
@@ -215,7 +215,7 @@ public class CernAccountLifecycleDisableUserTests extends TestSupport
     assertThat(messageLabel.isPresent(), is(true));
     assertThat(messageLabel.get().getValue(), is(format(NO_PARTICIPATION_MESSAGE, "test")));
 
-    ((MutableClock) clock).add(Hours.of(36));
+    ((TestClock) clock).fastForward(Duration.ofHours(36));
 
     expiredAccountsHandler.run();
  

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/cern/CernAccountLifecycleTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/cern/CernAccountLifecycleTests.java
@@ -18,16 +18,14 @@ package it.infn.mw.iam.test.lifecycle.cern;
 import static it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler.LIFECYCLE_STATUS_LABEL;
 import static it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler.AccountLifecycleStatus.PENDING_REMOVAL;
 import static it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler.AccountLifecycleStatus.SUSPENDED;
-import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.EXPIRED_MESSAGE;
 import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.HR_DB_API_ERROR;
 import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.IGNORE_MESSAGE;
 import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.NO_PARTICIPATION_MESSAGE;
 import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.NO_PERSON_FOUND_MESSAGE;
-import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.VALID_MESSAGE;
-import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.Status.EXPIRED;
-import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.Status.IGNORED;
-import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.Status.MEMBER;
+import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.SYNCHRONIZED_MESSAGE;
+import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.CernStatus.IGNORED;
 import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleUtils.LABEL_CERN_PREFIX;
+import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleUtils.LABEL_INSTITUTE;
 import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleUtils.LABEL_MESSAGE;
 import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleUtils.LABEL_STATUS;
 import static it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleUtils.LABEL_TIMESTAMP;
@@ -74,6 +72,7 @@ import it.infn.mw.iam.api.registration.cern.dto.ParticipationDTO;
 import it.infn.mw.iam.api.registration.cern.dto.VOPersonDTO;
 import it.infn.mw.iam.core.lifecycle.ExpiredAccountsHandler;
 import it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler;
+import it.infn.mw.iam.core.lifecycle.cern.CernHrLifecycleHandler.CernStatus;
 import it.infn.mw.iam.core.user.IamAccountService;
 import it.infn.mw.iam.persistence.model.IamAccount;
 import it.infn.mw.iam.persistence.model.IamLabel;
@@ -175,12 +174,12 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
     Optional<IamLabel> cernStatusLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_STATUS);
     assertThat(cernStatusLabel.isPresent(), is(true));
-    assertThat(cernStatusLabel.get().getValue(), is(EXPIRED.name()));
+    assertThat(cernStatusLabel.get().getValue(), is(CernStatus.OK.name()));
 
     Optional<IamLabel> cernMessageLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_MESSAGE);
     assertThat(cernMessageLabel.isPresent(), is(true));
-    assertThat(cernMessageLabel.get().getValue(), is(EXPIRED_MESSAGE));
+    assertThat(cernMessageLabel.get().getValue(), is(SYNCHRONIZED_MESSAGE));
 
     Optional<IamLabel> cernTimestampLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
@@ -194,11 +193,11 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
 
     cernStatusLabel = testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_STATUS);
     assertThat(cernStatusLabel.isPresent(), is(true));
-    assertThat(cernStatusLabel.get().getValue(), is(EXPIRED.name()));
+    assertThat(cernStatusLabel.get().getValue(), is(CernStatus.OK.name()));
 
     cernMessageLabel = testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_MESSAGE);
     assertThat(cernMessageLabel.isPresent(), is(true));
-    assertThat(cernMessageLabel.get().getValue(), is(EXPIRED_MESSAGE));
+    assertThat(cernMessageLabel.get().getValue(), is(SYNCHRONIZED_MESSAGE));
 
     cernTimestampLabel = testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
     assertThat(cernTimestampLabel.isPresent(), is(false));
@@ -226,12 +225,12 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
     Optional<IamLabel> cernStatusLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_STATUS);
     assertThat(cernStatusLabel.isPresent(), is(true));
-    assertThat(cernStatusLabel.get().getValue(), is(EXPIRED.name()));
+    assertThat(cernStatusLabel.get().getValue(), is(CernStatus.OK.name()));
 
     Optional<IamLabel> cernMessageLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_MESSAGE);
     assertThat(cernMessageLabel.isPresent(), is(true));
-    assertThat(cernMessageLabel.get().getValue(), is(EXPIRED_MESSAGE));
+    assertThat(cernMessageLabel.get().getValue(), is(SYNCHRONIZED_MESSAGE));
 
     Optional<IamLabel> cernTimestampLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
@@ -267,16 +266,24 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
     Optional<IamLabel> cernStatusLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_STATUS);
     assertThat(cernStatusLabel.isPresent(), is(true));
-    assertThat(cernStatusLabel.get().getValue(), is(MEMBER.name()));
+    assertThat(cernStatusLabel.get().getValue(), is(CernStatus.OK.name()));
 
     Optional<IamLabel> cernMessageLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_MESSAGE);
     assertThat(cernMessageLabel.isPresent(), is(true));
-    assertThat(cernMessageLabel.get().getValue(), is(VALID_MESSAGE));
+    assertThat(cernMessageLabel.get().getValue(), is(SYNCHRONIZED_MESSAGE));
 
     Optional<IamLabel> cernTimestampLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
     assertThat(cernTimestampLabel.isPresent(), is(false));
+
+    Optional<IamLabel> cernInstituteLabel =
+        testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_INSTITUTE);
+    assertThat(cernInstituteLabel.isPresent(), is(true));
+    assertThat(cernInstituteLabel.get().getValue(),
+        is("Istituto Nazionale di Fisica Nucleare, Bologna, IT"));
+    
+  
   }
 
   @Test
@@ -309,12 +316,12 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
     Optional<IamLabel> cernStatusLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_STATUS);
     assertThat(cernStatusLabel.isPresent(), is(true));
-    assertThat(cernStatusLabel.get().getValue(), is(MEMBER.name()));
+    assertThat(cernStatusLabel.get().getValue(), is(CernStatus.OK.name()));
 
     Optional<IamLabel> cernMessageLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_MESSAGE);
     assertThat(cernMessageLabel.isPresent(), is(true));
-    assertThat(cernMessageLabel.get().getValue(), is(VALID_MESSAGE));
+    assertThat(cernMessageLabel.get().getValue(), is(SYNCHRONIZED_MESSAGE));
 
     Optional<IamLabel> cernTimestampLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
@@ -347,12 +354,12 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
     Optional<IamLabel> cernStatusLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_STATUS);
     assertThat(cernStatusLabel.isPresent(), is(true));
-    assertThat(cernStatusLabel.get().getValue(), is(MEMBER.name()));
+    assertThat(cernStatusLabel.get().getValue(), is(CernStatus.OK.name()));
 
     Optional<IamLabel> cernMessageLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_MESSAGE);
     assertThat(cernMessageLabel.isPresent(), is(true));
-    assertThat(cernMessageLabel.get().getValue(), is(VALID_MESSAGE));
+    assertThat(cernMessageLabel.get().getValue(), is(SYNCHRONIZED_MESSAGE));
 
     Optional<IamLabel> cernTimestampLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
@@ -384,12 +391,12 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
     Optional<IamLabel> cernStatusLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_STATUS);
     assertThat(cernStatusLabel.isPresent(), is(true));
-    assertThat(cernStatusLabel.get().getValue(), is(MEMBER.name()));
+    assertThat(cernStatusLabel.get().getValue(), is(CernStatus.OK.name()));
 
     Optional<IamLabel> cernMessageLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_MESSAGE);
     assertThat(cernMessageLabel.isPresent(), is(true));
-    assertThat(cernMessageLabel.get().getValue(), is(VALID_MESSAGE));
+    assertThat(cernMessageLabel.get().getValue(), is(SYNCHRONIZED_MESSAGE));
 
     Optional<IamLabel> cernTimestampLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
@@ -425,10 +432,10 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
     Optional<IamLabel> iamStatusLabel = testAccount.getLabelByName(LIFECYCLE_STATUS_LABEL);
 
     assertThat(cernStatusLabel.isPresent(), is(true));
-    assertThat(cernStatusLabel.get().getValue(), is(MEMBER.name()));
+    assertThat(cernStatusLabel.get().getValue(), is(CernStatus.OK.name()));
 
     assertThat(cernMessageLabel.isPresent(), is(true));
-    assertThat(cernMessageLabel.get().getValue(), is(format(VALID_MESSAGE)));
+    assertThat(cernMessageLabel.get().getValue(), is(format(SYNCHRONIZED_MESSAGE)));
 
     assertThat(cernTimestampLabel.isPresent(), is(false));
     assertThat(iamStatusLabel.isPresent(), is(false));
@@ -453,7 +460,7 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_MESSAGE);
 
     assertThat(statusLabel.isPresent(), is(true));
-    assertThat(statusLabel.get().getValue(), is(CernHrLifecycleHandler.Status.ERROR.name()));
+    assertThat(statusLabel.get().getValue(), is(CernHrLifecycleHandler.CernStatus.ERROR.name()));
 
     assertThat(timestampLabel.isPresent(), is(false));
 
@@ -480,7 +487,8 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_MESSAGE);
 
     assertThat(statusLabel.isPresent(), is(true));
-    assertThat(statusLabel.get().getValue(), is(CernHrLifecycleHandler.Status.ID_NOT_FOUND.name()));
+    assertThat(statusLabel.get().getValue(),
+        is(CernHrLifecycleHandler.CernStatus.NOT_FOUND.name()));
 
     assertThat(timestampLabel.isPresent(), is(false));
 
@@ -509,7 +517,7 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
 
     assertThat(statusLabel.isPresent(), is(true));
     assertThat(statusLabel.get().getValue(),
-        is(CernHrLifecycleHandler.Status.EXP_NOT_FOUND.name()));
+        is(CernHrLifecycleHandler.CernStatus.NOT_MEMBER.name()));
 
     assertThat(timestampLabel.isPresent(), is(false));
 
@@ -537,7 +545,7 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
     Optional<IamLabel> statusLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_STATUS);
     assertThat(statusLabel.isPresent(), is(true));
-    assertThat(statusLabel.get().getValue(), is(MEMBER.name()));
+    assertThat(statusLabel.get().getValue(), is(CernStatus.OK.name()));
 
     Optional<IamLabel> timestampLabel =
         testAccount.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
@@ -599,7 +607,7 @@ public class CernAccountLifecycleTests extends TestSupport implements LifecycleT
           account.getLabelByPrefixAndName(LABEL_CERN_PREFIX, LABEL_TIMESTAMP);
 
       assertThat(statusLabel.isPresent(), is(true));
-      assertThat(statusLabel.get().getValue(), is(MEMBER.name()));
+      assertThat(statusLabel.get().getValue(), is(CernStatus.OK.name()));
 
       assertThat(timestampLabel.isPresent(), is(false));
     }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/cern/LifecycleTestSupport.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/lifecycle/cern/LifecycleTestSupport.java
@@ -109,7 +109,7 @@ public interface LifecycleTestSupport {
   default InstituteDTO getTestInstitute() {
     InstituteDTO i = new InstituteDTO();
     i.setId("000001");
-    i.setName("INFN");
+    i.setName("Istituto Nazionale di Fisica Nucleare");
     i.setCountry("IT");
     i.setTown("Bologna");
     return i;


### PR DESCRIPTION
- set end time to current date in case user is not found on API
- set ent time to current date when user has no experiment participation at all