### PR TITLE
Delete useless forbidden calls from current dashbaord

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/group/GroupLabelsController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/group/GroupLabelsController.java
@@ -67,7 +67,7 @@ public class GroupLabelsController {
   }
 
   @GetMapping
-  @PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN') or hasRole('READER') or #iam.isGroupManager(#id)")
+  @PreAuthorize("hasRole('USER')")
   public List<LabelDTO> getLabels(@PathVariable String id) {
 
     IamGroup group = service.findByUuid(id).orElseThrow(() -> NoSuchGroupError.forUuid(id));

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/groups/user.groups.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/groups/user.groups.component.js
@@ -16,7 +16,7 @@
 (function () {
     'use strict';
 
-    function UserGroupsController(toaster, $uibModal, ModalService, scimFactory) {
+    function UserGroupsController(toaster, $uibModal, ModalService, scimFactory, GroupsService) {
         var self = this;
 
         self.$onInit = function () {
@@ -25,13 +25,11 @@
             self.userGroupLabels = {};
             self.labelName = labelName;
 
-            if(self.isVoAdmin()) {
-                angular.forEach(self.user.groups, function(g) {
-                    self.groupLabels(g.value).then(function(res){
-                        self.userGroupLabels[g.value] = res;
-                    });
+            angular.forEach(self.user.groups, function(g) {
+                self.groupLabels(g.value).then(function(res){
+                    self.userGroupLabels[g.value] = res;
                 });
-            }
+            });
         };
 
         self.isVoAdmin = function () { return self.userCtrl.isVoAdmin(); };
@@ -45,16 +43,12 @@
                 });
             });
         };
-        
-        self.groupLabels = function(groupId){
-            
-                return scimFactory.getGroup(groupId).then(function(res){     
-                   var r = res.data;
-                   var labels = r['urn:indigo-dc:scim:schemas:IndigoGroup'].labels;
-                   return labels;
+
+        self.groupLabels = function(groupId) {
+            return GroupsService.getGroupLabels(groupId).then(function(res) {
+                return res.data;
             });
         };
-
 
         function labelName(label) {
             if (label.prefix) {
@@ -105,7 +99,7 @@
         bindings: { user: '=' },
         templateUrl: '/resources/iam/apps/dashboard-app/components/user/groups/user.groups.component.html',
         controller: [
-            'toaster', '$uibModal', 'ModalService', 'scimFactory',
+            'toaster', '$uibModal', 'ModalService', 'scimFactory', 'GroupsService',
             UserGroupsController
         ]
     });

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/groups/user.groups.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/groups/user.groups.component.js
@@ -25,12 +25,14 @@
             self.userGroupLabels = {};
             self.labelName = labelName;
 
-            angular.forEach(self.user.groups, function(g){
-                self.groupLabels(g.value).then(function(res){
-                    self.userGroupLabels[g.value] = res;
+            if(self.isVoAdmin()) {
+                angular.forEach(self.user.groups, function(g) {
+                    self.groupLabels(g.value).then(function(res){
+                        self.userGroupLabels[g.value] = res;
+                    });
                 });
-            });  
-    };
+            }
+        };
 
         self.isVoAdmin = function () { return self.userCtrl.isVoAdmin(); };
 

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/services/groups.service.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/services/groups.service.js
@@ -23,6 +23,7 @@
 
     function GroupsService($q, $http, $httpParamSerializer) {
         var service = {
+            getGroupLabels: getGroupLabels,
             getGroupsFilteredAndSortBy: getGroupsFilteredAndSortBy,
             getGroupsFilteredBy: getGroupsFilteredBy,
             getGroupsSortBy: getGroupsSortBy,
@@ -39,6 +40,10 @@
         function doGet(queryStr) {
             var url = urlGroups + '?' + queryStr;
             return $http.get(url);
+        }
+
+        function getGroupLabels(groupId) {
+            return $http.get("/iam/group/" + groupId + "/labels");
         }
 
         function getGroupsFilteredAndSortBy(startIndex, count, filter, sortBy, sortDir) {

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/group/GroupLabelTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/group/GroupLabelTests.java
@@ -21,8 +21,8 @@ import static org.apache.commons.lang.RandomStringUtils.randomAlphabetic;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -56,7 +56,7 @@ import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 
 @RunWith(SpringRunner.class)
 @IamMockMvcIntegrationTest
-@WithMockUser(username = "admin", roles = "ADMIN")
+@WithMockUser(username = "admin", roles = {"ADMIN", "USER"})
 public class GroupLabelTests extends TestSupport {
 
   private static final ResultMatcher GROUP_NOT_FOUND_ERROR_MESSAGE =
@@ -109,7 +109,7 @@ public class GroupLabelTests extends TestSupport {
   @WithMockUser(username = "test", roles = "USER")
   public void managingLabelsRequiresPrivilegedUser() throws Exception {
 
-    mvc.perform(get(RESOURCE, TEST_001_GROUP_UUID)).andExpect(FORBIDDEN);
+    mvc.perform(get(RESOURCE, TEST_001_GROUP_UUID)).andExpect(OK);
 
     mvc
       .perform(put(RESOURCE, TEST_001_GROUP_UUID).contentType(APPLICATION_JSON)
@@ -126,15 +126,15 @@ public class GroupLabelTests extends TestSupport {
   }
 
   @Test
-  @WithMockUser(username = "test", roles = {"READER"})
+  @WithMockUser(username = "test", roles = {"READER", "USER"})
   public void gettingLabelsWorksForReaderUser() throws Exception {
     gettingLabelsWorks();
   }
 
   @Test
   @WithMockOAuthUser(scopes = {"iam:admin.read"})
-  public void gettingLabelsWorksForAdminOAuthUser() throws Exception {
-    gettingLabelsWorks();
+  public void gettingLabelsDoesNotWorkWithoutRoleUser() throws Exception {
+    mvc.perform(get(RESOURCE, TEST_001_GROUP_UUID)).andExpect(FORBIDDEN);
   }
 
   private void gettingLabelsWorks() throws Exception {

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/group/GroupLabelTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/group/GroupLabelTests.java
@@ -49,7 +49,6 @@ import it.infn.mw.iam.api.common.LabelDTO;
 import it.infn.mw.iam.persistence.repository.IamGroupRepository;
 import it.infn.mw.iam.test.api.TestSupport;
 import it.infn.mw.iam.test.util.WithAnonymousUser;
-import it.infn.mw.iam.test.util.WithMockOAuthUser;
 import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
 import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 
@@ -92,7 +91,7 @@ public class GroupLabelTests extends TestSupport {
 
   @Test
   @WithAnonymousUser
-  public void managingLabelsRequiresAuthenticatedUser() throws Exception {
+  public void managingLabelsIsNotAllowedToAnonymousUsers() throws Exception {
 
     mvc.perform(get(RESOURCE, TEST_001_GROUP_UUID)).andExpect(UNAUTHORIZED);
 
@@ -107,7 +106,7 @@ public class GroupLabelTests extends TestSupport {
 
   @Test
   @WithMockUser(username = "test", roles = "USER")
-  public void managingLabelsRequiresPrivilegedUser() throws Exception {
+  public void managingLabelsRequiresAnAuthenticatedUser() throws Exception {
 
     mvc.perform(get(RESOURCE, TEST_001_GROUP_UUID)).andExpect(OK);
 
@@ -122,22 +121,6 @@ public class GroupLabelTests extends TestSupport {
 
   @Test
   public void gettingLabelsWorksForAdminUser() throws Exception {
-    gettingLabelsWorks();
-  }
-
-  @Test
-  @WithMockUser(username = "test", roles = {"READER", "USER"})
-  public void gettingLabelsWorksForReaderUser() throws Exception {
-    gettingLabelsWorks();
-  }
-
-  @Test
-  @WithMockOAuthUser(scopes = {"iam:admin.read"})
-  public void gettingLabelsDoesNotWorkWithoutRoleUser() throws Exception {
-    mvc.perform(get(RESOURCE, TEST_001_GROUP_UUID)).andExpect(FORBIDDEN);
-  }
-
-  private void gettingLabelsWorks() throws Exception {
 
     mvc.perform(get(RESOURCE, TEST_001_GROUP_UUID)).andExpect(OK);
 


### PR DESCRIPTION
Group labels are now retrieved from the `/iam/group/{groupId}/labels` endpoint, accessible to all authenticated users.