### PR TITLE
Filter unsupported response types during explicit client registration

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/openid_federation/FederationRegistrationController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/openid_federation/FederationRegistrationController.java
@@ -58,8 +58,6 @@ import it.infn.mw.iam.persistence.repository.client.IamClientRepository;
 @Profile("openid-federation")
 public class FederationRegistrationController {
 
-  private static final String INVALID_CLIENT_METADATA = "invalid_client_metadata";
-
   @Value("${iam.issuer}")
   private String issuer;
 
@@ -138,7 +136,7 @@ public class FederationRegistrationController {
         .map(OAuthResponseType::fromResponseType)
         .collect(Collectors.toSet());
       if (responseTypes.isEmpty()) {
-        throw new InvalidClientMetadataException(INVALID_CLIENT_METADATA,
+        throw new InvalidClientMetadataException("invalid_client_metadata",
             "Unsupported response type");
       }
       dto.setResponseTypes(responseTypes);
@@ -166,7 +164,7 @@ public class FederationRegistrationController {
 
   private void setEntityId(RegisteredClientDTO dto, EntityStatement rpRequest) {
     if (rpRequest.getEntityID() == null) {
-      throw new InvalidClientMetadataException(INVALID_CLIENT_METADATA, "Missing RP Entity ID");
+      throw new InvalidClientMetadataException("invalid_client_metadata", "Missing RP Entity ID");
     }
     dto.setEntityId(rpRequest.getEntityID().getValue());
   }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/openid_federation/FederationRegistrationController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/openid_federation/FederationRegistrationController.java
@@ -80,33 +80,54 @@ public class FederationRegistrationController {
     this.clientService = clientService;
   }
 
-  private RegisteredClientDTO createClientDtoFromRpMetadata(EntityStatement rpRequest)
-      throws InvalidClientMetadataException {
+  private RegisteredClientDTO createClientDtoFromRpMetadata(EntityStatement rpRequest) {
     RegisteredClientDTO dtoClient = new RegisteredClientDTO();
     OIDCClientMetadata metadata = rpRequest.getClaimsSet().getRPMetadata();
-    if (metadata.getName() != null) {
-      dtoClient.setClientName(metadata.getName());
-    } else {
-      dtoClient.setClientName("OIDFed client");
-    }
+
+    setClientName(dtoClient, metadata);
+    setContacts(dtoClient, metadata);
+    setGrantTypes(dtoClient, metadata);
+    setRedirectUris(dtoClient, metadata);
+    setResponseTypes(dtoClient, metadata);
+    setTokenEndpointAuthMethod(dtoClient, metadata);
+    setScope(dtoClient, metadata);
+    setEntityId(dtoClient, rpRequest);
+
+    return dtoClient;
+  }
+
+  private void setClientName(RegisteredClientDTO dto, OIDCClientMetadata metadata) {
+    dto.setClientName(metadata.getName() != null ? metadata.getName() : "OIDFed client");
+  }
+
+  private void setContacts(RegisteredClientDTO dto, OIDCClientMetadata metadata) {
     if (metadata.getEmailContacts() != null) {
-      dtoClient.setContacts(new HashSet<>(metadata.getEmailContacts()));
+      dto.setContacts(new HashSet<>(metadata.getEmailContacts()));
     }
+  }
+
+  private void setGrantTypes(RegisteredClientDTO dto, OIDCClientMetadata metadata) {
     if (metadata.getGrantTypes() != null) {
-      dtoClient.setGrantTypes(metadata.getGrantTypes()
+      dto.setGrantTypes(metadata.getGrantTypes()
         .stream()
         .map(GrantType::getValue)
         .map(AuthorizationGrantType::fromGrantType)
         .collect(Collectors.toSet()));
     } else {
-      dtoClient.setGrantTypes(Set.of(AuthorizationGrantType.CODE));
+      dto.setGrantTypes(Set.of(AuthorizationGrantType.CODE));
     }
+  }
+
+  private void setRedirectUris(RegisteredClientDTO dto, OIDCClientMetadata metadata) {
     if (metadata.getRedirectionURIs() == null || metadata.getRedirectionURIs().isEmpty()) {
       throw new InvalidClientMetadataException("invalid_redirect_uri",
           "Missing redirect uris from RP Entity Statement");
     }
-    dtoClient.setRedirectUris(
+    dto.setRedirectUris(
         metadata.getRedirectionURIs().stream().map(URI::toString).collect(Collectors.toSet()));
+  }
+
+  private void setResponseTypes(RegisteredClientDTO dto, OIDCClientMetadata metadata) {
     Set<String> supportedResponseTypes =
         Set.of(ResponseType.CODE.toString(), ResponseType.TOKEN.toString());
     if (metadata.getResponseTypes() != null) {
@@ -120,34 +141,41 @@ public class FederationRegistrationController {
         throw new InvalidClientMetadataException(INVALID_CLIENT_METADATA,
             "Unsupported response type");
       }
-      dtoClient.setResponseTypes(responseTypes);
+      dto.setResponseTypes(responseTypes);
     } else {
-      dtoClient.setResponseTypes(Set.of(OAuthResponseType.CODE));
+      dto.setResponseTypes(Set.of(OAuthResponseType.CODE));
     }
+  }
+
+  private void setTokenEndpointAuthMethod(RegisteredClientDTO dto, OIDCClientMetadata metadata) {
     if (metadata.getTokenEndpointAuthMethod() != null) {
-      dtoClient.setTokenEndpointAuthMethod(TokenEndpointAuthenticationMethod
+      dto.setTokenEndpointAuthMethod(TokenEndpointAuthenticationMethod
         .valueOf(metadata.getTokenEndpointAuthMethod().getValue()));
     } else {
-      dtoClient.setTokenEndpointAuthMethod(TokenEndpointAuthenticationMethod.client_secret_basic);
+      dto.setTokenEndpointAuthMethod(TokenEndpointAuthenticationMethod.client_secret_basic);
     }
+  }
+
+  private void setScope(RegisteredClientDTO dto, OIDCClientMetadata metadata) {
     if (metadata.getScope() != null) {
-      dtoClient.setScope(metadata.getScope().toStringList().stream().collect(Collectors.toSet()));
+      dto.setScope(metadata.getScope().toStringList().stream().collect(Collectors.toSet()));
     } else {
-      dtoClient.setScope(Set.of("openid"));
+      dto.setScope(Set.of("openid"));
     }
+  }
+
+  private void setEntityId(RegisteredClientDTO dto, EntityStatement rpRequest) {
     if (rpRequest.getEntityID() == null) {
       throw new InvalidClientMetadataException(INVALID_CLIENT_METADATA, "Missing RP Entity ID");
     }
-    dtoClient.setEntityId(rpRequest.getEntityID().getValue());
-
-    return dtoClient;
+    dto.setEntityId(rpRequest.getEntityID().getValue());
   }
 
   @PostMapping(value = "/iam/api/oid-fed/client-registration",
       consumes = "application/entity-statement+jwt",
       produces = "application/explicit-registration-response+jwt")
   public ResponseEntity<String> register(@RequestBody String requestJwt)
-      throws ParseException, JOSEException, InvalidClientMetadataException {
+      throws ParseException, JOSEException {
 
     // 1. Parse request Entity Statement (self-signed EC of the RP)
     EntityStatement rpRequest;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/openid_federation/FederationRegistrationController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/openid_federation/FederationRegistrationController.java
@@ -119,7 +119,7 @@ public class FederationRegistrationController {
   }
 
   private void setRedirectUris(RegisteredClientDTO dto, OIDCClientMetadata metadata) {
-    if (metadata.getRedirectionURIs() == null || metadata.getRedirectionURIs().isEmpty()) {
+    if (metadata.getRedirectionURIs() == null) {
       throw new InvalidClientMetadataException("invalid_redirect_uri",
           "Missing redirect uris from RP Entity Statement");
     }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/openid_federation/FederationRegistrationController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/openid_federation/FederationRegistrationController.java
@@ -38,7 +38,6 @@ import com.nimbusds.jose.JOSEException;
 import com.nimbusds.oauth2.sdk.GrantType;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.openid.connect.sdk.federation.entities.EntityStatement;
-import com.nimbusds.openid.connect.sdk.federation.trust.InvalidEntityMetadataException;
 import com.nimbusds.openid.connect.sdk.federation.trust.TrustChain;
 import com.nimbusds.openid.connect.sdk.rp.OIDCClientMetadata;
 
@@ -50,6 +49,7 @@ import it.infn.mw.iam.api.common.client.OAuthResponseType;
 import it.infn.mw.iam.api.common.client.RegisteredClientDTO;
 import it.infn.mw.iam.api.common.client.TokenEndpointAuthenticationMethod;
 import it.infn.mw.iam.core.oidc.FederationError;
+import it.infn.mw.iam.core.oidc.InvalidClientMetadataException;
 import it.infn.mw.iam.core.oidc.InvalidTrustChainException;
 import it.infn.mw.iam.core.oidc.TrustChainService;
 import it.infn.mw.iam.persistence.repository.client.IamClientRepository;
@@ -57,6 +57,8 @@ import it.infn.mw.iam.persistence.repository.client.IamClientRepository;
 @RestController
 @Profile("openid-federation")
 public class FederationRegistrationController {
+
+  private static final String INVALID_CLIENT_METADATA = "invalid_client_metadata";
 
   @Value("${iam.issuer}")
   private String issuer;
@@ -79,7 +81,7 @@ public class FederationRegistrationController {
   }
 
   private RegisteredClientDTO createClientDtoFromRpMetadata(EntityStatement rpRequest)
-      throws InvalidEntityMetadataException {
+      throws InvalidClientMetadataException {
     RegisteredClientDTO dtoClient = new RegisteredClientDTO();
     OIDCClientMetadata metadata = rpRequest.getClaimsSet().getRPMetadata();
     if (metadata.getName() != null) {
@@ -100,16 +102,23 @@ public class FederationRegistrationController {
       dtoClient.setGrantTypes(Set.of(AuthorizationGrantType.CODE));
     }
     if (metadata.getRedirectionURIs() == null || metadata.getRedirectionURIs().isEmpty()) {
-      throw new InvalidEntityMetadataException("Missing redirect uris from RP Entity Statement");
+      throw new InvalidClientMetadataException("invalid_redirect_uri",
+          "Missing redirect uris from RP Entity Statement");
     }
     dtoClient.setRedirectUris(
         metadata.getRedirectionURIs().stream().map(URI::toString).collect(Collectors.toSet()));
     if (metadata.getResponseTypes() != null) {
-      dtoClient.setResponseTypes(metadata.getResponseTypes()
+      Set<OAuthResponseType> responseTypes = metadata.getResponseTypes()
         .stream()
         .map(ResponseType::toString)
+        .filter(rt -> !rt.equals(ResponseType.IDTOKEN.toString()))
         .map(OAuthResponseType::fromResponseType)
-        .collect(Collectors.toSet()));
+        .collect(Collectors.toSet());
+      if (responseTypes.isEmpty()) {
+        throw new InvalidClientMetadataException(INVALID_CLIENT_METADATA,
+            "Unsupported response type: id_token");
+      }
+      dtoClient.setResponseTypes(responseTypes);
     } else {
       dtoClient.setResponseTypes(Set.of(OAuthResponseType.CODE));
     }
@@ -125,7 +134,7 @@ public class FederationRegistrationController {
       dtoClient.setScope(Set.of("openid"));
     }
     if (rpRequest.getEntityID() == null) {
-      throw new InvalidEntityMetadataException("Missing RP Entity ID");
+      throw new InvalidClientMetadataException(INVALID_CLIENT_METADATA, "Missing RP Entity ID");
     }
     dtoClient.setEntityId(rpRequest.getEntityID().getValue());
 
@@ -136,7 +145,7 @@ public class FederationRegistrationController {
       consumes = "application/entity-statement+jwt",
       produces = "application/explicit-registration-response+jwt")
   public ResponseEntity<String> register(@RequestBody String requestJwt)
-      throws ParseException, JOSEException, InvalidEntityMetadataException {
+      throws ParseException, JOSEException, InvalidClientMetadataException {
 
     // 1. Parse request Entity Statement (self-signed EC of the RP)
     EntityStatement rpRequest;
@@ -179,7 +188,7 @@ public class FederationRegistrationController {
   }
 
   @ResponseStatus(HttpStatus.BAD_REQUEST)
-  @ExceptionHandler({ParseException.class, InvalidEntityMetadataException.class})
+  @ExceptionHandler(ParseException.class)
   public ErrorDTO badRequestError(Exception ex) {
     return ErrorDTO.fromString(ex.getMessage());
   }
@@ -193,6 +202,12 @@ public class FederationRegistrationController {
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   @ExceptionHandler(InvalidTrustChainException.class)
   public FederationError handleTrustChainException(InvalidTrustChainException e) {
+    return new FederationError(e.getErrorCode(), e.getMessage());
+  }
+
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(InvalidClientMetadataException.class)
+  public FederationError handleClientMetadataException(InvalidClientMetadataException e) {
     return new FederationError(e.getErrorCode(), e.getMessage());
   }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/openid_federation/FederationRegistrationController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/openid_federation/FederationRegistrationController.java
@@ -107,16 +107,18 @@ public class FederationRegistrationController {
     }
     dtoClient.setRedirectUris(
         metadata.getRedirectionURIs().stream().map(URI::toString).collect(Collectors.toSet()));
+    Set<String> supportedResponseTypes =
+        Set.of(ResponseType.CODE.toString(), ResponseType.TOKEN.toString());
     if (metadata.getResponseTypes() != null) {
       Set<OAuthResponseType> responseTypes = metadata.getResponseTypes()
         .stream()
         .map(ResponseType::toString)
-        .filter(rt -> !rt.equals(ResponseType.IDTOKEN.toString()))
+        .filter(supportedResponseTypes::contains)
         .map(OAuthResponseType::fromResponseType)
         .collect(Collectors.toSet());
       if (responseTypes.isEmpty()) {
         throw new InvalidClientMetadataException(INVALID_CLIENT_METADATA,
-            "Unsupported response type: id_token");
+            "Unsupported response type");
       }
       dtoClient.setResponseTypes(responseTypes);
     } else {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oidc/InvalidClientMetadataException.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oidc/InvalidClientMetadataException.java
@@ -25,11 +25,6 @@ public class InvalidClientMetadataException extends RuntimeException {
     this.errorCode = errorCode;
   }
 
-  public InvalidClientMetadataException(String errorCode, String message, Throwable cause) {
-    super(message, cause);
-    this.errorCode = errorCode;
-  }
-
   public String getErrorCode() {
     return errorCode;
   }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oidc/InvalidClientMetadataException.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oidc/InvalidClientMetadataException.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.core.oidc;
+
+public class InvalidClientMetadataException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+  private final String errorCode;
+
+  public InvalidClientMetadataException(String errorCode, String message) {
+    super(message);
+    this.errorCode = errorCode;
+  }
+
+  public InvalidClientMetadataException(String errorCode, String message, Throwable cause) {
+    super(message, cause);
+    this.errorCode = errorCode;
+  }
+
+  public String getErrorCode() {
+    return errorCode;
+  }
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/openid_federation/FederationRegistrationControllerTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/openid_federation/FederationRegistrationControllerTests.java
@@ -28,6 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.net.URI;
 import java.util.Date;
 import java.util.Optional;
 import java.util.Set;
@@ -63,6 +64,7 @@ public class FederationRegistrationControllerTests {
   private static final String IAM_OIDFED_CLIENT_REGISTRATION_ENDPOINT =
       "/iam/api/oid-fed/client-registration";
   private static final String IAM_CLIENT_API_URL = "/iam/api/clients/";
+  private static final URI REDIRECT_URI = URI.create("https://rp.example/callback");
 
   @Autowired
   private MockMvc mvc;
@@ -86,7 +88,7 @@ public class FederationRegistrationControllerTests {
 
   @Test
   public void testSuccessfullExplicitClientRegistration() throws Exception {
-    fakeChain = TrustChainTestFactory.createRpToTaChain(issuer, null);
+    fakeChain = TrustChainTestFactory.createRpToTaChain(issuer, null, REDIRECT_URI);
     EntityStatement rpEC = fakeChain.getLeafSelfStatement();
     String rpJwt = rpEC.getSignedStatement().serialize();
 
@@ -104,7 +106,7 @@ public class FederationRegistrationControllerTests {
   @Test
   public void testResponseTypesAreFiltered() throws Exception {
     fakeChain = TrustChainTestFactory.createRpToTaChain(issuer,
-        Set.of(ResponseType.CODE_IDTOKEN, ResponseType.CODE));
+        Set.of(ResponseType.CODE_IDTOKEN, ResponseType.CODE), REDIRECT_URI);
     EntityStatement rpEC = fakeChain.getLeafSelfStatement();
     String rpJwt = rpEC.getSignedStatement().serialize();
 
@@ -121,7 +123,8 @@ public class FederationRegistrationControllerTests {
 
   @Test
   public void testUnsupportedResponseTypeError() throws Exception {
-    fakeChain = TrustChainTestFactory.createRpToTaChain(issuer, Set.of(ResponseType.IDTOKEN));
+    fakeChain =
+        TrustChainTestFactory.createRpToTaChain(issuer, Set.of(ResponseType.IDTOKEN), REDIRECT_URI);
     EntityStatement rpEC = fakeChain.getLeafSelfStatement();
     String rpJwt = rpEC.getSignedStatement().serialize();
 
@@ -138,10 +141,29 @@ public class FederationRegistrationControllerTests {
   }
 
   @Test
+  public void testMissingRedirectUriCausesError() throws Exception {
+    fakeChain = TrustChainTestFactory.createRpToTaChain(issuer, null, null);
+    EntityStatement rpEC = fakeChain.getLeafSelfStatement();
+    String rpJwt = rpEC.getSignedStatement().serialize();
+
+    when(trustChainService.validateFromEntityConfiguration(any())).thenReturn(fakeChain);
+
+    mvc
+      .perform(post(IAM_OIDFED_CLIENT_REGISTRATION_ENDPOINT)
+        .contentType("application/entity-statement+jwt")
+        .content(rpJwt))
+      .andDo(print())
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.error", equalTo("invalid_redirect_uri")))
+      .andExpect(jsonPath("$.error_description",
+          equalTo("Missing redirect uris from RP Entity Statement")));
+  }
+
+  @Test
   @WithMockOAuthUser(user = "admin", scopes = "iam:admin.write")
   public void testRelyingPartyClientUpdateThroughApiClientsEndpointReturnsException()
       throws Exception {
-    fakeChain = TrustChainTestFactory.createRpToTaChain(issuer, null);
+    fakeChain = TrustChainTestFactory.createRpToTaChain(issuer, null, REDIRECT_URI);
     EntityStatement rpEC = fakeChain.getLeafSelfStatement();
     String rpJwt = rpEC.getSignedStatement().serialize();
 
@@ -168,7 +190,8 @@ public class FederationRegistrationControllerTests {
 
   @Test
   public void testInvalidAudienceDuringRegistration() throws Exception {
-    fakeChain = TrustChainTestFactory.createRpToTaChain("http://wrong-audience", null);
+    fakeChain =
+        TrustChainTestFactory.createRpToTaChain("http://wrong-audience", null, REDIRECT_URI);
     EntityStatement rpEC = fakeChain.getLeafSelfStatement();
     String rpJwt = rpEC.getSignedStatement().serialize();
 
@@ -186,7 +209,7 @@ public class FederationRegistrationControllerTests {
 
   @Test
   public void testClientDisabledWhenExpired() throws Exception {
-    fakeChain = TrustChainTestFactory.createRpToTaChain(null, null);
+    fakeChain = TrustChainTestFactory.createRpToTaChain(null, null, REDIRECT_URI);
     Optional<ClientDetailsEntity> client = clientRepo.findByClientId("client-cred");
     assertTrue(client.isPresent());
 
@@ -213,7 +236,7 @@ public class FederationRegistrationControllerTests {
 
   @Test
   public void testClientDeletedAndRecreatedWhenAlreadyExists() throws Exception {
-    fakeChain = TrustChainTestFactory.createRpToTaChain(issuer, null);
+    fakeChain = TrustChainTestFactory.createRpToTaChain(issuer, null, REDIRECT_URI);
     EntityStatement rpEC = fakeChain.getLeafSelfStatement();
     String rpJwt = rpEC.getSignedStatement().serialize();
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/openid_federation/FederationRegistrationControllerTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/openid_federation/FederationRegistrationControllerTests.java
@@ -44,6 +44,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.openid.connect.sdk.federation.entities.EntityStatement;
 import com.nimbusds.openid.connect.sdk.federation.trust.TrustChain;
 
@@ -85,7 +86,7 @@ public class FederationRegistrationControllerTests {
 
   @Test
   public void testSuccessfullExplicitClientRegistration() throws Exception {
-    fakeChain = TrustChainTestFactory.createRpToTaChain(issuer);
+    fakeChain = TrustChainTestFactory.createRpToTaChain(issuer, null);
     EntityStatement rpEC = fakeChain.getLeafSelfStatement();
     String rpJwt = rpEC.getSignedStatement().serialize();
 
@@ -101,10 +102,46 @@ public class FederationRegistrationControllerTests {
   }
 
   @Test
+  public void testResponseTypesAreFiltered() throws Exception {
+    fakeChain = TrustChainTestFactory.createRpToTaChain(issuer,
+        Set.of(ResponseType.CODE_IDTOKEN, ResponseType.CODE));
+    EntityStatement rpEC = fakeChain.getLeafSelfStatement();
+    String rpJwt = rpEC.getSignedStatement().serialize();
+
+    when(trustChainService.validateFromEntityConfiguration(any())).thenReturn(fakeChain);
+
+    mvc
+      .perform(post(IAM_OIDFED_CLIENT_REGISTRATION_ENDPOINT)
+        .contentType("application/entity-statement+jwt")
+        .content(rpJwt))
+      .andDo(print())
+      .andExpect(status().isOk())
+      .andExpect(content().contentType("application/explicit-registration-response+jwt"));
+  }
+
+  @Test
+  public void testUnsupportedResponseTypeError() throws Exception {
+    fakeChain = TrustChainTestFactory.createRpToTaChain(issuer, Set.of(ResponseType.IDTOKEN));
+    EntityStatement rpEC = fakeChain.getLeafSelfStatement();
+    String rpJwt = rpEC.getSignedStatement().serialize();
+
+    when(trustChainService.validateFromEntityConfiguration(any())).thenReturn(fakeChain);
+
+    mvc
+      .perform(post(IAM_OIDFED_CLIENT_REGISTRATION_ENDPOINT)
+        .contentType("application/entity-statement+jwt")
+        .content(rpJwt))
+      .andDo(print())
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.error", equalTo("invalid_client_metadata")))
+      .andExpect(jsonPath("$.error_description", equalTo("Unsupported response type")));
+  }
+
+  @Test
   @WithMockOAuthUser(user = "admin", scopes = "iam:admin.write")
   public void testRelyingPartyClientUpdateThroughApiClientsEndpointReturnsException()
       throws Exception {
-    fakeChain = TrustChainTestFactory.createRpToTaChain(issuer);
+    fakeChain = TrustChainTestFactory.createRpToTaChain(issuer, null);
     EntityStatement rpEC = fakeChain.getLeafSelfStatement();
     String rpJwt = rpEC.getSignedStatement().serialize();
 
@@ -131,7 +168,7 @@ public class FederationRegistrationControllerTests {
 
   @Test
   public void testInvalidAudienceDuringRegistration() throws Exception {
-    fakeChain = TrustChainTestFactory.createRpToTaChain("http://wrong-audience");
+    fakeChain = TrustChainTestFactory.createRpToTaChain("http://wrong-audience", null);
     EntityStatement rpEC = fakeChain.getLeafSelfStatement();
     String rpJwt = rpEC.getSignedStatement().serialize();
 
@@ -149,7 +186,7 @@ public class FederationRegistrationControllerTests {
 
   @Test
   public void testClientDisabledWhenExpired() throws Exception {
-    fakeChain = TrustChainTestFactory.createRpToTaChain(null);
+    fakeChain = TrustChainTestFactory.createRpToTaChain(null, null);
     Optional<ClientDetailsEntity> client = clientRepo.findByClientId("client-cred");
     assertTrue(client.isPresent());
 
@@ -176,7 +213,7 @@ public class FederationRegistrationControllerTests {
 
   @Test
   public void testClientDeletedAndRecreatedWhenAlreadyExists() throws Exception {
-    fakeChain = TrustChainTestFactory.createRpToTaChain(issuer);
+    fakeChain = TrustChainTestFactory.createRpToTaChain(issuer, null);
     EntityStatement rpEC = fakeChain.getLeafSelfStatement();
     String rpJwt = rpEC.getSignedStatement().serialize();
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/openid_federation/TrustChainServiceTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/openid_federation/TrustChainServiceTests.java
@@ -79,7 +79,7 @@ public class TrustChainServiceTests {
   }
 
   private void mockRpToTaChain(boolean taTrusted) throws Exception {
-    fakeChain = TrustChainTestFactory.createRpToTaChain(null);
+    fakeChain = TrustChainTestFactory.createRpToTaChain(null, null);
     EntityStatement rpEC = fakeChain.getLeafSelfStatement();
     String rpJwt = rpEC.getSignedStatement().serialize();
 
@@ -203,7 +203,7 @@ public class TrustChainServiceTests {
         null);
     String taEcJwt = taEC.getSignedStatement().serialize();
 
-    TrustChain shorterChain = TrustChainTestFactory.createRpToTaChain(null);
+    TrustChain shorterChain = TrustChainTestFactory.createRpToTaChain(null, null);
     TrustChain longerChain =
         TrustChainTestFactory.createRpToIntermediateToTaChain("https://ta.example");
 
@@ -278,7 +278,7 @@ public class TrustChainServiceTests {
         null);
     String untrustedTaEcJwt = untrustedTaEC.getSignedStatement().serialize();
 
-    TrustChain shorterChain = TrustChainTestFactory.createRpToTaChain(null);
+    TrustChain shorterChain = TrustChainTestFactory.createRpToTaChain(null, null);
     TrustChain longerChain =
         TrustChainTestFactory.createRpToIntermediateToTaChain("https://ta1.example");
 
@@ -409,7 +409,7 @@ public class TrustChainServiceTests {
 
   @Test(expected = InvalidTrustChainException.class)
   public void testMissingFetchEndpoint() throws JOSEException {
-    fakeChain = TrustChainTestFactory.createRpToTaChain(null);
+    fakeChain = TrustChainTestFactory.createRpToTaChain(null, null);
     EntityStatement rpEC = fakeChain.getLeafSelfStatement();
     String rpJwt = rpEC.getSignedStatement().serialize();
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/openid_federation/TrustChainServiceTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/openid_federation/TrustChainServiceTests.java
@@ -79,7 +79,7 @@ public class TrustChainServiceTests {
   }
 
   private void mockRpToTaChain(boolean taTrusted) throws Exception {
-    fakeChain = TrustChainTestFactory.createRpToTaChain(null, null);
+    fakeChain = TrustChainTestFactory.createRpToTaChain(null, null, null);
     EntityStatement rpEC = fakeChain.getLeafSelfStatement();
     String rpJwt = rpEC.getSignedStatement().serialize();
 
@@ -203,7 +203,7 @@ public class TrustChainServiceTests {
         null);
     String taEcJwt = taEC.getSignedStatement().serialize();
 
-    TrustChain shorterChain = TrustChainTestFactory.createRpToTaChain(null, null);
+    TrustChain shorterChain = TrustChainTestFactory.createRpToTaChain(null, null, null);
     TrustChain longerChain =
         TrustChainTestFactory.createRpToIntermediateToTaChain("https://ta.example");
 
@@ -278,7 +278,7 @@ public class TrustChainServiceTests {
         null);
     String untrustedTaEcJwt = untrustedTaEC.getSignedStatement().serialize();
 
-    TrustChain shorterChain = TrustChainTestFactory.createRpToTaChain(null, null);
+    TrustChain shorterChain = TrustChainTestFactory.createRpToTaChain(null, null, null);
     TrustChain longerChain =
         TrustChainTestFactory.createRpToIntermediateToTaChain("https://ta1.example");
 
@@ -409,7 +409,7 @@ public class TrustChainServiceTests {
 
   @Test(expected = InvalidTrustChainException.class)
   public void testMissingFetchEndpoint() throws JOSEException {
-    fakeChain = TrustChainTestFactory.createRpToTaChain(null, null);
+    fakeChain = TrustChainTestFactory.createRpToTaChain(null, null, null);
     EntityStatement rpEC = fakeChain.getLeafSelfStatement();
     String rpJwt = rpEC.getSignedStatement().serialize();
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/openid_federation/TrustChainTestFactory.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/openid_federation/TrustChainTestFactory.java
@@ -94,7 +94,8 @@ public class TrustChainTestFactory {
   }
 
   /** Minimum Trust Chain: RP → TA */
-  public static TrustChain createRpToTaChain(String aud) throws JOSEException {
+  public static TrustChain createRpToTaChain(String aud, Set<ResponseType> responseTypes)
+      throws JOSEException {
     Date now = new Date();
     Date exp = new Date(now.getTime() + 600000);
 
@@ -106,7 +107,7 @@ public class TrustChainTestFactory {
     clientMetadata.setRedirectionURI(URI.create(rp + "/callback"));
     clientMetadata.setName("Relying Party");
     clientMetadata.setClientRegistrationTypes(List.of(ClientRegistrationType.EXPLICIT));
-    clientMetadata.setResponseTypes(Set.of(ResponseType.IDTOKEN, ResponseType.CODE));
+    clientMetadata.setResponseTypes(responseTypes);
     EntityStatement rpEC =
         selfEC(rp, now, exp, List.of(new EntityID(ta)), null, clientMetadata, aud);
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/openid_federation/TrustChainTestFactory.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/openid_federation/TrustChainTestFactory.java
@@ -27,6 +27,7 @@ import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.oauth2.sdk.GrantType;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.id.Audience;
 import com.nimbusds.openid.connect.sdk.federation.entities.EntityID;
@@ -108,6 +109,8 @@ public class TrustChainTestFactory {
     clientMetadata.setName("Relying Party");
     clientMetadata.setClientRegistrationTypes(List.of(ClientRegistrationType.EXPLICIT));
     clientMetadata.setResponseTypes(responseTypes);
+    clientMetadata.setGrantTypes(Set.of(GrantType.AUTHORIZATION_CODE));
+    clientMetadata.setEmailContacts(List.of("iam-support@example.it"));
     EntityStatement rpEC =
         selfEC(rp, now, exp, List.of(new EntityID(ta)), null, clientMetadata, aud);
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/openid_federation/TrustChainTestFactory.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/openid_federation/TrustChainTestFactory.java
@@ -20,12 +20,14 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.id.Audience;
 import com.nimbusds.openid.connect.sdk.federation.entities.EntityID;
 import com.nimbusds.openid.connect.sdk.federation.entities.EntityStatement;
@@ -104,6 +106,7 @@ public class TrustChainTestFactory {
     clientMetadata.setRedirectionURI(URI.create(rp + "/callback"));
     clientMetadata.setName("Relying Party");
     clientMetadata.setClientRegistrationTypes(List.of(ClientRegistrationType.EXPLICIT));
+    clientMetadata.setResponseTypes(Set.of(ResponseType.IDTOKEN, ResponseType.CODE));
     EntityStatement rpEC =
         selfEC(rp, now, exp, List.of(new EntityID(ta)), null, clientMetadata, aud);
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/openid_federation/TrustChainTestFactory.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/openid_federation/TrustChainTestFactory.java
@@ -95,8 +95,8 @@ public class TrustChainTestFactory {
   }
 
   /** Minimum Trust Chain: RP → TA */
-  public static TrustChain createRpToTaChain(String aud, Set<ResponseType> responseTypes)
-      throws JOSEException {
+  public static TrustChain createRpToTaChain(String aud, Set<ResponseType> responseTypes,
+      URI redirectUri) throws JOSEException {
     Date now = new Date();
     Date exp = new Date(now.getTime() + 600000);
 
@@ -105,7 +105,7 @@ public class TrustChainTestFactory {
 
     // RP self EC with authority_hint = TA
     OIDCClientMetadata clientMetadata = new OIDCClientMetadata();
-    clientMetadata.setRedirectionURI(URI.create(rp + "/callback"));
+    clientMetadata.setRedirectionURI(redirectUri);
     clientMetadata.setName("Relying Party");
     clientMetadata.setClientRegistrationTypes(List.of(ClientRegistrationType.EXPLICIT));
     clientMetadata.setResponseTypes(responseTypes);


### PR DESCRIPTION
IAM supports only `code` and `token` response types.
If the client requests one or both of these response types and, for example, `id_token`, `id_token` (not supported) is filtered out. If, on the other hand, the client requests only one or more unsupported response types, an error occurs.
```
"error":"invalid_client_metadata","error_description":"Unsupported response type"
```