### PR TITLE
Scoped voPerson_id

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcClaimValueHelper.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcClaimValueHelper.java
@@ -18,12 +18,14 @@ package it.infn.mw.iam.core.oauth.profile.aarc;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
 
+import it.infn.mw.iam.config.IamProperties;
 import it.infn.mw.iam.core.oauth.profile.ClaimValueHelper;
 import it.infn.mw.iam.persistence.model.IamGroup;
 import it.infn.mw.iam.persistence.model.IamUserInfo;
@@ -46,6 +48,9 @@ public class AarcClaimValueHelper implements ClaimValueHelper {
   @Value("${iam.aarc-profile.urn-subnamespaces}")
   String urnSubnamespaces;
 
+  @Autowired
+  private IamProperties iamProperties;
+
   static final String DEFAULT_AFFILIATION_TYPE = "member";
 
   @Override
@@ -66,7 +71,7 @@ public class AarcClaimValueHelper implements ClaimValueHelper {
         return resolveLOA();
 
       case "voperson_id":
-        return String.format("%s", info.getSub());
+        return String.format("%s@%s", info.getSub(), iamProperties.getOrganisation().getName());
 
       default:
         return null;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcClaimValueHelper.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcClaimValueHelper.java
@@ -48,10 +48,14 @@ public class AarcClaimValueHelper implements ClaimValueHelper {
   @Value("${iam.aarc-profile.urn-subnamespaces}")
   String urnSubnamespaces;
 
-  @Autowired
   private IamProperties iamProperties;
 
   static final String DEFAULT_AFFILIATION_TYPE = "member";
+
+  @Autowired
+  public AarcClaimValueHelper(IamProperties iamProperties) {
+    this.iamProperties = iamProperties;
+  }
 
   @Override
   public Object getClaimValueFromUserInfo(String claim, IamUserInfo info) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcJWTProfileAccessTokenBuilder.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcJWTProfileAccessTokenBuilder.java
@@ -63,7 +63,8 @@ public class AarcJWTProfileAccessTokenBuilder extends BaseAccessTokenBuilder {
         .filter(ADDITIONAL_CLAIMS::contains)
         .forEach(c -> builder.claim(c, claimValueHelper.getClaimValueFromUserInfo(c,
             ((UserInfoAdapter) userInfo).getUserinfo())));
-      builder.claim("voperson_id", userInfo.getSub());
+      builder.claim("voperson_id",
+          userInfo.getSub() + '@' + properties.getOrganisation().getName());
     }
 
     return builder.build();

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcJWTProfileIdTokenCustomizer.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcJWTProfileIdTokenCustomizer.java
@@ -36,10 +36,13 @@ import it.infn.mw.iam.persistence.repository.IamAccountRepository;
 @SuppressWarnings("deprecation")
 public class AarcJWTProfileIdTokenCustomizer extends IamJWTProfileIdTokenCustomizer {
 
+  private IamProperties properties;
+
   public AarcJWTProfileIdTokenCustomizer(IamAccountRepository accountRepo,
       ScopeClaimTranslationService scopeClaimConverter, ClaimValueHelper claimValueHelper,
       IamProperties properties) {
     super(accountRepo, scopeClaimConverter, claimValueHelper, properties);
+    this.properties = properties;
   }
 
   @Override
@@ -57,7 +60,9 @@ public class AarcJWTProfileIdTokenCustomizer extends IamJWTProfileIdTokenCustomi
     includeAmrAndAcrClaimsIfNeeded(request, idClaims, accessToken);
 
     includeLabelsInIdToken(idClaims, account);
+    properties.getBaseUrl();
 
-    idClaims.claim("voperson_id", account.getUserInfo().getSub());
+    idClaims.claim("voperson_id",
+        account.getUserInfo().getSub() + '@' + properties.getOrganisation().getName());
   }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcJWTProfileTokenIntrospectionHelper.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcJWTProfileTokenIntrospectionHelper.java
@@ -31,12 +31,14 @@ import it.infn.mw.iam.persistence.repository.UserInfoAdapter;
 public class AarcJWTProfileTokenIntrospectionHelper extends BaseIntrospectionHelper {
 
   protected final AarcClaimValueHelper claimValueHelper;
+  private IamProperties properties;
 
   public AarcJWTProfileTokenIntrospectionHelper(IamProperties props,
       IntrospectionResultAssembler assembler, ScopeMatcherRegistry scopeMatchersRegistry,
       AarcClaimValueHelper claimValueHelper) {
     super(props, assembler, scopeMatchersRegistry);
     this.claimValueHelper = claimValueHelper;
+    this.properties = props;
   }
 
   @Override
@@ -85,7 +87,7 @@ public class AarcJWTProfileTokenIntrospectionHelper extends BaseIntrospectionHel
             claimValueHelper.getClaimValueFromUserInfo(EDUPERSON_ASSURANCE, iamUserInfo));
       }
 
-      result.put("voperson_id", userInfo.getSub());
+      result.put("voperson_id", userInfo.getSub() + '@' + properties.getOrganisation().getName());
 
     }
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/AarcProfileIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/AarcProfileIntegrationTests.java
@@ -25,11 +25,12 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -76,6 +77,7 @@ public class AarcProfileIntegrationTests extends EndpointsTestUtils {
   private static final String USERNAME = "test";
   private static final String PASSWORD = "password";
   private static final String GRANT_TYPE = "password";
+  private static final String ORGANISATION_NAME = "indigo-dc";
 
   private static final String URN_GROUP_ANALYSIS = "urn:geant:iam.example:group:Analysis";
   private static final String URN_GROUP_PRODUCTION = "urn:geant:iam.example:group:Production";
@@ -360,7 +362,7 @@ public class AarcProfileIntegrationTests extends EndpointsTestUtils {
       .andExpect(jsonPath("$.sub").exists())
       .andExpect(jsonPath("$.organisation_name").doesNotExist())
       .andExpect(jsonPath("$.groups").doesNotExist())
-      .andExpect(jsonPath("$.voperson_id").isNotEmpty())
+      .andExpect(jsonPath("$.voperson_id", containsString("@"+ORGANISATION_NAME)))
       .andExpect(jsonPath("$." + EDUPERSON_SCOPED_AFFILIATION_CLAIM, equalTo("member@iam.example")))
       .andExpect(jsonPath("$." + ENTITLEMENTS_CLAIM, hasSize(equalTo(2))))
       .andExpect(jsonPath("$." + ENTITLEMENTS_CLAIM, containsInAnyOrder(URN_GROUP_ANALYSIS, URN_GROUP_PRODUCTION)))
@@ -380,14 +382,17 @@ public class AarcProfileIntegrationTests extends EndpointsTestUtils {
     Set<String> scopes = Sets.newHashSet("openid", "profile", "email");
     JWT token = JWTParser.parse(getAccessTokenForUser(scopes));
 
-    assertNotNull(token.getJWTClaimsSet().getClaim("voperson_id"));
+    assertTrue(token.getJWTClaimsSet()
+      .getClaim("voperson_id")
+      .toString()
+      .contains("@" + ORGANISATION_NAME));
 
     // @formatter:off
     mvc.perform(post("/introspect")
         .with(httpBasic(CLIENT_ID, CLIENT_SECRET))
         .param("token", token.getParsedString()))
       .andExpect(status().isOk())
-      .andExpect(jsonPath("$.voperson_id").isNotEmpty())
+      .andExpect(jsonPath("$.voperson_id",containsString("@"+ORGANISATION_NAME)))
       .andExpect(jsonPath("$.active", equalTo(true)))
       .andExpect(jsonPath("$." + EDUPERSON_SCOPED_AFFILIATION_CLAIM).doesNotExist())
       .andExpect(jsonPath("$." + ENTITLEMENTS_CLAIM).doesNotExist())
@@ -407,7 +412,10 @@ public class AarcProfileIntegrationTests extends EndpointsTestUtils {
         "eduperson_scoped_affiliation", "eduperson_entitlement", "eduperson_assurance");
     JWT token = JWTParser.parse(getAccessTokenForUser(scopes));
 
-    assertNotNull(token.getJWTClaimsSet().getClaim("voperson_id"));
+    assertTrue(token.getJWTClaimsSet()
+      .getClaim("voperson_id")
+      .toString()
+      .contains("@" + ORGANISATION_NAME));
 
     // @formatter:off
     mvc.perform(post("/introspect")
@@ -415,7 +423,7 @@ public class AarcProfileIntegrationTests extends EndpointsTestUtils {
         .param("token", token.getParsedString()))
       .andExpect(status().isOk())
       .andExpect(jsonPath("$.active", equalTo(true)))
-      .andExpect(jsonPath("$.voperson_id").isNotEmpty())
+      .andExpect(jsonPath("$.voperson_id", containsString("@"+ORGANISATION_NAME)))
       .andExpect(jsonPath("$." + EDUPERSON_SCOPED_AFFILIATION_CLAIM, equalTo("member@iam.example")))
       .andExpect(jsonPath("$." + EDUPERSON_ENTITLEMENT_CLAIM, hasSize(equalTo(2))))
       .andExpect(jsonPath("$." + EDUPERSON_ENTITLEMENT_CLAIM, containsInAnyOrder(URN_GROUP_ANALYSIS, URN_GROUP_PRODUCTION)))
@@ -438,7 +446,10 @@ public class AarcProfileIntegrationTests extends EndpointsTestUtils {
         "eduperson_scoped_affiliation", "entitlements", "eduperson_assurance");
     JWT token = JWTParser.parse(getAccessTokenForUser(scopes));
 
-    assertNotNull(token.getJWTClaimsSet().getClaim("voperson_id"));
+    assertTrue(token.getJWTClaimsSet()
+      .getClaim("voperson_id")
+      .toString()
+      .contains("@" + ORGANISATION_NAME));
 
     // @formatter:off
     mvc.perform(post("/introspect")
@@ -446,7 +457,7 @@ public class AarcProfileIntegrationTests extends EndpointsTestUtils {
         .param("token", token.getParsedString()))
       .andExpect(status().isOk())
       .andExpect(jsonPath("$.active", equalTo(true)))
-      .andExpect(jsonPath("$.voperson_id").isNotEmpty())
+      .andExpect(jsonPath("$.voperson_id", containsString("@"+ORGANISATION_NAME)))
       .andExpect(jsonPath("$." + EDUPERSON_SCOPED_AFFILIATION_CLAIM, equalTo("member@iam.example")))
       .andExpect(jsonPath("$." + ENTITLEMENTS_CLAIM, hasSize(equalTo(2))))
       .andExpect(jsonPath("$." + ENTITLEMENTS_CLAIM, containsInAnyOrder(URN_GROUP_ANALYSIS, URN_GROUP_PRODUCTION)))
@@ -466,8 +477,10 @@ public class AarcProfileIntegrationTests extends EndpointsTestUtils {
     JWT token = JWTParser.parse(getIdToken("openid email"));
     System.out.println(token.getJWTClaimsSet());
     assertNotNull(token.getJWTClaimsSet().getClaim("sub"));
-    assertNotNull(token.getJWTClaimsSet().getClaim("voperson_id"));
-    assertNotEquals(null, token.getJWTClaimsSet().getClaim("voperson_id"));
+    assertTrue(token.getJWTClaimsSet()
+      .getClaim("voperson_id")
+      .toString()
+      .contains("@" + ORGANISATION_NAME));
   }
 
   @Test
@@ -477,8 +490,10 @@ public class AarcProfileIntegrationTests extends EndpointsTestUtils {
         "eduperson_scoped_affiliation", "eduperson_entitlement", "eduperson_assurance");
     JWT token = JWTParser.parse(getAccessTokenForUser(scopes));
 
-    assertNotNull(token.getJWTClaimsSet().getClaim("voperson_id"));
-    assertNotEquals(null, token.getJWTClaimsSet().getClaim("voperson_id"));
+    assertTrue(token.getJWTClaimsSet()
+      .getClaim("voperson_id")
+      .toString()
+      .contains("@" + ORGANISATION_NAME));
   }
 
 


### PR DESCRIPTION
This implementation changes the `voPerson_id` value for the AARC profile from `<uuid>` to `<uuid>@<organization.name>`
