### PR TITLE
aarc_idp_hint implementation

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/AARCHintService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/AARCHintService.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn;
+
+@FunctionalInterface
+public interface AARCHintService {
+
+  public String resolve(String aarcHint);
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/DefaultAARCHintService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/DefaultAARCHintService.java
@@ -37,9 +37,7 @@ public class DefaultAARCHintService implements AARCHintService {
 
   private String baseUrl;
 
-  @Autowired
   private OidcValidatedProviders oidcProviders;
-
 
   private DefaultMetadataLookupService samlProviders;
 
@@ -47,6 +45,13 @@ public class DefaultAARCHintService implements AARCHintService {
   @Autowired
   public DefaultAARCHintService(@Value("${iam.baseUrl}") String url) {
     this.baseUrl = url;
+  }
+
+  @Autowired
+  public DefaultAARCHintService(@Value("${iam.baseUrl}") String url,
+      OidcValidatedProviders oidcProviders) {
+    this.baseUrl = url;
+    this.oidcProviders = oidcProviders;
   }
 
   protected void hintSanityChecks(String hint) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/DefaultAARCHintService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/DefaultAARCHintService.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn;
+
+import java.util.Objects;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.google.common.base.Strings;
+
+import it.infn.mw.iam.authn.error.InvalidAARCHintError;
+
+@Service
+public class DefaultAARCHintService implements AARCHintService {
+
+  private static final String SAML_COLON = "saml:";
+
+
+  private String baseUrl;
+
+
+  // right, now I need to modify this, so it doesn't just accept SAML
+
+  @Autowired
+  public DefaultAARCHintService(@Value("${iam.baseUrl}") String url) {
+    this.baseUrl = url;
+  }
+
+  protected void hintSanityChecks(String hint) {
+    if (Objects.isNull(hint)) {
+      throw new InvalidAARCHintError("null hint");
+    }
+
+    if (Strings.isNullOrEmpty(hint.trim())) {
+      throw new InvalidAARCHintError("empty hint");
+    }
+  }
+
+  @Override
+  public String resolve(String aarcHint) {
+    hintSanityChecks(aarcHint);
+
+    // Okay, this works, but I need to check for OIDC providers and SAML providers
+    // fuck yes, this seems to be working!! 
+    // Now I just need to gather the whitelisted providers so I can check with them
+
+
+
+    // OIDC redirect
+    //return String.format("%s/openid_connect_login?iss=%s", baseUrl, aarcHint);
+
+    // SAML redirect 
+    return String.format("%s/saml/login?idp=%s", baseUrl, aarcHint);
+
+
+    // It shouldn't be if the hint starts with it. 
+    // It should be if it is within the oidc list 
+    // and otherwise it should check if it is in the saml list
+/*     if (aarcHint.startsWith(SAML_COLON)) {
+      if (SAML_COLON.equals(aarcHint)) {
+        return String.format("%s/saml/login", baseUrl);
+      }
+      return String.format("%s/saml/login?idp=%s", baseUrl, aarcHint.substring(5));
+    }
+    throw new InvalidAARCHintError(String.format("unsupported hint: %s", aarcHint));
+ */
+    
+  }
+
+}
+

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/DefaultAARCHintService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/DefaultAARCHintService.java
@@ -43,7 +43,8 @@ public class DefaultAARCHintService implements AARCHintService {
 
 
   @Autowired
-  public DefaultAARCHintService(@Value("${iam.baseUrl}") String url, OidcValidatedProviders oidcProvicers) {
+  public DefaultAARCHintService(@Value("${iam.baseUrl}") String url,
+      OidcValidatedProviders oidcProvicers) {
     this.baseUrl = url;
     this.oidcProviders = oidcProvicers;
   }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/DefaultAARCHintService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/DefaultAARCHintService.java
@@ -68,24 +68,30 @@ public class DefaultAARCHintService implements AARCHintService {
   public String resolve(String aarcHint) {
     hintSanityChecks(aarcHint);
 
+    int indexOfNestedHints = aarcHint.indexOf('?');
+
+    // Currently not accepting the nested hint parameters
+    String aarcHintEntityID =
+        (indexOfNestedHints != -1) ? aarcHint.substring(0, indexOfNestedHints) : aarcHint;
+
     List<OidcProvider> availableOidcProviders = oidcProviders.getValidatedProviders();
     List<IdpDescription> availableSamlProviders = samlProviders.listIdps();
 
     // OIDC redirect
     if (availableOidcProviders.stream()
-      .anyMatch(provider -> provider.getIssuer().equals(aarcHint))) {
+      .anyMatch(provider -> provider.getIssuer().equals(aarcHintEntityID))) {
 
-      return String.format("%s/openid_connect_login?iss=%s", baseUrl, aarcHint);
+      return String.format("%s/openid_connect_login?iss=%s", baseUrl, aarcHintEntityID);
 
       // SAML redirect
     } else if (availableSamlProviders.stream()
-      .anyMatch(provider -> provider.getEntityId().equals(aarcHint))) {
+      .anyMatch(provider -> provider.getEntityId().equals(aarcHintEntityID))) {
 
-      return String.format("%s/saml/login?idp=%s", baseUrl, aarcHint);
+      return String.format("%s/saml/login?idp=%s", baseUrl, aarcHintEntityID);
 
     } else {
 
-      throw new InvalidAARCHintError(String.format("unsupported hint: %s", aarcHint));
+      throw new InvalidAARCHintError(String.format("unsupported hint: %s", aarcHintEntityID));
     }
   }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/DefaultAARCHintService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/DefaultAARCHintService.java
@@ -15,26 +15,34 @@
  */
 package it.infn.mw.iam.authn;
 
+import java.util.List;
 import java.util.Objects;
+
+import it.infn.mw.iam.config.oidc.OidcProvider;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
 import com.google.common.base.Strings;
 
 import it.infn.mw.iam.authn.error.InvalidAARCHintError;
+import it.infn.mw.iam.authn.saml.DefaultMetadataLookupService;
+import it.infn.mw.iam.authn.saml.model.IdpDescription;
+import it.infn.mw.iam.config.oidc.OidcValidatedProviders;
 
 @Service
 public class DefaultAARCHintService implements AARCHintService {
 
-  private static final String SAML_COLON = "saml:";
-
-
   private String baseUrl;
 
+  @Autowired
+  private OidcValidatedProviders oidcProviders;
 
-  // right, now I need to modify this, so it doesn't just accept SAML
+
+  private DefaultMetadataLookupService samlProviders;
+
 
   @Autowired
   public DefaultAARCHintService(@Value("${iam.baseUrl}") String url) {
@@ -51,36 +59,34 @@ public class DefaultAARCHintService implements AARCHintService {
     }
   }
 
+  @Autowired
+  public void setSaml(@Lazy DefaultMetadataLookupService samlProviders) {
+    this.samlProviders = samlProviders;
+  }
+
   @Override
   public String resolve(String aarcHint) {
     hintSanityChecks(aarcHint);
 
-    // Okay, this works, but I need to check for OIDC providers and SAML providers
-    // fuck yes, this seems to be working!! 
-    // Now I just need to gather the whitelisted providers so I can check with them
-
-
+    List<OidcProvider> availableOidcProviders = oidcProviders.getValidatedProviders();
+    List<IdpDescription> availableSamlProviders = samlProviders.listIdps();
 
     // OIDC redirect
-    //return String.format("%s/openid_connect_login?iss=%s", baseUrl, aarcHint);
+    if (availableOidcProviders.stream()
+      .anyMatch(provider -> provider.getIssuer().equals(aarcHint))) {
 
-    // SAML redirect 
-    return String.format("%s/saml/login?idp=%s", baseUrl, aarcHint);
+      return String.format("%s/openid_connect_login?iss=%s", baseUrl, aarcHint);
 
+      // SAML redirect
+    } else if (availableSamlProviders.stream()
+      .anyMatch(provider -> provider.getEntityId().equals(aarcHint))) {
 
-    // It shouldn't be if the hint starts with it. 
-    // It should be if it is within the oidc list 
-    // and otherwise it should check if it is in the saml list
-/*     if (aarcHint.startsWith(SAML_COLON)) {
-      if (SAML_COLON.equals(aarcHint)) {
-        return String.format("%s/saml/login", baseUrl);
-      }
-      return String.format("%s/saml/login?idp=%s", baseUrl, aarcHint.substring(5));
+      return String.format("%s/saml/login?idp=%s", baseUrl, aarcHint);
+
+    } else {
+
+      throw new InvalidAARCHintError(String.format("unsupported hint: %s", aarcHint));
     }
-    throw new InvalidAARCHintError(String.format("unsupported hint: %s", aarcHint));
- */
-    
   }
-
 }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/DefaultAARCHintService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/DefaultAARCHintService.java
@@ -43,15 +43,9 @@ public class DefaultAARCHintService implements AARCHintService {
 
 
   @Autowired
-  public DefaultAARCHintService(@Value("${iam.baseUrl}") String url) {
+  public DefaultAARCHintService(@Value("${iam.baseUrl}") String url, OidcValidatedProviders oidcProvicers) {
     this.baseUrl = url;
-  }
-
-  @Autowired
-  public DefaultAARCHintService(@Value("${iam.baseUrl}") String url,
-      OidcValidatedProviders oidcProviders) {
-    this.baseUrl = url;
-    this.oidcProviders = oidcProviders;
+    this.oidcProviders = oidcProvicers;
   }
 
   protected void hintSanityChecks(String hint) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/HintAwareAuthenticationEntryPoint.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/HintAwareAuthenticationEntryPoint.java
@@ -28,25 +28,37 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 public class HintAwareAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
   public static final String EXT_AUTHN_HINT_PARAM = "ext_authn_hint";
+  public static final String AARC_HINT_PARAM = "aarc_idp_hint";
 
   private final AuthenticationEntryPoint delegate;
   private final ExternalAuthenticationHintService hintService;
+  private final AARCHintService aarcHintService;
 
   public HintAwareAuthenticationEntryPoint(AuthenticationEntryPoint delegate,
-      ExternalAuthenticationHintService service) {
+      ExternalAuthenticationHintService service, AARCHintService aarcHintService) {
     this.delegate = delegate;
     this.hintService = service;
+    this.aarcHintService = aarcHintService;
   }
 
   protected boolean isOAuthAuthorizationRequestWithHint(HttpServletRequest request) {
 
     // This is some current way of handling whether there is a hint or not
-    // I need to have a similar method to check if my hint is there 
-    boolean isAuthorizeRequest = "/authorize".equals(request.getRequestURI()); 
+    // I need to have a similar method to check if my hint is there
+    boolean isAuthorizeRequest = "/authorize".equals(request.getRequestURI());
     String hintParam = request.getParameter(EXT_AUTHN_HINT_PARAM);
     return isAuthorizeRequest && !Objects.isNull(hintParam);
 
   }
+
+  protected boolean isOAuthAuthorizationRequestWithAARCHint(HttpServletRequest request) {
+
+    boolean isAuthorizeRequest = "/authorize".equals(request.getRequestURI());
+    String aarcHintParam = request.getParameter(AARC_HINT_PARAM);
+
+    return isAuthorizeRequest && !Objects.isNull(aarcHintParam);
+  }
+
 
   protected void handleExternalAuthenticationHint(HttpServletRequest request,
       HttpServletResponse response) throws IOException {
@@ -55,11 +67,34 @@ public class HintAwareAuthenticationEntryPoint implements AuthenticationEntryPoi
     response.sendRedirect(redirectUrl);
   }
 
+
+  protected void handleAARCIdpHint(HttpServletRequest request, HttpServletResponse response)
+      throws IOException {
+
+    String redirectUrl = aarcHintService.resolve(request.getParameter(AARC_HINT_PARAM));
+    response.sendRedirect(redirectUrl);
+
+  }
+
   @Override
   public void commence(HttpServletRequest request, HttpServletResponse response,
       AuthenticationException authException) throws IOException, ServletException {
 
-    if (isOAuthAuthorizationRequestWithHint(request)) {
+    // No, this is where the AI spirit wants me to implement the aarc_hint
+
+    // Fuck ofcourse, this is after the failed authenthication
+    // It makes sense
+
+    // I need to get the aarc idp hint value from here.
+
+    // Need to have the aarc idp hint within the request
+
+
+    if (isOAuthAuthorizationRequestWithAARCHint(request)) {
+      handleAARCIdpHint(request, response);
+      return;
+
+    } else if (isOAuthAuthorizationRequestWithHint(request)) {
       handleExternalAuthenticationHint(request, response);
       return;
     }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/HintAwareAuthenticationEntryPoint.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/HintAwareAuthenticationEntryPoint.java
@@ -43,8 +43,6 @@ public class HintAwareAuthenticationEntryPoint implements AuthenticationEntryPoi
 
   protected boolean isOAuthAuthorizationRequestWithHint(HttpServletRequest request) {
 
-    // This is some current way of handling whether there is a hint or not
-    // I need to have a similar method to check if my hint is there
     boolean isAuthorizeRequest = "/authorize".equals(request.getRequestURI());
     String hintParam = request.getParameter(EXT_AUTHN_HINT_PARAM);
     return isAuthorizeRequest && !Objects.isNull(hintParam);
@@ -79,16 +77,6 @@ public class HintAwareAuthenticationEntryPoint implements AuthenticationEntryPoi
   @Override
   public void commence(HttpServletRequest request, HttpServletResponse response,
       AuthenticationException authException) throws IOException, ServletException {
-
-    // No, this is where the AI spirit wants me to implement the aarc_hint
-
-    // Fuck ofcourse, this is after the failed authenthication
-    // It makes sense
-
-    // I need to get the aarc idp hint value from here.
-
-    // Need to have the aarc idp hint within the request
-
 
     if (isOAuthAuthorizationRequestWithAARCHint(request)) {
       handleAARCIdpHint(request, response);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/HintAwareAuthenticationEntryPoint.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/HintAwareAuthenticationEntryPoint.java
@@ -40,6 +40,8 @@ public class HintAwareAuthenticationEntryPoint implements AuthenticationEntryPoi
 
   protected boolean isOAuthAuthorizationRequestWithHint(HttpServletRequest request) {
 
+    // This is some current way of handling whether there is a hint or not
+    // I need to have a similar method to check if my hint is there 
     boolean isAuthorizeRequest = "/authorize".equals(request.getRequestURI()); 
     String hintParam = request.getParameter(EXT_AUTHN_HINT_PARAM);
     return isAuthorizeRequest && !Objects.isNull(hintParam);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/error/InvalidAARCHintError.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/error/InvalidAARCHintError.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.authn.error;
+
+public class InvalidAARCHintError extends RuntimeException {
+
+  /**
+   * 
+   */
+  private static final long serialVersionUID = 1507034816495000471L;
+
+  public InvalidAARCHintError() {
+  }
+
+  public InvalidAARCHintError(String message) {
+    super(message);
+  }
+
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamWebSecurityConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamWebSecurityConfig.java
@@ -52,6 +52,7 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.filter.GenericFilterBean;
 
 import it.infn.mw.iam.api.account.AccountUtils;
+import it.infn.mw.iam.authn.AARCHintService;
 import it.infn.mw.iam.authn.AuthenticationSuccessHandlerHelper;
 import it.infn.mw.iam.authn.CheckMultiFactorIsEnabledSuccessHandler;
 import it.infn.mw.iam.authn.ExternalAuthenticationHintService;
@@ -128,6 +129,9 @@ public class IamWebSecurityConfig {
     private ExternalAuthenticationHintService hintService;
 
     @Autowired
+    private AARCHintService aarcHintService;
+
+    @Autowired
     private IamProperties iamProperties;
 
     @Autowired
@@ -155,8 +159,10 @@ public class IamWebSecurityConfig {
     }
 
     protected AuthenticationEntryPoint entryPoint() {
+
+      // The AI overlord suggests to do the check here
       LoginUrlAuthenticationEntryPoint delegate = new LoginUrlAuthenticationEntryPoint("/login");
-      return new HintAwareAuthenticationEntryPoint(delegate, hintService);
+      return new HintAwareAuthenticationEntryPoint(delegate, hintService, aarcHintService);
     }
 
 
@@ -166,7 +172,7 @@ public class IamWebSecurityConfig {
       // @formatter:off
       http.requestMatchers()
         .antMatchers("/", "/login**", "/logout", "/authorize", "/manage/**", "/dashboard**",
-            "/reset-session", "/device/**", "/idp/saml/sso")
+            "/reset-session", "/device/**")
         .and()
         .sessionManagement()
           .enableSessionUrlRewriting(false)
@@ -175,7 +181,6 @@ public class IamWebSecurityConfig {
             .antMatchers("/login**", "/webjars/**").permitAll()
             .antMatchers("/authorize**").permitAll()
             .antMatchers("/reset-session").permitAll()
-            .antMatchers("/idp/saml/sso").permitAll()
             .antMatchers("/device/**").authenticated()
             .antMatchers("/").authenticated()
         .and()

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamWebSecurityConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamWebSecurityConfig.java
@@ -166,7 +166,7 @@ public class IamWebSecurityConfig {
       // @formatter:off
       http.requestMatchers()
         .antMatchers("/", "/login**", "/logout", "/authorize", "/manage/**", "/dashboard**",
-            "/reset-session", "/device/**")
+            "/reset-session", "/device/**", "/idp/saml/sso")
         .and()
         .sessionManagement()
           .enableSessionUrlRewriting(false)
@@ -175,6 +175,7 @@ public class IamWebSecurityConfig {
             .antMatchers("/login**", "/webjars/**").permitAll()
             .antMatchers("/authorize**").permitAll()
             .antMatchers("/reset-session").permitAll()
+            .antMatchers("/idp/saml/sso").permitAll()
             .antMatchers("/device/**").authenticated()
             .antMatchers("/").authenticated()
         .and()

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamWebSecurityConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamWebSecurityConfig.java
@@ -160,7 +160,6 @@ public class IamWebSecurityConfig {
 
     protected AuthenticationEntryPoint entryPoint() {
 
-      // The AI overlord suggests to do the check here
       LoginUrlAuthenticationEntryPoint delegate = new LoginUrlAuthenticationEntryPoint("/login");
       return new HintAwareAuthenticationEntryPoint(delegate, hintService, aarcHintService);
     }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/web/IamRootController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/web/IamRootController.java
@@ -28,6 +28,9 @@ import org.springframework.ui.Model;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
 
 @Controller
 public class IamRootController {
@@ -61,6 +64,20 @@ public class IamRootController {
     return "redirect:/";
 
   }
+
+
+  @RequestMapping(method=RequestMethod.GET, path = "/idp/saml/sso")
+  @ResponseBody
+  public String samlIdpHintService(@RequestParam (required = false) String param) {
+      return "Ta daaa";
+  }
+
+/*   @RequestMapping(method=RequestMethod.GET, path = "/authorize")
+  @ResponseBody
+  public String oidcIdpHintService(@RequestParam (required = false) String param) {
+      return "Ta daaa";
+  } */
+  
 
   @RequestMapping(method = RequestMethod.GET, path = "/reset-session")
   public String resetSession(HttpSession session) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/web/IamRootController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/web/IamRootController.java
@@ -28,9 +28,6 @@ import org.springframework.ui.Model;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
-
 
 @Controller
 public class IamRootController {
@@ -64,20 +61,6 @@ public class IamRootController {
     return "redirect:/";
 
   }
-
-
-  @RequestMapping(method=RequestMethod.GET, path = "/idp/saml/sso")
-  @ResponseBody
-  public String samlIdpHintService(@RequestParam (required = false) String param) {
-      return "Ta daaa";
-  }
-
-/*   @RequestMapping(method=RequestMethod.GET, path = "/authorize")
-  @ResponseBody
-  public String oidcIdpHintService(@RequestParam (required = false) String param) {
-      return "Ta daaa";
-  } */
-  
 
   @RequestMapping(method = RequestMethod.GET, path = "/reset-session")
   public String resetSession(HttpSession session) {

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/AarcAuthenticationHintServiceTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/AarcAuthenticationHintServiceTests.java
@@ -40,15 +40,14 @@ import it.infn.mw.iam.config.oidc.OidcValidatedProviders;
 public class AarcAuthenticationHintServiceTests {
 
     private static final String BASE_URL = "http://localhost:8080";
-
-    @InjectMocks
-    private DefaultAARCHintService service = new DefaultAARCHintService(BASE_URL);
-
     private static final String OIDC_ISSUER = "https://accounts.google.com";
     private static final String SAML_ENTITYID = "urn:example.us.auth0.com";
 
     @Mock
     private OidcValidatedProviders oidcProviders;
+
+    @InjectMocks
+    private DefaultAARCHintService service = new DefaultAARCHintService(BASE_URL, oidcProviders);
 
     @Mock
     private DefaultMetadataLookupService samlProviders;

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/AarcAuthenticationHintServiceTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/AarcAuthenticationHintServiceTests.java
@@ -39,13 +39,13 @@ import it.infn.mw.iam.config.oidc.OidcValidatedProviders;
 @RunWith(MockitoJUnitRunner.class)
 public class AarcAuthenticationHintServiceTests {
 
-    public static final String BASE_URL = "http://localhost:8080";
+    private static final String BASE_URL = "http://localhost:8080";
 
     @InjectMocks
     private DefaultAARCHintService service = new DefaultAARCHintService(BASE_URL);
 
-    private String OIDC_ISSUER = "https://accounts.google.com";
-    private String SAML_ENTITYID = "urn:example.us.auth0.com";
+    private static final String OIDC_ISSUER = "https://accounts.google.com";
+    private static final String SAML_ENTITYID = "urn:example.us.auth0.com";
 
     @Mock
     private OidcValidatedProviders oidcProviders;

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/AarcAuthenticationHintServiceTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/AarcAuthenticationHintServiceTests.java
@@ -42,7 +42,7 @@ public class AarcAuthenticationHintServiceTests {
     public static final String BASE_URL = "http://localhost:8080";
 
     @InjectMocks
-    DefaultAARCHintService service = new DefaultAARCHintService(BASE_URL);
+    private DefaultAARCHintService service = new DefaultAARCHintService(BASE_URL);
 
     private String OIDC_ISSUER = "https://accounts.google.com";
     private String SAML_ENTITYID = "urn:example.us.auth0.com";
@@ -55,7 +55,7 @@ public class AarcAuthenticationHintServiceTests {
 
 
     @Before
-    public void setUp(){
+    public void setUp() {
 
         // Populating known Oidc's
         OidcProvider oidcProvider = new OidcProvider();
@@ -64,7 +64,7 @@ public class AarcAuthenticationHintServiceTests {
 
         when(oidcProviders.getValidatedProviders()).thenReturn(oidcProvidersTemp);
 
-        // Populating known Saml's 
+        // Populating known Saml's
         IdpDescription idpDescription = new IdpDescription();
         idpDescription.setEntityId(SAML_ENTITYID);
         List<IdpDescription> idpDescriptionsTemp = List.of(idpDescription);
@@ -97,7 +97,7 @@ public class AarcAuthenticationHintServiceTests {
     @Test
     public void testSamlWorks() {
         String url = service.resolve(SAML_ENTITYID);
-        assertThat(url, is(String.format("%s/saml/login?idp=%s", BASE_URL,SAML_ENTITYID)));
+        assertThat(url, is(String.format("%s/saml/login?idp=%s", BASE_URL, SAML_ENTITYID)));
     }
 
     @Test

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/AarcAuthenticationHintServiceTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/AarcAuthenticationHintServiceTests.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.ext_authn;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import it.infn.mw.iam.authn.DefaultAARCHintService;
+import it.infn.mw.iam.authn.error.InvalidAARCHintError;
+import it.infn.mw.iam.authn.saml.DefaultMetadataLookupService;
+import it.infn.mw.iam.authn.saml.model.IdpDescription;
+import it.infn.mw.iam.config.oidc.OidcProvider;
+import it.infn.mw.iam.config.oidc.OidcValidatedProviders;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AarcAuthenticationHintServiceTests {
+
+    public static final String BASE_URL = "http://localhost:8080";
+
+    @InjectMocks
+    DefaultAARCHintService service = new DefaultAARCHintService(BASE_URL);
+
+    private String OIDC_ISSUER = "https://accounts.google.com";
+    private String SAML_ENTITYID = "urn:example.us.auth0.com";
+
+    @Mock
+    private OidcValidatedProviders oidcProviders;
+
+    @Mock
+    private DefaultMetadataLookupService samlProviders;
+
+
+    @Before
+    public void setUp(){
+
+        // Populating known Oidc's
+        OidcProvider oidcProvider = new OidcProvider();
+        oidcProvider.setIssuer(OIDC_ISSUER);
+        List<OidcProvider> oidcProvidersTemp = List.of(oidcProvider);
+
+        when(oidcProviders.getValidatedProviders()).thenReturn(oidcProvidersTemp);
+
+        // Populating known Saml's 
+        IdpDescription idpDescription = new IdpDescription();
+        idpDescription.setEntityId(SAML_ENTITYID);
+        List<IdpDescription> idpDescriptionsTemp = List.of(idpDescription);
+
+        when(samlProviders.listIdps()).thenReturn(idpDescriptionsTemp);
+    }
+
+
+    @Test(expected = InvalidAARCHintError.class)
+    public void testNullAarcHint() {
+        service.resolve(null);
+    }
+
+    @Test(expected = InvalidAARCHintError.class)
+    public void testEmptyAarcHint() {
+        service.resolve("");
+    }
+
+    @Test(expected = InvalidAARCHintError.class)
+    public void testSpacesAarcHint() {
+        service.resolve("   ");
+    }
+
+
+    @Test(expected = InvalidAARCHintError.class)
+    public void testInvalidSchemeHint() {
+        service.resolve("whatever:sdsdad");
+    }
+
+    @Test
+    public void testSamlWorks() {
+        String url = service.resolve(SAML_ENTITYID);
+        assertThat(url, is(String.format("%s/saml/login?idp=%s", BASE_URL,SAML_ENTITYID)));
+    }
+
+    @Test
+    public void testOidcWorks() {
+        String url = service.resolve(OIDC_ISSUER);
+        assertThat(url, is(String.format("%s/openid_connect_login?iss=%s", BASE_URL, OIDC_ISSUER)));
+    }
+
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/AarcHintAwareAuthenticationEntryPointTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/AarcHintAwareAuthenticationEntryPointTests.java
@@ -79,7 +79,7 @@ public class AarcHintAwareAuthenticationEntryPointTests {
 
         entryPoint.commence(authorizeRequest, response, exception);
         verify(delegateEntryPoint, times(0)).commence(authorizeRequest, response, exception);
-        verify(aarcHintService, times(1)).resolve(eq(SAML_ENTITYID));
+        verify(aarcHintService, times(1)).resolve(SAML_ENTITYID);
         verify(response, times(1)).sendRedirect("/saml/login?idp=" + SAML_ENTITYID);
     }
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/AarcHintAwareAuthenticationEntryPointTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/AarcHintAwareAuthenticationEntryPointTests.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.ext_authn;
+
+import static it.infn.mw.iam.authn.HintAwareAuthenticationEntryPoint.AARC_HINT_PARAM;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import it.infn.mw.iam.authn.DefaultAARCHintService;
+import it.infn.mw.iam.authn.HintAwareAuthenticationEntryPoint;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AarcHintAwareAuthenticationEntryPointTests {
+
+
+    public static final String BASE_URL = "";
+    public static final String AUTHORIZE_URL = String.format("%s/authorize", BASE_URL);
+
+    private String SAML_ENTITYID = "urn:example.us.auth0.com";
+
+    @Mock
+    HttpServletRequest request;
+
+    @Mock
+    HttpServletRequest authorizeRequest;
+
+    @Mock
+    HttpServletResponse response;
+
+    @Mock
+    AuthenticationException exception;
+
+    @Mock
+    AuthenticationEntryPoint delegateEntryPoint;
+
+    @InjectMocks
+    HintAwareAuthenticationEntryPoint entryPoint;
+
+    @Mock
+    DefaultAARCHintService aarcHintService;
+
+    @Before
+    public void before() {
+        when(request.getRequestURI()).thenReturn(BASE_URL);
+        when(authorizeRequest.getRequestURI()).thenReturn(AUTHORIZE_URL);
+        when(authorizeRequest.getRequestURI()).thenReturn(AUTHORIZE_URL);
+        when(authorizeRequest.getParameter(AARC_HINT_PARAM)).thenReturn(SAML_ENTITYID);
+        when(aarcHintService.resolve(anyString())).thenReturn("/saml/login?idp=" + SAML_ENTITYID);
+    }
+
+    @Test
+    public void nonAuthorizeRequestIsPassedToDelegateEntryPoint()
+            throws IOException, ServletException {
+
+        entryPoint.commence(request, response, exception);
+        verify(delegateEntryPoint, times(1)).commence(request, response, exception);
+    }
+
+    @Test
+    public void authorizeRequestWithoutHintIsPassedToDelegateEntryPoint()
+            throws IOException, ServletException {
+
+        entryPoint.commence(request, response, exception);
+        verify(delegateEntryPoint, times(1)).commence(request, response, exception);
+    }
+
+    @Test
+    public void authorizeRequestWithHintIsUnderstood() throws IOException, ServletException {
+
+        entryPoint.commence(authorizeRequest, response, exception);
+        verify(delegateEntryPoint, times(0)).commence(authorizeRequest, response, exception);
+        verify(aarcHintService, times(1)).resolve(eq(SAML_ENTITYID));
+        verify(response, times(1)).sendRedirect(eq("/saml/login?idp=" + SAML_ENTITYID));
+    }
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/AarcHintAwareAuthenticationEntryPointTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/AarcHintAwareAuthenticationEntryPointTests.java
@@ -17,7 +17,6 @@ package it.infn.mw.iam.test.ext_authn;
 
 import static it.infn.mw.iam.authn.HintAwareAuthenticationEntryPoint.AARC_HINT_PARAM;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/AarcHintAwareAuthenticationEntryPointTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/AarcHintAwareAuthenticationEntryPointTests.java
@@ -44,13 +44,10 @@ import it.infn.mw.iam.authn.HintAwareAuthenticationEntryPoint;
 public class AarcHintAwareAuthenticationEntryPointTests {
 
 
-    public static final String BASE_URL = "";
-    public static final String AUTHORIZE_URL = String.format("%s/authorize", BASE_URL);
+    private static final String BASE_URL = "";
+    private static final String AUTHORIZE_URL = String.format("%s/authorize", BASE_URL);
 
-    private String SAML_ENTITYID = "urn:example.us.auth0.com";
-
-    @Mock
-    HttpServletRequest request;
+    private static final String SAML_ENTITYID = "urn:example.us.auth0.com";
 
     @Mock
     HttpServletRequest authorizeRequest;
@@ -72,27 +69,9 @@ public class AarcHintAwareAuthenticationEntryPointTests {
 
     @Before
     public void before() {
-        when(request.getRequestURI()).thenReturn(BASE_URL);
-        when(authorizeRequest.getRequestURI()).thenReturn(AUTHORIZE_URL);
         when(authorizeRequest.getRequestURI()).thenReturn(AUTHORIZE_URL);
         when(authorizeRequest.getParameter(AARC_HINT_PARAM)).thenReturn(SAML_ENTITYID);
         when(aarcHintService.resolve(anyString())).thenReturn("/saml/login?idp=" + SAML_ENTITYID);
-    }
-
-    @Test
-    public void nonAuthorizeRequestIsPassedToDelegateEntryPoint()
-            throws IOException, ServletException {
-
-        entryPoint.commence(request, response, exception);
-        verify(delegateEntryPoint, times(1)).commence(request, response, exception);
-    }
-
-    @Test
-    public void authorizeRequestWithoutHintIsPassedToDelegateEntryPoint()
-            throws IOException, ServletException {
-
-        entryPoint.commence(request, response, exception);
-        verify(delegateEntryPoint, times(1)).commence(request, response, exception);
     }
 
     @Test
@@ -101,6 +80,6 @@ public class AarcHintAwareAuthenticationEntryPointTests {
         entryPoint.commence(authorizeRequest, response, exception);
         verify(delegateEntryPoint, times(0)).commence(authorizeRequest, response, exception);
         verify(aarcHintService, times(1)).resolve(eq(SAML_ENTITYID));
-        verify(response, times(1)).sendRedirect(eq("/saml/login?idp=" + SAML_ENTITYID));
+        verify(response, times(1)).sendRedirect("/saml/login?idp=" + SAML_ENTITYID);
     }
 }


### PR DESCRIPTION
Implementation of the `aarc_idp_hint` parameter according to [AARC61](https://aarc-community.org/guidelines/aarc-g061/) guideline. 

The access point is at `/authorize` and will redirect according to the hint, but only to known OIDC and SAML providers. 

This implementation follows specifically the rule set in the guidelines at point 3.3.13.b, that the Iam may disregard any nested hints and in this implementation it always will. From 3.3.13.d it states that if it were to handle the nested hints, then
>   the consumer MUST send this nested
hint using a protocol understood by the next consumer.

For this reason it has not implemented. 

Please advise if there is a way to ensure what protocols the next consumer can and will accept. 