### PR TITLE
Make AttributeDTO a Record class

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/common/AttributeDTO.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/common/AttributeDTO.java
@@ -15,87 +15,22 @@
  */
 package it.infn.mw.iam.api.common;
 
-import javax.annotation.Generated;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
 import it.infn.mw.iam.api.common.validator.NoNewLineOrCarriageReturn;
 
+public record AttributeDTO(
 
+    @Size(max = 64, message = "name cannot be longer than 64 chars") @Pattern(
+        regexp = NAME_REGEXP,
+        message = "invalid name (does not match with regexp: '" + NAME_REGEXP
+            + "')") @NotBlank String name,
 
-public class AttributeDTO {
+    @Size(max = 256,
+        message = "value cannot be longer than 256 chars") @NoNewLineOrCarriageReturn String value
 
+) {
   public static final String NAME_REGEXP = "^[a-zA-Z][a-zA-Z0-9\\-_.]*$";
-
-  @Size(max = 64, message = "name cannot be longer than 64 chars")
-  @Pattern(regexp = NAME_REGEXP,
-      message = "invalid name (does not match with regexp: '" + NAME_REGEXP + "')")
-  @NotBlank
-  private String name;
-
-  @Size(max = 256, message = "value cannot be longer than 256 chars")
-  @NoNewLineOrCarriageReturn
-  private String value;
-
-  public AttributeDTO() {
-    // empty constructor
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public String getValue() {
-    return value;
-  }
-
-  public void setValue(String value) {
-    this.value = value;
-  }
-
-  
-  @Override
-  @Generated("eclipse")
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((name == null) ? 0 : name.hashCode());
-    result = prime * result + ((value == null) ? 0 : value.hashCode());
-    return result;
-  }
-
-  @Override
-  @Generated("eclipse")
-  public boolean equals(Object obj) {
-    if (this == obj)
-      return true;
-    if (obj == null)
-      return false;
-    if (getClass() != obj.getClass())
-      return false;
-    AttributeDTO other = (AttributeDTO) obj;
-    if (name == null) {
-      if (other.name != null)
-        return false;
-    } else if (!name.equals(other.name))
-      return false;
-    if (value == null) {
-      if (other.value != null)
-        return false;
-    } else if (!value.equals(other.value))
-      return false;
-    return true;
-  }
-
-  public static AttributeDTO newInstance(String name, String value) {
-    AttributeDTO dto = new AttributeDTO();
-    dto.setName(name);
-    dto.setValue(value);
-    return dto;
-  }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/common/AttributeDTOConverter.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/common/AttributeDTOConverter.java
@@ -29,21 +29,18 @@ public class AttributeDTOConverter implements Converter<AttributeDTO, IamAttribu
 
   @Override
   public IamAttribute entityFromDto(AttributeDTO dto) {
-    
+
     IamAttribute attribute = new IamAttribute();
-    attribute.setName(dto.getName());
-    attribute.setValue(dto.getValue());
+    attribute.setName(dto.name());
+    attribute.setValue(dto.value());
     return attribute;
   }
 
   @Override
   public AttributeDTO dtoFromEntity(IamAttribute entity) {
-    
-    AttributeDTO dto = new AttributeDTO();
-    dto.setName(entity.getName());
-    dto.setValue(entity.getValue());
-    return dto;
-    
-  }
 
+    AttributeDTO dto = new AttributeDTO(entity.getName(), entity.getValue());
+    return dto;
+
+  }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/common/AttributeDTOConverter.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/common/AttributeDTOConverter.java
@@ -39,8 +39,6 @@ public class AttributeDTOConverter implements Converter<AttributeDTO, IamAttribu
   @Override
   public AttributeDTO dtoFromEntity(IamAttribute entity) {
 
-    AttributeDTO dto = new AttributeDTO(entity.getName(), entity.getValue());
-    return dto;
-
+    return new AttributeDTO(entity.getName(), entity.getValue());
   }
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/attributes/AccountAttributesTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/attributes/AccountAttributesTests.java
@@ -125,10 +125,7 @@ public class AccountAttributesTests {
 
     mvc.perform(get(ACCOUNT_ATTR_URL_TEMPLATE, UUID)).andExpect(UNAUTHORIZED);
 
-    AttributeDTO attr = new AttributeDTO();
-
-    attr.setName(ATTR_NAME);
-    attr.setValue(ATTR_VALUE);
+    AttributeDTO attr = new AttributeDTO(ATTR_NAME, ATTR_VALUE);
 
     mvc
       .perform(put(ACCOUNT_ATTR_URL_TEMPLATE, UUID).contentType(APPLICATION_JSON)
@@ -159,10 +156,7 @@ public class AccountAttributesTests {
 
     mvc.perform(get(ACCOUNT_ATTR_URL_TEMPLATE, UUID)).andExpect(FORBIDDEN);
 
-    AttributeDTO attr = new AttributeDTO();
-
-    attr.setName(ATTR_NAME);
-    attr.setValue(ATTR_VALUE);
+    AttributeDTO attr = new AttributeDTO(ATTR_NAME, ATTR_VALUE);
 
     mvc
       .perform(put(ACCOUNT_ATTR_URL_TEMPLATE, UUID).contentType(APPLICATION_JSON)
@@ -209,10 +203,7 @@ public class AccountAttributesTests {
 
     final String UUID = testAccount.getUuid();
 
-    AttributeDTO attr = new AttributeDTO();
-
-    attr.setName(ATTR_NAME);
-    attr.setValue(ATTR_VALUE);
+    AttributeDTO attr = new AttributeDTO(ATTR_NAME, ATTR_VALUE);
 
     mvc
       .perform(put(ACCOUNT_ATTR_URL_TEMPLATE, UUID).contentType(APPLICATION_JSON)
@@ -225,7 +216,7 @@ public class AccountAttributesTests {
       .andExpect(jsonPath("$[0].name", is(ATTR_NAME)))
       .andExpect(jsonPath("$[0].value", is(ATTR_VALUE)));
 
-    attr.setValue(null);
+    attr = new AttributeDTO(ATTR_NAME, null);
 
     mvc
       .perform(put(ACCOUNT_ATTR_URL_TEMPLATE, UUID).contentType(APPLICATION_JSON)
@@ -249,10 +240,7 @@ public class AccountAttributesTests {
 
     final String UUID = testAccount.getUuid();
 
-    AttributeDTO attr = new AttributeDTO();
-
-    attr.setName(ATTR_NAME);
-    attr.setValue(ATTR_VALUE);
+    AttributeDTO attr = new AttributeDTO(ATTR_NAME, ATTR_VALUE);
 
     mvc
       .perform(put(ACCOUNT_ATTR_URL_TEMPLATE, UUID).contentType(APPLICATION_JSON)
@@ -271,10 +259,7 @@ public class AccountAttributesTests {
 
     final String UUID = testAccount.getUuid();
 
-    AttributeDTO attr = new AttributeDTO();
-
-    attr.setName(ATTR_NAME);
-    attr.setValue(ATTR_VALUE);
+    AttributeDTO attr = new AttributeDTO(ATTR_NAME, ATTR_VALUE);
 
     mvc
       .perform(put(ACCOUNT_ATTR_URL_TEMPLATE, UUID).contentType(APPLICATION_JSON)
@@ -290,10 +275,7 @@ public class AccountAttributesTests {
 
     final String UUID = testAccount.getUuid();
 
-    AttributeDTO attr = new AttributeDTO();
-
-    attr.setName(ATTR_NAME);
-    attr.setValue(ATTR_VALUE);
+    AttributeDTO attr = new AttributeDTO(ATTR_NAME, ATTR_VALUE);
 
     mvc
       .perform(put(ACCOUNT_ATTR_URL_TEMPLATE, UUID).contentType(APPLICATION_JSON)
@@ -316,10 +298,7 @@ public class AccountAttributesTests {
 
     final String UUID = testAccount.getUuid();
 
-    AttributeDTO attr = new AttributeDTO();
-
-    attr.setName(ATTR_NAME);
-    attr.setValue(ATTR_VALUE);
+    AttributeDTO attr = new AttributeDTO(ATTR_NAME, ATTR_VALUE);
 
     mvc
       .perform(delete(ACCOUNT_ATTR_URL_TEMPLATE, UUID).contentType(APPLICATION_JSON)
@@ -333,10 +312,7 @@ public class AccountAttributesTests {
   @WithMockUser(username = "admin", roles = "ADMIN")
   public void nonExistingAccountIsHandledCorrectly() throws Exception {
     String randomUuid = UUID.randomUUID().toString();
-    AttributeDTO attr = new AttributeDTO();
-
-    attr.setName(ATTR_NAME);
-    attr.setValue(ATTR_VALUE);
+    AttributeDTO attr = new AttributeDTO(ATTR_NAME, ATTR_VALUE);
 
     final ResultMatcher accountNotFound = jsonPath("$.error", containsString(ACCOUNT_NOT_FOUND));
 
@@ -372,8 +348,7 @@ public class AccountAttributesTests {
     List<AttributeDTO> attrs = Lists.newArrayList();
 
     for (int i = 0; i < 10; i++) {
-      attrs.add(
-          AttributeDTO.newInstance(format(ATTR_NAME_TEMPLATE, i), format(ATTR_VALUE_TEMPLATE, i)));
+      attrs.add(new AttributeDTO(format(ATTR_NAME_TEMPLATE, i), format(ATTR_VALUE_TEMPLATE, i)));
     }
 
     for (AttributeDTO a : attrs) {
@@ -406,11 +381,16 @@ public class AccountAttributesTests {
   @Test
   @WithMockUser(username = "admin", roles = "ADMIN")
   public void attributeValidationTests() throws Exception {
+    
+    IamAccount testAccount =
+        repo.findByUsername(TEST_USER).orElseThrow(assertionError(EXPECTED_USER_NOT_FOUND));
 
-    AttributeDTO noNameAttribute = AttributeDTO.newInstance(null, ATTR_VALUE);
+    final String TEST_UUID = testAccount.getUuid();
+
+    AttributeDTO noNameAttribute = new AttributeDTO(null, ATTR_VALUE);
 
     mvc
-      .perform(put(ACCOUNT_ATTR_URL_TEMPLATE, noNameAttribute).contentType(APPLICATION_JSON)
+      .perform(put(ACCOUNT_ATTR_URL_TEMPLATE, TEST_UUID).contentType(APPLICATION_JSON)
         .content(mapper.writeValueAsString(noNameAttribute)))
       .andExpect(BAD_REQUEST)
       .andExpect(jsonPath("$.error", containsString("must not be blank")));
@@ -419,9 +399,9 @@ public class AccountAttributesTests {
         {"-pippo", "/ciccio/paglia", ".starts-with-dot", "carriage\nreturn", "another\rreturn"};
 
     for (String name : SOME_INVALID_NAMES) {
-      AttributeDTO invalidAttribute = AttributeDTO.newInstance(name, ATTR_VALUE);
+      AttributeDTO invalidAttribute = new AttributeDTO(name, ATTR_VALUE);
       mvc
-        .perform(put(ACCOUNT_ATTR_URL_TEMPLATE, invalidAttribute).contentType(APPLICATION_JSON)
+        .perform(put(ACCOUNT_ATTR_URL_TEMPLATE, TEST_UUID).contentType(APPLICATION_JSON)
           .content(mapper.writeValueAsString(invalidAttribute)))
         .andExpect(BAD_REQUEST)
         .andExpect(jsonPath("$.error", containsString("invalid name (does not match with regexp")));
@@ -430,28 +410,28 @@ public class AccountAttributesTests {
     final String SOME_INVALID_VALES[] = {"carriage\nreturn", "another\rreturn"};
 
     for (String value : SOME_INVALID_VALES) {
-      AttributeDTO invalidAttribute = AttributeDTO.newInstance(ATTR_NAME, value);
+      AttributeDTO invalidAttribute = new AttributeDTO(ATTR_NAME, value);
       mvc
-        .perform(put(ACCOUNT_ATTR_URL_TEMPLATE, invalidAttribute).contentType(APPLICATION_JSON)
+        .perform(put(ACCOUNT_ATTR_URL_TEMPLATE, TEST_UUID).contentType(APPLICATION_JSON)
           .content(mapper.writeValueAsString(invalidAttribute)))
         .andExpect(BAD_REQUEST)
         .andExpect(jsonPath("$.error",
             containsString("The string must not contain any new line or carriage return")));
     }
 
-    AttributeDTO longNameAttribute = AttributeDTO.newInstance(randomAlphabetic(65), ATTR_VALUE);
+    AttributeDTO longNameAttribute = new AttributeDTO(randomAlphabetic(65), ATTR_VALUE);
 
     mvc
-      .perform(put(ACCOUNT_ATTR_URL_TEMPLATE, longNameAttribute).contentType(APPLICATION_JSON)
+      .perform(put(ACCOUNT_ATTR_URL_TEMPLATE, TEST_UUID).contentType(APPLICATION_JSON)
         .content(mapper.writeValueAsString(longNameAttribute)))
       .andExpect(BAD_REQUEST)
       .andExpect(jsonPath("$.error", containsString("name cannot be longer than 64 chars")));
 
 
-    AttributeDTO longValueAttribute = AttributeDTO.newInstance(ATTR_NAME, randomAlphabetic(257));
+    AttributeDTO longValueAttribute = new AttributeDTO(ATTR_NAME, randomAlphabetic(257));
 
     mvc
-      .perform(put(ACCOUNT_ATTR_URL_TEMPLATE, longValueAttribute).contentType(APPLICATION_JSON)
+      .perform(put(ACCOUNT_ATTR_URL_TEMPLATE, TEST_UUID).contentType(APPLICATION_JSON)
         .content(mapper.writeValueAsString(longValueAttribute)))
       .andExpect(BAD_REQUEST)
       .andExpect(jsonPath("$.error", containsString("value cannot be longer than 256 chars")));

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/group/GroupAttributeTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/group/GroupAttributeTests.java
@@ -90,7 +90,6 @@ public class GroupAttributeTests {
     return () -> new AssertionError(message);
   }
 
-
   @Test
   public void managingAttributesRequiresAuthenticatedUser() throws Exception {
 
@@ -99,15 +98,10 @@ public class GroupAttributeTests {
 
     mvc.perform(get("/iam/group/{id}/attributes", testGroup.getUuid())).andExpect(UNAUTHORIZED);
 
-    AttributeDTO attr = new AttributeDTO();
+    AttributeDTO attr = new AttributeDTO(ATTR_NAME, ATTR_VALUE);
 
-    attr.setName(ATTR_NAME);
-    attr.setValue(ATTR_VALUE);
-
-    mvc.perform(
-        put("/iam/group/{id}/attributes", testGroup.getUuid()).contentType(APPLICATION_JSON)
-          .content(mapper.writeValueAsString(attr)))
-      .andExpect(UNAUTHORIZED);
+    mvc.perform(put("/iam/group/{id}/attributes", testGroup.getUuid()).contentType(APPLICATION_JSON)
+      .content(mapper.writeValueAsString(attr))).andExpect(UNAUTHORIZED);
 
     mvc.perform(delete("/iam/group/{id}/attributes", testGroup.getUuid()).param("name", ATTR_NAME))
       .andExpect(UNAUTHORIZED);
@@ -122,15 +116,10 @@ public class GroupAttributeTests {
 
     mvc.perform(get("/iam/group/{id}/attributes", testGroup.getUuid())).andExpect(FORBIDDEN);
 
-    AttributeDTO attr = new AttributeDTO();
+    AttributeDTO attr = new AttributeDTO(ATTR_NAME, ATTR_VALUE);
 
-    attr.setName(ATTR_NAME);
-    attr.setValue(ATTR_VALUE);
-
-    mvc.perform(
-        put("/iam/group/{id}/attributes", testGroup.getUuid()).contentType(APPLICATION_JSON)
-          .content(mapper.writeValueAsString(attr)))
-      .andExpect(FORBIDDEN);
+    mvc.perform(put("/iam/group/{id}/attributes", testGroup.getUuid()).contentType(APPLICATION_JSON)
+      .content(mapper.writeValueAsString(attr))).andExpect(FORBIDDEN);
 
     mvc.perform(delete("/iam/group/{id}/attributes", testGroup.getUuid()).param("name", ATTR_NAME))
       .andExpect(FORBIDDEN);
@@ -155,15 +144,10 @@ public class GroupAttributeTests {
     IamGroup testGroup =
         groupRepo.findByName(TEST_001_GROUP).orElseThrow(assertionError(EXPECTED_GROUP_NOT_FOUND));
 
-    AttributeDTO attr = new AttributeDTO();
+    AttributeDTO attr = new AttributeDTO(ATTR_NAME, ATTR_VALUE);
 
-    attr.setName(ATTR_NAME);
-    attr.setValue(ATTR_VALUE);
-
-    mvc.perform(
-        put("/iam/group/{id}/attributes", testGroup.getUuid()).contentType(APPLICATION_JSON)
-          .content(mapper.writeValueAsString(attr)))
-      .andExpect(status().isOk());
+    mvc.perform(put("/iam/group/{id}/attributes", testGroup.getUuid()).contentType(APPLICATION_JSON)
+      .content(mapper.writeValueAsString(attr))).andExpect(status().isOk());
 
     mvc.perform(get("/iam/group/{id}/attributes", testGroup.getUuid()))
       .andExpect(status().isOk())
@@ -171,12 +155,10 @@ public class GroupAttributeTests {
       .andExpect(jsonPath("$[0].name", is(ATTR_NAME)))
       .andExpect(jsonPath("$[0].value", is(ATTR_VALUE)));
 
-    attr.setValue(null);
+    attr = new AttributeDTO(ATTR_NAME, null);
 
-    mvc.perform(
-        put("/iam/group/{id}/attributes", testGroup.getUuid()).contentType(APPLICATION_JSON)
-          .content(mapper.writeValueAsString(attr)))
-      .andExpect(status().isOk());
+    mvc.perform(put("/iam/group/{id}/attributes", testGroup.getUuid()).contentType(APPLICATION_JSON)
+      .content(mapper.writeValueAsString(attr))).andExpect(status().isOk());
 
     mvc.perform(get("/iam/group/{id}/attributes", testGroup.getUuid()))
       .andExpect(status().isOk())
@@ -192,15 +174,10 @@ public class GroupAttributeTests {
     IamGroup testGroup =
         groupRepo.findByName(TEST_001_GROUP).orElseThrow(assertionError(EXPECTED_GROUP_NOT_FOUND));
 
-    AttributeDTO attr = new AttributeDTO();
+    AttributeDTO attr = new AttributeDTO(ATTR_NAME, ATTR_VALUE);
 
-    attr.setName(ATTR_NAME);
-    attr.setValue(ATTR_VALUE);
-
-    mvc.perform(
-        put("/iam/group/{id}/attributes", testGroup.getUuid()).contentType(APPLICATION_JSON)
-          .content(mapper.writeValueAsString(attr)))
-      .andExpect(status().isOk());
+    mvc.perform(put("/iam/group/{id}/attributes", testGroup.getUuid()).contentType(APPLICATION_JSON)
+      .content(mapper.writeValueAsString(attr))).andExpect(status().isOk());
 
     mvc.perform(delete("/iam/group/{id}/attributes", testGroup.getUuid()).param("name", ATTR_NAME))
       .andExpect(status().isNoContent());
@@ -214,10 +191,7 @@ public class GroupAttributeTests {
   @WithMockUser(username = "admin", roles = "ADMIN")
   public void nonExistingGroupIsHandledCorrectly() throws Exception {
     String randomUuid = UUID.randomUUID().toString();
-    AttributeDTO attr = new AttributeDTO();
-
-    attr.setName(ATTR_NAME);
-    attr.setValue(ATTR_VALUE);
+    AttributeDTO attr = new AttributeDTO(ATTR_NAME, ATTR_VALUE);
 
     mvc.perform(get("/iam/group/{id}/attributes", randomUuid))
       .andExpect(NOT_FOUND)


### PR DESCRIPTION
An example of using the java record class. To be used gradually for other classes as well.
Also, a wrong test (`attributeValidationTests` in `AccountAttributeTests` class) was fixed.