### PR TITLE
Return the number of active users from the stats endpoint

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/IamStatisticalEndpoint.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/IamStatisticalEndpoint.java
@@ -29,7 +29,8 @@ public class IamStatisticalEndpoint {
 
   @GetMapping("/stats")
   public StatsEndpointResponse getStats() {
-    long count = accountRepo.count();
-    return new StatsEndpointResponse(count);
+    long totalUsers = accountRepo.count();
+    long activeUsers = accountRepo.countActiveAccounts();
+    return new StatsEndpointResponse(totalUsers, activeUsers);
   }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/StatsEndpointResponse.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/StatsEndpointResponse.java
@@ -17,17 +17,19 @@ package it.infn.mw.iam.core;
 
 public class StatsEndpointResponse {
 
-  private long numberOfUsers;
+  private long totalUsers;
+  private long activeUsers;
 
-  public StatsEndpointResponse(long numberOfUsers) {
-    this.numberOfUsers = numberOfUsers;
+  public StatsEndpointResponse(long totalUsers, long activeUsers) {
+    this.totalUsers = totalUsers;
+    this.activeUsers = activeUsers;
   }
 
-  public long getNumberOfUsers() {
-    return numberOfUsers;
+  public long getTotalUsers() {
+    return totalUsers;
   }
 
-  public void setNumberOfUsers(long numberOfUsers) {
-    this.numberOfUsers = numberOfUsers;
+  public long getActiveUsers() {
+    return activeUsers;
   }
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/core/IamStatisticalEndpointTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/core/IamStatisticalEndpointTests.java
@@ -16,7 +16,6 @@
 package it.infn.mw.iam.test.core;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -28,7 +27,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
-import it.infn.mw.iam.core.StatsEndpointResponse;
+import it.infn.mw.iam.persistence.model.IamAccount;
+import it.infn.mw.iam.persistence.repository.IamAccountRepository;
 import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
 
 @RunWith(SpringRunner.class)
@@ -38,19 +38,19 @@ public class IamStatisticalEndpointTests {
   @Autowired
   protected MockMvc mvc;
 
+  @Autowired
+  private IamAccountRepository accountRepo;
+
   @Test
-  public void anonymousisAcceptedAtStatEndpoint() throws Exception {
+  public void anonymousIsAcceptedAtStatEndpoint() throws Exception {
+    IamAccount account = accountRepo.findByUsername("test")
+      .orElseThrow(() -> new AssertionError("Expected test account not found"));
+    account.setActive(false);
     mvc.perform(get("/stats"))
       .andDo(print())
       .andExpect(status().isOk())
-      .andExpect(jsonPath("$.numberOfUsers", equalTo(255)));
+      .andExpect(jsonPath("$.totalUsers", equalTo(255)))
+      .andExpect(jsonPath("$.activeUsers", equalTo(254)));
+    account.setActive(true);
   }
-
-  @Test
-  public void testSetNumberOfUsers() {
-    StatsEndpointResponse userCount = new StatsEndpointResponse(0);
-    userCount.setNumberOfUsers(255);
-    assertEquals(255, userCount.getNumberOfUsers());
-  }
-
 }

--- a/iam-persistence/src/main/java/it/infn/mw/iam/persistence/repository/IamAccountRepository.java
+++ b/iam-persistence/src/main/java/it/infn/mw/iam/persistence/repository/IamAccountRepository.java
@@ -141,6 +141,9 @@ public interface IamAccountRepository
   @Query("select a from IamAccount a where a.active = TRUE")
   Page<IamAccount> findActiveAccounts(Pageable op);
 
+  @Query("select count(a) from IamAccount a where a.active = TRUE")
+  long countActiveAccounts();
+
   @Modifying
   @Query("delete from IamAccountGroupMembership")
   void deleteAllAccountGroupMemberships();


### PR DESCRIPTION
e.g.
```
$ curl --silent http://localhost:8080/stats | jq
{
  "totalUsers": 255,
  "activeUsers": 254
}
```