### PR TITLE
Fix bug related to group managers

### DIFF
--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/user.component.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/user.component.html
@@ -49,7 +49,7 @@
                         <user-detail user="$ctrl.user" aup="$ctrl.aup"></user-detail>
                         <user-labels user="$ctrl.user" labels="$ctrl.labels"></user-labels>
                     </div>
-                    <div ng-hide="$ctrl.isGroupManager && !$ctrl.isMe() && !$ctrl.isVoAdmin()" class="box-footer">
+                    <div ng-hide="$ctrl.isGroupManager() && !$ctrl.isMe() && !$ctrl.isVoAdmin()" class="box-footer">
                         <!-- Edit details button -->
                         <user-edit user="$ctrl.user"></user-edit>
 
@@ -89,13 +89,13 @@
                     </div>
                 </div>
             </section>
-            <section ng-hide="$ctrl.isGroupManager && !$ctrl.isMe() && !$ctrl.isVoAdmin() && !$ctrl.userIsReader" id="user-profile-right" class="col-sm-12 col-md-7 col-lg-8" ng-cloak>
+            <section ng-hide="$ctrl.isGroupManager() && !$ctrl.isMe() && !$ctrl.isVoAdmin() && !$ctrl.userIsReader()" id="user-profile-right" class="col-sm-12 col-md-7 col-lg-8" ng-cloak>
                 <user-groups user="$ctrl.user"></user-groups>
-                <user-pending-requests ng-hide="$ctrl.isGroupManager && !$ctrl.isMe() && !$ctrl.isVoAdmin()" user="$ctrl.user"></user-pending-requests>
+                <user-pending-requests ng-hide="$ctrl.isGroupManager() && !$ctrl.isMe() && !$ctrl.isVoAdmin()" user="$ctrl.user"></user-pending-requests>
                 <user-linked-accounts user="$ctrl.user"></user-linked-accounts>
                 <user-x509 user="$ctrl.user"></user-x509>
                 <user-cert-link-pending-requests user="$ctrl.user"></user-cert-link-pending-requests>
-                <user-ssh-keys ng-hide="$ctrl.isGroupManager && !$ctrl.isMe() && !$ctrl.isVoAdmin()" user="$ctrl.user"></user-ssh-keys>
+                <user-ssh-keys ng-hide="$ctrl.isGroupManager() && !$ctrl.isMe() && !$ctrl.isVoAdmin()" user="$ctrl.user"></user-ssh-keys>
                 <user-attributes user="$ctrl.user" attributes="$ctrl.attrs"></user-attributes>
             </section>
         </div>

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/services/authenticator-app.service.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/services/authenticator-app.service.js
@@ -75,6 +75,10 @@ function AuthenticatorAppService($http, $httpParamSerializerJQLike) {
 	}
 
 	function handleError(res) {
+		if (res.status == 403) {
+			console.info("MFA settings error");
+			return null;
+		}
 		return $q.reject(res);
 	}
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/multi_factor_authentication/MultiFactorSettingsControllerTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/multi_factor_authentication/MultiFactorSettingsControllerTests.java
@@ -29,6 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.Optional;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,42 +48,53 @@ import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
 @RunWith(SpringRunner.class)
 @IamMockMvcIntegrationTest
 public class MultiFactorSettingsControllerTests extends MultiFactorTestSupport {
-    private MockMvc mvc;
-    @Autowired
-    private WebApplicationContext context;
-    @MockBean
-    private IamAccountRepository accountRepository;
-    @MockBean
-    private IamTotpMfaRepository totpMfaRepository;
+  private MockMvc mvc;
+  @Autowired
+  private WebApplicationContext context;
+  @MockBean
+  private IamAccountRepository accountRepository;
+  @MockBean
+  private IamTotpMfaRepository totpMfaRepository;
 
-    @Before
-    public void setup() {
-        when(accountRepository.findByUuid(TOTP_UUID)).thenReturn(Optional.of(TOTP_MFA_ACCOUNT));
-        when(accountRepository.findByUsername(TOTP_USERNAME)).thenReturn(Optional.of(TOTP_MFA_ACCOUNT));
-        when(totpMfaRepository.findByAccount(TOTP_MFA_ACCOUNT)).thenReturn(Optional.of(TOTP_MFA));
+  @Before
+  public void setup() {
+    when(accountRepository.findByUuid(TOTP_UUID)).thenReturn(Optional.of(TOTP_MFA_ACCOUNT));
+    when(accountRepository.findByUsername(TOTP_USERNAME)).thenReturn(Optional.of(TOTP_MFA_ACCOUNT));
+    when(totpMfaRepository.findByAccount(TOTP_MFA_ACCOUNT)).thenReturn(Optional.of(TOTP_MFA));
 
-        mvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).alwaysDo(log()).build();
-    }
+    mvc =
+        MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).alwaysDo(log()).build();
+  }
 
-    @Test
-    @WithAnonymousUser
-    public void testGetMfaAccountSettingNoAuthenticationFails() throws Exception {
-        mvc.perform(get(MULTI_FACTOR_SETTINGS_FOR_ACCOUNT_URL, TOTP_UUID)).andExpect(status().isUnauthorized());
-    }
+  @Test
+  @WithAnonymousUser
+  public void testGetMfaAccountSettingNoAuthenticationFails() throws Exception {
+    mvc.perform(get(MULTI_FACTOR_SETTINGS_FOR_ACCOUNT_URL, TOTP_UUID))
+      .andExpect(status().isUnauthorized());
+  }
 
-    @Test
-    @WithMockUser(username = "admin", roles = "ADMIN")
-    public void testGetMfaAccountSettingWorksForAdmin() throws Exception {
-        mvc.perform(get(MULTI_FACTOR_SETTINGS_FOR_ACCOUNT_URL, TOTP_UUID))
-                .andExpect(status().isOk())
-                .andExpect((jsonPath("$.authenticatorAppActive", equalTo(true))));
-    }
+  @Test
+  @WithMockUser(username = "admin", roles = "ADMIN")
+  public void testGetMfaAccountSettingWorksForAdmin() throws Exception {
+    mvc.perform(get(MULTI_FACTOR_SETTINGS_FOR_ACCOUNT_URL, TOTP_UUID))
+      .andExpect(status().isOk())
+      .andExpect((jsonPath("$.authenticatorAppActive", equalTo(true))));
+  }
 
-    @Test
-    @WithMockUser(username = "test-mfa-user", roles = "USER")
-    public void testGetMfaAccountSettingWorksForAuthenticatedUser() throws Exception {
-        mvc.perform(get(MULTI_FACTOR_SETTINGS_URL))
-                .andExpect(status().isOk())
-                .andExpect((jsonPath("$.authenticatorAppActive", equalTo(true))));
-    }
+  @Ignore
+  @Test
+  @WithMockUser(username = "group-manager", roles = "GM:6a384bcd-d4b3-4b7f-a2fe-7d897ada0dd1")
+  public void testGetMfaAccountSettingWorksForGroupManager() throws Exception {
+    mvc.perform(get(MULTI_FACTOR_SETTINGS_FOR_ACCOUNT_URL, TOTP_UUID))
+      .andExpect(status().isOk())
+      .andExpect((jsonPath("$.authenticatorAppActive", equalTo(true))));
+  }
+
+  @Test
+  @WithMockUser(username = "test-mfa-user", roles = "USER")
+  public void testGetMfaAccountSettingWorksForAuthenticatedUser() throws Exception {
+    mvc.perform(get(MULTI_FACTOR_SETTINGS_URL))
+      .andExpect(status().isOk())
+      .andExpect((jsonPath("$.authenticatorAppActive", equalTo(true))));
+  }
 }


### PR DESCRIPTION
In particular, group manager was no longer able to see information on the members of the groups they manage, because the endpoint `/iam/multi-factor-settings/{accountId}` - showing the mfa status of the account - is accessible only by admins.