### PR TITLE
Change the message when identifying with X509 and the account is suspended #901

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamWebSecurityConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamWebSecurityConfig.java
@@ -68,6 +68,7 @@ import it.infn.mw.iam.config.IamProperties;
 import it.infn.mw.iam.core.IamLocalAuthenticationProvider;
 import it.infn.mw.iam.persistence.repository.IamAccountRepository;
 import it.infn.mw.iam.persistence.repository.IamTotpMfaRepository;
+import it.infn.mw.iam.persistence.repository.IamX509CertificateRepository;
 import it.infn.mw.iam.service.aup.AUPSignatureCheckService;
 
 @SuppressWarnings("deprecation")
@@ -109,7 +110,10 @@ public class IamWebSecurityConfig {
 
     @Autowired
     private IamAccountRepository accountRepo;
-    
+
+    @Autowired
+    private IamX509CertificateRepository certRepo;
+
     @Autowired
     private IamTotpMfaRepository totpMfaRepository;
 
@@ -146,7 +150,7 @@ public class IamWebSecurityConfig {
 
     public IamX509PreauthenticationProcessingFilter iamX509Filter() {
       return new IamX509PreauthenticationProcessingFilter(x509CredentialExtractor,
-          iamX509AuthenticationProvider(), successHandler());
+          iamX509AuthenticationProvider(), successHandler(), certRepo);
     }
 
     protected AuthenticationEntryPoint entryPoint() {

--- a/iam-login-service/src/main/webapp/WEB-INF/views/iam/login.jsp
+++ b/iam-login-service/src/main/webapp/WEB-INF/views/iam/login.jsp
@@ -216,9 +216,14 @@
             <div id="x509-authn-info">
                 You have been successfully authenticated as<br>
                 <strong>${IAM_X509_CRED.subject}</strong>
-                <c:if test="${!IAM_X509_CAN_LOGIN}">
+                <c:if test="${!IAM_X509_CAN_LOGIN && !IAM_X509_SUSPENDED_ACCOUNT}">
                     <p>
                     This certificate is not linked to any account in this organization
+                    </p>
+                </c:if>
+                <c:if test="${IAM_X509_SUSPENDED_ACCOUNT}">
+                    <p>
+                    This certificate is linked to a suspended account in this organization
                     </p>
                 </c:if>
           </div>

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/x509/X509AuthenticationIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/x509/X509AuthenticationIntegrationTests.java
@@ -20,6 +20,7 @@ import static it.infn.mw.iam.authn.ExternalAuthenticationHandlerSupport.ACCOUNT_
 import static it.infn.mw.iam.authn.x509.IamX509PreauthenticationProcessingFilter.X509_AUTHN_REQUESTED_PARAM;
 import static it.infn.mw.iam.authn.x509.IamX509PreauthenticationProcessingFilter.X509_CAN_LOGIN_KEY;
 import static it.infn.mw.iam.authn.x509.IamX509PreauthenticationProcessingFilter.X509_CREDENTIAL_SESSION_KEY;
+import static it.infn.mw.iam.authn.x509.IamX509PreauthenticationProcessingFilter.X509_SUSPENDED_ACCOUNT_KEY;
 import static java.lang.Boolean.TRUE;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -124,8 +125,33 @@ public class X509AuthenticationIntegrationTests extends X509TestSupport {
       .orElseThrow(
           () -> new AssertionError("Expected test user linked with subject " + TEST_0_SUBJECT));
 
-    // Check that last login time is updated when loggin in with X.509 credentials
+    // Check that last login time is updated when login in with X.509 credentials
     assertThat(resolvedAccount.getLastLoginTime().toInstant(), greaterThan(now));
+
+  }
+
+  @Test
+  public void testX509AuthenticationWhenAccountIsSuspended() throws Exception {
+
+    IamAccount testAccount = iamAccountRepo.findByUsername("test")
+      .orElseThrow(() -> new AssertionError("Expected test user not found"));
+
+    linkTest0CertificateToAccount(testAccount);
+
+    testAccount.setActive(false);
+    iamAccountRepo.save(testAccount);
+
+    IamAccount resolvedAccount = iamAccountRepo.findByCertificate(TEST_0_CERT_STRING)
+      .orElseThrow(
+          () -> new AssertionError("Expected test user linked to cert " + TEST_0_CERT_STRING));
+
+    assertThat(resolvedAccount.getUsername(), equalTo("test"));
+
+    mvc.perform(get("/").headers(test0SSLHeadersVerificationSuccess()))
+      .andExpect(status().isFound())
+      .andExpect(redirectedUrl("http://localhost/login"))
+      .andExpect(request().sessionAttribute(X509_CREDENTIAL_SESSION_KEY, not(nullValue())))
+      .andExpect(request().attribute(X509_SUSPENDED_ACCOUNT_KEY, is(TRUE)));
 
   }
 
@@ -195,7 +221,8 @@ public class X509AuthenticationIntegrationTests extends X509TestSupport {
     assertThat(linkedUser.isPresent(), is(true));
     assertThat(linkedUser.get().getUsername(), is("test"));
 
-    Optional<IamX509Certificate> test0Cert = iamX509CertificateRepo.findBySubjectDnAndIssuerDn(TEST_0_SUBJECT, TEST_0_ISSUER);
+    Optional<IamX509Certificate> test0Cert =
+        iamX509CertificateRepo.findBySubjectDnAndIssuerDn(TEST_0_SUBJECT, TEST_0_ISSUER);
     assertThat(test0Cert.isPresent(), is(true));
 
     IamAccount linkedAccount = iamAccountRepo.findByCertificateSubject(TEST_0_SUBJECT)
@@ -234,11 +261,13 @@ public class X509AuthenticationIntegrationTests extends X509TestSupport {
       .andExpect(
           flash().attribute(ACCOUNT_LINKING_DASHBOARD_MESSAGE_KEY, equalTo(confirmationMsg)));
 
-    Optional<IamX509Certificate> testCert1 = iamX509CertificateRepo.findBySubjectDnAndIssuerDn(TEST_0_SUBJECT, TEST_0_ISSUER);
+    Optional<IamX509Certificate> testCert1 =
+        iamX509CertificateRepo.findBySubjectDnAndIssuerDn(TEST_0_SUBJECT, TEST_0_ISSUER);
     assertThat(testCert1.isPresent(), is(true));
     assertThat(testCert1.get().getAccount().getUsername(), is("test"));
-    
-    Optional<IamX509Certificate> testCert2 = iamX509CertificateRepo.findBySubjectDnAndIssuerDn(TEST_0_SUBJECT, TEST_NEW_ISSUER);
+
+    Optional<IamX509Certificate> testCert2 =
+        iamX509CertificateRepo.findBySubjectDnAndIssuerDn(TEST_0_SUBJECT, TEST_NEW_ISSUER);
     assertThat(testCert2.isPresent(), is(true));
     assertThat(testCert2.get().getAccount().getUsername(), is("test"));
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/x509/X509AuthenticationIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/x509/X509AuthenticationIntegrationTests.java
@@ -453,7 +453,15 @@ public class X509AuthenticationIntegrationTests extends X509TestSupport {
       .andExpect(status().is3xxRedirection())
       .andExpect(redirectedUrl("http://localhost/login"));
 
+    mvc.perform(post("/login").param("username", "test").param("password", "password"))
+      .andExpect(status().is3xxRedirection())
+      .andExpect(redirectedUrl("/login?error=failure"));
+
     resolvedAccount.setActive(true);
+
+    mvc.perform(post("/login").param("username", "test").param("password", "password"))
+      .andExpect(status().is3xxRedirection())
+      .andExpect(redirectedUrl("/dashboard"));
 
   }
 


### PR DESCRIPTION
When the user identifies with an X509 certificate but it is not linked to any account in IAM, the message shown in the login screen is
```
This certificate is not linked to any account in this organization
```
If, instead, the user is disabled, they will get
```
This certificate is linked to a suspended account in this organization
```