### PR TITLE
Restrict authZ on /iam/account/search endpoint

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/search/AccountSearchController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/search/AccountSearchController.java
@@ -37,7 +37,7 @@ import it.infn.mw.iam.persistence.model.IamAccount;
 
 @RestController
 @Transactional
-@PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_GM', 'ROLE_READER')")
+@PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasAnyDashboardRole('ROLE_ADMIN', 'ROLE_READER')")
 @RequestMapping(AccountSearchController.ACCOUNT_SEARCH_ENDPOINT)
 public class AccountSearchController extends AbstractSearchController<ScimUser, IamAccount> {
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/search/AccountSearchControllerTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/search/AccountSearchControllerTests.java
@@ -273,10 +273,15 @@ public class AccountSearchControllerTests {
   }
 
   @Test
-  @WithMockOAuthUser(user = "test",
-      authorities = {"ROLE_USER", "ROLE_GM:c617d586-54e6-411d-8e38-649677980001"},
-      scopes = "iam:admin.read")
+  @WithMockUser(username = "test", roles = "GM")
   public void getUsersAsGroupManager() throws Exception {
+    mvc.perform(get(ACCOUNT_SEARCH_ENDPOINT).contentType(APPLICATION_JSON_CONTENT_TYPE))
+      .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockOAuthUser(scopes = "iam:admin.read")
+  public void getUsersWithAdminScope() throws Exception {
     mvc.perform(get(ACCOUNT_SEARCH_ENDPOINT).contentType(APPLICATION_JSON_CONTENT_TYPE))
       .andExpect(status().isOk());
   }


### PR DESCRIPTION
In particular, group managers should not see the list of all users.