### PR TITLE
Log the outcome of a VOMS proxy request

### DIFF
--- a/iam-voms-aa/src/main/java/it/infn/mw/voms/api/VOMSController.java
+++ b/iam-voms-aa/src/main/java/it/infn/mw/voms/api/VOMSController.java
@@ -31,7 +31,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import it.infn.mw.iam.authn.x509.IamX509AuthenticationCredential;
 import it.infn.mw.iam.persistence.model.IamAccount;
-import it.infn.mw.iam.persistence.repository.IamAccountRepository;
 import it.infn.mw.iam.service.aup.AUPSignatureCheckService;
 import it.infn.mw.voms.aa.AttributeAuthority;
 import it.infn.mw.voms.aa.RequestContextFactory;
@@ -58,8 +57,7 @@ public class VOMSController extends VOMSControllerSupport {
   private final AUPSignatureCheckService signatureCheckService;
 
   public VOMSController(AttributeAuthority aa, VomsProperties props, ACGenerator acGenerator,
-      VOMSResponseBuilder responseBuilder, IamAccountRepository accountRepo,
-      AUPSignatureCheckService signatureCheckService) {
+      VOMSResponseBuilder responseBuilder, AUPSignatureCheckService signatureCheckService) {
     this.aa = aa;
     this.vomsProperties = props;
     this.acGenerator = acGenerator;

--- a/iam-voms-aa/src/main/java/it/infn/mw/voms/api/VOMSController.java
+++ b/iam-voms-aa/src/main/java/it/infn/mw/voms/api/VOMSController.java
@@ -148,8 +148,13 @@ public class VOMSController extends VOMSControllerSupport {
   }
 
   private String requestToString(VOMSRequest request) {
-    String reqSubject = request.getRequesterSubject();
-    String reqIssuer = request.getRequesterIssuer();
-    return String.format("VOMSRequest [requesterSubject = %s, requestedIssuer = %s, requestedFQANs = %s]", reqSubject, reqIssuer, request.getRequestedFQANs());
+    String reqSubject = sanitize(request.getRequesterSubject());
+    String reqIssuer = sanitize(request.getRequesterIssuer());
+    String requestedFqans = sanitize(request.getRequestedFQANs().toString());
+    return String.format("VOMSRequest [requesterSubject = %s, requestedIssuer = %s, requestedFQANs = %s]", reqSubject, reqIssuer, requestedFqans);
+  }
+
+  private String sanitize(String str) {
+    return str.replaceAll("[\n\r]", "_");
   }
 }

--- a/iam-voms-aa/src/test/resources/application.properties
+++ b/iam-voms-aa/src/test/resources/application.properties
@@ -1,0 +1,18 @@
+#
+# Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+logging.level.root=WARN
+logging.level.it.infn.mw=INFO

--- a/iam-voms-aa/src/test/resources/application.properties
+++ b/iam-voms-aa/src/test/resources/application.properties
@@ -15,4 +15,4 @@
 #
 
 logging.level.root=WARN
-logging.level.it.infn.mw=INFO
+logging.level.it.infn.mw=DEBUG


### PR DESCRIPTION
This PR adds INFO log messages to VOMS-aa in order to track successful and failed VOMS requests.

For each request the following requestor info are logged:
- IAM account's username and uuid
- subject DN
- issuer DN

In case of a successful request, the following info are logged:

- the issued FQANs
- the notAfter timestamp
- the notBefore timestamp
- the uri (host:port)
- the vo name
- the list of targets

In case of a failure, the list of errors is showed.

With debug level, the request is logged.