### PR TITLE
Show amr claim in ID token

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/audit/utils/Jackson2AuditDataSerializer.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/audit/utils/Jackson2AuditDataSerializer.java
@@ -17,7 +17,6 @@ package it.infn.mw.iam.audit.utils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -33,7 +32,6 @@ public class Jackson2AuditDataSerializer implements AuditDataSerializer {
   
   final ObjectMapper mapper;
   
-  @Autowired
   public Jackson2AuditDataSerializer(ObjectMapper mapper) {
     this.mapper = mapper;
   }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/multi_factor_authentication/ExtendedHttpServletRequestFilter.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/multi_factor_authentication/ExtendedHttpServletRequestFilter.java
@@ -16,7 +16,8 @@
 package it.infn.mw.iam.authn.multi_factor_authentication;
 
 import java.io.IOException;
-import java.util.Iterator;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 import javax.servlet.FilterChain;
@@ -28,6 +29,9 @@ import javax.servlet.http.HttpServletRequest;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.GenericFilterBean;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import it.infn.mw.iam.core.ExtendedAuthenticationToken;
 
@@ -70,24 +74,20 @@ public class ExtendedHttpServletRequestFilter extends GenericFilterBean {
   }
 
   /**
-   * Convert a set of authentication method references into a request parameter string Values are
-   * separated with a + symbol
+   * Convert a set of authentication method references into a JSON array of strings.
    * 
    * @param amrSet the set of authentication method references
-   * @return the parsed string
+   * @return the parsed JSON array as a string
+   * @throws JsonProcessingException if an error occurs while converting to JSON
    */
-  private String parseAuthenticationMethodReferences(Set<IamAuthenticationMethodReference> amrSet) {
-    String amrClaim = "";
-    Iterator<IamAuthenticationMethodReference> it = amrSet.iterator();
-    while (it.hasNext()) {
-      IamAuthenticationMethodReference current = it.next();
-      StringBuilder amrClaimBuilder = new StringBuilder(amrClaim);
-      amrClaimBuilder.append(current.getName()).append("+");
-      amrClaim = amrClaimBuilder.toString();
+  private String parseAuthenticationMethodReferences(Set<IamAuthenticationMethodReference> amrSet)
+      throws JsonProcessingException {
+    List<String> amrList = new ArrayList<>();
+    for (IamAuthenticationMethodReference amr : amrSet) {
+      amrList.add(amr.getName());
     }
 
-    // Remove trailing + symbol at end of string
-    amrClaim = amrClaim.substring(0, amrClaim.length() - 1);
-    return amrClaim;
+    ObjectMapper objectMapper = new ObjectMapper();
+    return objectMapper.writeValueAsString(amrList);
   }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/IamOAuth2RequestFactory.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/IamOAuth2RequestFactory.java
@@ -85,13 +85,13 @@ public class IamOAuth2RequestFactory extends ConnectOAuth2RequestFactory {
 
     AuthorizationRequest authzRequest = super.createAuthorizationRequest(inputParams);
 
-    if (authn instanceof ExtendedAuthenticationToken) {
+    if (authn instanceof ExtendedAuthenticationToken extendedAuthenticationToken) {
       Set<IamAuthenticationMethodReference> amrSet =
-          ((ExtendedAuthenticationToken) authn).getAuthenticationMethodReferences();
+          extendedAuthenticationToken.getAuthenticationMethodReferences();
       try {
         authzRequest.getExtensions().put("amr", parseAuthenticationMethodReferences(amrSet));
       } catch (JsonProcessingException e) {
-        throw new RuntimeException("Failed to convert amr set to JSON array", e);
+        LOG.error("Failed to convert amr set to JSON array", e);
       }
     }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/iam/IamJWTProfileIdTokenCustomizer.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/iam/IamJWTProfileIdTokenCustomizer.java
@@ -41,7 +41,7 @@ import it.infn.mw.iam.persistence.repository.IamAccountRepository;
 @SuppressWarnings("deprecation")
 public class IamJWTProfileIdTokenCustomizer extends BaseIdTokenCustomizer {
 
-  public static final Logger LOG = LoggerFactory.getLogger(IamOAuth2RequestFactory.class);
+  public static final Logger LOG = LoggerFactory.getLogger(IamJWTProfileIdTokenCustomizer.class);
 
   protected final ScopeClaimTranslationService scopeClaimConverter;
   protected final ClaimValueHelper claimValueHelper;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/iam/IamJWTProfileIdTokenCustomizer.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/iam/IamJWTProfileIdTokenCustomizer.java
@@ -32,7 +32,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jwt.JWTClaimsSet.Builder;
 
 import it.infn.mw.iam.config.IamProperties;
-import it.infn.mw.iam.core.oauth.IamOAuth2RequestFactory;
 import it.infn.mw.iam.core.oauth.profile.common.BaseIdTokenCustomizer;
 import it.infn.mw.iam.persistence.model.IamAccount;
 import it.infn.mw.iam.persistence.model.IamUserInfo;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/iam/IamJWTProfileIdTokenCustomizer.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/iam/IamJWTProfileIdTokenCustomizer.java
@@ -59,6 +59,12 @@ public class IamJWTProfileIdTokenCustomizer extends BaseIdTokenCustomizer {
       .filter(ADDITIONAL_CLAIMS::contains)
       .forEach(c -> idClaims.claim(c, claimValueHelper.getClaimValueFromUserInfo(c, info)));
 
+    Object amrClaim = request.getExtensions().get("amr");
+
+    if (amrClaim != null && amrClaim instanceof String) {
+      idClaims.claim("amr", amrClaim);
+    }
+
     includeLabelsInIdToken(idClaims, account);
   }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/iam/IamJWTProfileIdTokenCustomizer.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/iam/IamJWTProfileIdTokenCustomizer.java
@@ -23,6 +23,8 @@ import java.util.Set;
 import org.mitre.oauth2.model.ClientDetailsEntity;
 import org.mitre.oauth2.model.OAuth2AccessTokenEntity;
 import org.mitre.openid.connect.service.ScopeClaimTranslationService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.oauth2.provider.OAuth2Request;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -30,6 +32,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jwt.JWTClaimsSet.Builder;
 
 import it.infn.mw.iam.config.IamProperties;
+import it.infn.mw.iam.core.oauth.IamOAuth2RequestFactory;
 import it.infn.mw.iam.core.oauth.profile.common.BaseIdTokenCustomizer;
 import it.infn.mw.iam.persistence.model.IamAccount;
 import it.infn.mw.iam.persistence.model.IamUserInfo;
@@ -37,6 +40,8 @@ import it.infn.mw.iam.persistence.repository.IamAccountRepository;
 
 @SuppressWarnings("deprecation")
 public class IamJWTProfileIdTokenCustomizer extends BaseIdTokenCustomizer {
+
+  public static final Logger LOG = LoggerFactory.getLogger(IamOAuth2RequestFactory.class);
 
   protected final ScopeClaimTranslationService scopeClaimConverter;
   protected final ClaimValueHelper claimValueHelper;
@@ -63,15 +68,15 @@ public class IamJWTProfileIdTokenCustomizer extends BaseIdTokenCustomizer {
 
     Object amrClaim = request.getExtensions().get("amr");
 
-    if (amrClaim != null && amrClaim instanceof String) {
+    if (amrClaim instanceof String amrString) {
       try {
         ObjectMapper objectMapper = new ObjectMapper();
         List<String> amrList =
-            objectMapper.readValue((String) amrClaim, new TypeReference<List<String>>() {});
+            objectMapper.readValue(amrString, new TypeReference<List<String>>() {});
 
         idClaims.claim("amr", amrList);
       } catch (Exception e) {
-        throw new RuntimeException("Failed to deserialize amr claim", e);
+        LOG.error("Failed to deserialize amr claim", e);
       }
     }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/iam/IamJWTProfileIdTokenCustomizer.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/iam/IamJWTProfileIdTokenCustomizer.java
@@ -73,8 +73,8 @@ public class IamJWTProfileIdTokenCustomizer extends BaseIdTokenCustomizer {
       } catch (Exception e) {
         throw new RuntimeException("Failed to deserialize amr claim", e);
       }
-
-      includeLabelsInIdToken(idClaims, account);
     }
+
+    includeLabelsInIdToken(idClaims, account);
   }
 }


### PR DESCRIPTION
Reference: [RFC8176](https://datatracker.ietf.org/doc/html/rfc8176)

* When MFA is enabled, the value of `amr` claim in ID token is `["otp", "pwd"]`.
* When MFA is not enabled, the `amr` value is `["pwd"]`.