### PR TITLE
Add code to handle of Immediate Group Requests in the Database

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/requests/service/DefaultGroupRequestsService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/requests/service/DefaultGroupRequestsService.java
@@ -19,6 +19,8 @@ import static it.infn.mw.iam.core.IamGroupRequestStatus.APPROVED;
 import static it.infn.mw.iam.core.IamGroupRequestStatus.PENDING;
 import static it.infn.mw.iam.core.IamGroupRequestStatus.REJECTED;
 
+import static java.util.Objects.isNull;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -148,6 +150,21 @@ public class DefaultGroupRequestsService implements GroupRequestsService {
     request = updateGroupRequestStatus(request, APPROVED);
     notificationFactory.createGroupMembershipApprovedMessage(request);
     eventPublisher.publishEvent(new GroupRequestApprovedEvent(this, request));
+
+    while(!isNull(group)) {
+      // Approve all other PENDING requests for any intermediate groups up to the root
+      Optional<IamGroupRequest> hasPendingRequest = 
+          groupRequestRepository.findByGroupIdAndAccountIdAndStatus(group.getId(), account.getId(), PENDING);
+
+      if (hasPendingRequest.isPresent() && !hasPendingRequest.get().getId().equals(request.getId())) {
+        IamGroupRequest pendingRequest = hasPendingRequest.get();
+        updateGroupRequestStatus(pendingRequest, APPROVED);
+        notificationFactory.createGroupMembershipApprovedMessage(pendingRequest);
+        eventPublisher.publishEvent(new GroupRequestApprovedEvent(this, pendingRequest));
+      }
+
+      group = group.getParentGroup();
+    }
 
     return converter.fromEntity(request);
   }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/requests/service/DefaultGroupRequestsService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/requests/service/DefaultGroupRequestsService.java
@@ -21,11 +21,13 @@ import static it.infn.mw.iam.core.IamGroupRequestStatus.REJECTED;
 
 import static java.util.Objects.isNull;
 
+import java.util.LinkedList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
 
@@ -172,12 +174,35 @@ public class DefaultGroupRequestsService implements GroupRequestsService {
   @Override
   public GroupRequestDto rejectGroupRequest(String requestId, String motivation) {
     IamGroupRequest request = groupRequestUtils.getGroupRequest(requestId);
+    IamAccount account = request.getAccount();
+    IamGroup group = request.getGroup();
+
     groupRequestUtils.validateRejectMotivation(motivation);
 
     request.setMotivation(motivation);
     request = updateGroupRequestStatus(request, REJECTED);
     notificationFactory.createGroupMembershipRejectedMessage(request);
     eventPublisher.publishEvent(new GroupRequestRejectedEvent(this, request));
+
+    // reject all PENDING requests in the subtree
+    Queue<IamGroup> queue = new LinkedList<>(group.getChildrenGroups());
+
+    while (!queue.isEmpty()) {
+      IamGroup child = queue.poll();
+
+      Optional<IamGroupRequest> hasPendingRequest = 
+          groupRequestRepository.findByGroupIdAndAccountIdAndStatus(child.getId(), account.getId(), PENDING);
+
+      if (hasPendingRequest.isPresent() && !hasPendingRequest.get().getId().equals(request.getId())) {
+        IamGroupRequest pendingRequest = hasPendingRequest.get();
+        pendingRequest.setMotivation(motivation);
+        updateGroupRequestStatus(pendingRequest, REJECTED);
+        notificationFactory.createGroupMembershipRejectedMessage(pendingRequest);
+        eventPublisher.publishEvent(new GroupRequestRejectedEvent(this, pendingRequest));
+      }
+
+      queue.addAll(child.getChildrenGroups());
+    }
 
     return converter.fromEntity(request);
   }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/requests/GroupRequestsApproveTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/requests/GroupRequestsApproveTests.java
@@ -236,4 +236,46 @@ public class GroupRequestsApproveTests extends GroupRequestsTestUtils {
     assertThat(updatedParentRequest.getStatus(), equalTo(IamGroupRequestStatus.APPROVED));
     assertThat(updatedParentRequest.getAccount().getUsername(), equalTo(TEST_100_USERNAME));
   }
+
+  @Transactional
+  @Test
+  @WithMockUser(roles = {"ADMIN"})
+  public void autoRejectChildGroupRequest() throws Exception {
+    // Setup: parent-child relationship
+    IamGroup parentGroup = groupRepository.findByName(TEST_002_GROUPNAME).get();
+    IamGroup childGroup = groupRepository.findByName(TEST_001_GROUPNAME).get();
+    childGroup.setParentGroup(parentGroup);
+    groupRepository.save(childGroup);
+
+    IamAccount account = accountRepository.findByUsername(TEST_100_USERNAME).get();
+
+    // Parent request
+    IamGroupRequest parentRequest = new IamGroupRequest();
+    parentRequest.setUuid(UUID.randomUUID().toString());
+    parentRequest.setAccount(account);
+    parentRequest.setGroup(parentGroup);
+    parentRequest.setStatus(IamGroupRequestStatus.PENDING);
+    parentRequest.setCreationTime(new java.util.Date());
+    groupRequestRepository.save(parentRequest);
+
+    // Child request
+    IamGroupRequest childRequest = new IamGroupRequest();
+    childRequest.setUuid(UUID.randomUUID().toString());
+    childRequest.setAccount(account);
+    childRequest.setGroup(childGroup);
+    childRequest.setStatus(IamGroupRequestStatus.PENDING);
+    childRequest.setCreationTime(new java.util.Date());
+    groupRequestRepository.save(childRequest);
+
+    // Reject parent request -> should cascade to child
+    String motivation = "Parent group request rejected";
+    mvc.perform(post(REJECT_URL, parentRequest.getUuid()).param("motivation", motivation))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.status", equalTo(IamGroupRequestStatus.REJECTED.name())));
+
+    Optional<IamGroupRequest> rejectedChild =
+        groupRequestRepository.findByGroupIdAndAccountIdAndStatus(childGroup.getId(), account.getId(),
+            IamGroupRequestStatus.REJECTED);
+    assertThat(rejectedChild.isPresent(), equalTo(true));
+  }
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/requests/GroupRequestsApproveTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/requests/GroupRequestsApproveTests.java
@@ -26,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.junit.Before;
@@ -37,13 +38,17 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 
 import it.infn.mw.iam.IamLoginService;
 import it.infn.mw.iam.api.requests.model.GroupRequestDto;
 import it.infn.mw.iam.core.IamGroupRequestStatus;
 import it.infn.mw.iam.core.IamNotificationType;
 import it.infn.mw.iam.notification.service.NotificationStoreService;
+import it.infn.mw.iam.persistence.model.IamAccount;
 import it.infn.mw.iam.persistence.model.IamEmailNotification;
+import it.infn.mw.iam.persistence.model.IamGroup;
+import it.infn.mw.iam.persistence.model.IamGroupRequest;
 import it.infn.mw.iam.persistence.repository.IamEmailNotificationRepository;
 import it.infn.mw.iam.test.util.WithAnonymousUser;
 import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
@@ -172,5 +177,63 @@ public class GroupRequestsApproveTests extends GroupRequestsTestUtils {
       .andExpect(jsonPath("$.lastUpdateTime").exists())
       .andExpect(jsonPath("$.lastUpdateTime").isNotEmpty());
     // @formatter:on
+  }
+
+  @Transactional
+  @Test
+  @WithMockUser(roles = {"ADMIN"})
+  public void autoApproveParentGroupRequest() throws Exception {
+    // Setup: Create parent-child group hierarchy
+    IamGroup parentGroup = groupRepository.findByName(TEST_002_GROUPNAME).get();
+    IamGroup childGroup = groupRepository.findByName(TEST_001_GROUPNAME).get();
+  
+    childGroup.setParentGroup(parentGroup);
+    groupRepository.save(childGroup);
+  
+    IamAccount account = accountRepository.findByUsername(TEST_100_USERNAME).get();
+  
+    // Create a pending request for parent group
+    IamGroupRequest parentRequest = new IamGroupRequest();
+    parentRequest.setUuid(UUID.randomUUID().toString());
+    parentRequest.setAccount(account);
+    parentRequest.setGroup(parentGroup);
+    parentRequest.setStatus(IamGroupRequestStatus.PENDING);
+    parentRequest.setCreationTime(new java.util.Date());
+    groupRequestRepository.save(parentRequest);
+  
+    // Create a pending request for child group
+    IamGroupRequest childRequest = new IamGroupRequest();
+    childRequest.setUuid(UUID.randomUUID().toString());
+    childRequest.setAccount(account);
+    childRequest.setGroup(childGroup);
+    childRequest.setStatus(IamGroupRequestStatus.PENDING);
+    childRequest.setCreationTime(new java.util.Date());
+    groupRequestRepository.save(childRequest);
+  
+    // Approve child request - User will be automatically added to the parent group
+    String response = mvc.perform(post(APPROVE_URL, childRequest.getUuid()))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.status", equalTo(IamGroupRequestStatus.APPROVED.name())))
+      .andExpect(jsonPath("$.groupName", equalTo(TEST_001_GROUPNAME)))
+      .andExpect(jsonPath("$.username", equalTo(TEST_100_USERNAME)))
+      .andReturn()
+      .getResponse()
+      .getContentAsString();
+  
+    GroupRequestDto result = mapper.readValue(response, GroupRequestDto.class);
+  
+    // Child request is approved
+    assertThat(result.getStatus(), equalTo(IamGroupRequestStatus.APPROVED.toString()));
+    assertThat(result.getGroupName(), equalTo(TEST_001_GROUPNAME));
+    assertThat(result.getUsername(), equalTo(TEST_100_USERNAME));
+  
+    // Parent request will be approved automatically via recursive logic
+    Optional<IamGroupRequest> hasParentRequest =
+        groupRequestRepository.findByGroupIdAndAccountIdAndStatus(parentGroup.getId(), account.getId(), IamGroupRequestStatus.APPROVED);
+  
+    assertThat(hasParentRequest.isPresent(), equalTo(true));
+    IamGroupRequest updatedParentRequest = hasParentRequest.get();
+    assertThat(updatedParentRequest.getStatus(), equalTo(IamGroupRequestStatus.APPROVED));
+    assertThat(updatedParentRequest.getAccount().getUsername(), equalTo(TEST_100_USERNAME));
   }
 }

--- a/iam-persistence/src/main/java/it/infn/mw/iam/persistence/repository/IamGroupRequestRepository.java
+++ b/iam-persistence/src/main/java/it/infn/mw/iam/persistence/repository/IamGroupRequestRepository.java
@@ -35,5 +35,5 @@ public interface IamGroupRequestRepository
   List<IamGroupRequest> findByUsernameAndGroup(@Param("username") String username,
       @Param("groupName") String groupName);
 
-      Optional<IamGroupRequest> findByGroupIdAndAccountIdAndStatus(Long groupID, Long accountID, IamGroupRequestStatus status);
+  Optional<IamGroupRequest> findByGroupIdAndAccountIdAndStatus(Long groupID, Long accountID, IamGroupRequestStatus status);
 }

--- a/iam-persistence/src/main/java/it/infn/mw/iam/persistence/repository/IamGroupRequestRepository.java
+++ b/iam-persistence/src/main/java/it/infn/mw/iam/persistence/repository/IamGroupRequestRepository.java
@@ -23,6 +23,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
 
+import it.infn.mw.iam.core.IamGroupRequestStatus;
 import it.infn.mw.iam.persistence.model.IamGroupRequest;
 
 public interface IamGroupRequestRepository
@@ -34,5 +35,5 @@ public interface IamGroupRequestRepository
   List<IamGroupRequest> findByUsernameAndGroup(@Param("username") String username,
       @Param("groupName") String groupName);
 
-  
+      Optional<IamGroupRequest> findByGroupIdAndAccountIdAndStatus(Long groupID, Long accountID, IamGroupRequestStatus status);
 }


### PR DESCRIPTION
Resolves https://github.com/indigo-iam/iam/issues/979 


say, we have rootGroup, subGroup1, subGroup2, subGroup3.

If the user raises a request to join subGroup3. We will auto-approve requests to the parent group requests if the subGroup3 Group manager approves the request.