### PR TITLE
Remove client_secret  from fetch client data

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/client/AccountClientController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/client/AccountClientController.java
@@ -15,8 +15,6 @@
  */
 package it.infn.mw.iam.api.account.client;
 
-import static it.infn.mw.iam.api.utils.ValidationErrorUtils.handleValidationError;
-
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
@@ -31,6 +29,7 @@ import it.infn.mw.iam.api.common.ClientViews;
 import it.infn.mw.iam.api.common.ListResponseDTO;
 import it.infn.mw.iam.api.common.client.RegisteredClientDTO;
 import it.infn.mw.iam.api.common.form.PaginatedRequestForm;
+import static it.infn.mw.iam.api.utils.ValidationErrorUtils.handleValidationError;
 
 @RestController
 public class AccountClientController {
@@ -43,7 +42,7 @@ public class AccountClientController {
     this.clientSearchService = clientSearchService;
   }
 
-  @JsonView(ClientViews.Limited.class)
+  @JsonView(ClientViews.NoSecretManagementRegistration.class)
   @PreAuthorize("hasRole('USER')")
   @GetMapping("/iam/account/me/clients")
   public ListResponseDTO<RegisteredClientDTO> getOwnedClients(@Validated PaginatedRequestForm form,
@@ -53,7 +52,7 @@ public class AccountClientController {
     return clientSearchService.findOwnedClients(form);
   }
 
-  @JsonView(ClientViews.Limited.class)
+  @JsonView(ClientViews.NoSecretManagementRegistration.class)
   @PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isUser(#id)")
   @GetMapping("/iam/account/{id}/clients")
   public ListResponseDTO<RegisteredClientDTO> getClientsOwnedByAccount(@PathVariable("id") String id,

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/management/ClientManagementAPIController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/management/ClientManagementAPIController.java
@@ -206,7 +206,7 @@ public class ClientManagementAPIController {
 
   @PostMapping("/{clientId}/secret")
   @ResponseStatus(CREATED)
-  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN') or #iam.isClientOwner(#clientId)")
   public RegisteredClientDTO rotateClientSecret(@PathVariable String clientId) {
     return managementService.generateNewClientSecret(clientId);
   }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/management/ClientManagementAPIController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/management/ClientManagementAPIController.java
@@ -15,11 +15,6 @@
  */
 package it.infn.mw.iam.api.client.management;
 
-import static it.infn.mw.iam.api.client.util.ClientSuppliers.clientNotFound;
-import static it.infn.mw.iam.api.common.PagingUtils.buildPageRequest;
-import static org.springframework.http.HttpStatus.CREATED;
-import static org.springframework.http.HttpStatus.NO_CONTENT;
-
 import java.text.ParseException;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
@@ -31,6 +26,8 @@ import org.mitre.oauth2.model.ClientDetailsEntity;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 import org.springframework.http.converter.json.MappingJacksonValue;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.oauth2.common.exceptions.InvalidRequestException;
@@ -55,10 +52,12 @@ import it.infn.mw.iam.api.client.error.NoSuchClient;
 import it.infn.mw.iam.api.client.management.service.ClientManagementService;
 import it.infn.mw.iam.api.client.service.ClientService;
 import it.infn.mw.iam.api.client.util.ClientSuppliers;
+import static it.infn.mw.iam.api.client.util.ClientSuppliers.clientNotFound;
 import it.infn.mw.iam.api.common.ClientViews;
 import it.infn.mw.iam.api.common.ErrorDTO;
 import it.infn.mw.iam.api.common.ListResponseDTO;
 import it.infn.mw.iam.api.common.PagingUtils;
+import static it.infn.mw.iam.api.common.PagingUtils.buildPageRequest;
 import it.infn.mw.iam.api.common.client.RegisteredClientDTO;
 import it.infn.mw.iam.api.scim.model.ScimUser;
 import it.infn.mw.iam.core.oauth.revocation.TokenRevocationService;
@@ -97,7 +96,7 @@ public class ClientManagementAPIController {
     return managementService.saveNewClient(client);
   }
 
-  @JsonView({ClientViews.ClientManagement.class})
+  @JsonView({ClientViews.NoSecretManagementRegistration.class})
   @GetMapping
   @PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public ListResponseDTO<RegisteredClientDTO> retrieveClients(
@@ -113,7 +112,7 @@ public class ClientManagementAPIController {
     }
   }
 
-  @JsonView({ClientViews.ClientManagement.class})
+  @JsonView({ClientViews.NoSecretManagementRegistration.class})
   @GetMapping("/{clientId}")
   @PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public RegisteredClientDTO retrieveClient(@PathVariable String clientId) {
@@ -123,6 +122,7 @@ public class ClientManagementAPIController {
 
   @GetMapping("/{clientId}/owners")
   @PreAuthorize("#iam.hasScope('iam:admin.read') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @JsonView({ClientViews.NoSecretManagementRegistration.class})
   public ListResponseDTO<ScimUser> retrieveClientOwners(@PathVariable String clientId,
       @RequestParam final Optional<Integer> count,
       @RequestParam final Optional<Integer> startIndex) {
@@ -140,6 +140,7 @@ public class ClientManagementAPIController {
 
   @PostMapping("/{clientId}/rat")
   @ResponseStatus(CREATED)
+  @JsonView({ClientViews.NoSecretManagementRegistration.class})
   @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
   public RegisteredClientDTO rotateRegistrationAccessToken(@PathVariable String clientId) {
     return managementService.rotateRegistrationAccessToken(clientId);
@@ -155,6 +156,7 @@ public class ClientManagementAPIController {
 
   @PutMapping("/{clientId}")
   @PreAuthorize("#iam.hasScope('iam:admin.write') or #iam.hasDashboardRole('ROLE_ADMIN')")
+  @JsonView({ClientViews.NoSecretManagementRegistration.class})
   public RegisteredClientDTO updateClient(@PathVariable String clientId,
       @RequestBody RegisteredClientDTO client) throws ParseException {
     return managementService.updateClient(clientId, client);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/registration/ClientRegistrationApiController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/registration/ClientRegistrationApiController.java
@@ -15,15 +15,14 @@
  */
 package it.infn.mw.iam.api.client.registration;
 
-import static org.springframework.http.HttpStatus.CREATED;
-import static org.springframework.http.HttpStatus.NO_CONTENT;
-
 import java.text.ParseException;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.ConstraintViolationException;
 
 import org.springframework.http.HttpStatus;
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -69,7 +68,7 @@ public class ClientRegistrationApiController {
 
   }
 
-  @JsonView({ClientViews.DynamicRegistration.class})
+  @JsonView({ClientViews.NoSecretDynamicRegistration.class})
   @GetMapping("/{clientId}")
   public RegisteredClientDTO retrieveClient(@PathVariable String clientId,
       Authentication authentication) {
@@ -78,7 +77,7 @@ public class ClientRegistrationApiController {
   }
 
   @PutMapping("/{clientId}")
-  @JsonView({ClientViews.DynamicRegistration.class})
+  @JsonView({ClientViews.NoSecretDynamicRegistration.class})
   public RegisteredClientDTO updateClient(@PathVariable String clientId,
       @RequestBody RegisteredClientDTO request, Authentication authentication)
       throws ParseException {
@@ -94,7 +93,7 @@ public class ClientRegistrationApiController {
 
 
   @PostMapping("/{clientId}/redeem")
-  @JsonView({ClientViews.DynamicRegistration.class})
+  @JsonView({ClientViews.NoSecretDynamicRegistration.class})
   public RegisteredClientDTO redeemClient(@PathVariable String clientId,
       @RequestBody String registrationAccessToken, Authentication authentication) {
     return service.redeemClient(clientId, registrationAccessToken, authentication);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/registration/service/DefaultClientRegistrationService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/registration/service/DefaultClientRegistrationService.java
@@ -15,20 +15,15 @@
  */
 package it.infn.mw.iam.api.client.registration.service;
 
-import static it.infn.mw.iam.api.client.util.ClientSuppliers.clientNotFound;
-import static it.infn.mw.iam.config.client_registration.ClientRegistrationProperties.ClientRegistrationAuthorizationPolicy.ADMINISTRATORS;
-import static it.infn.mw.iam.config.client_registration.ClientRegistrationProperties.ClientRegistrationAuthorizationPolicy.ANYONE;
-import static it.infn.mw.iam.config.client_registration.ClientRegistrationProperties.ClientRegistrationAuthorizationPolicy.REGISTERED_USERS;
-import static java.util.Objects.isNull;
-import static java.util.stream.Collectors.toSet;
-
 import java.text.ParseException;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.EnumSet;
+import static java.util.Objects.isNull;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
+import static java.util.stream.Collectors.toSet;
 
 import javax.validation.constraints.NotBlank;
 
@@ -55,6 +50,7 @@ import it.infn.mw.iam.api.client.registration.validation.OnDynamicClientUpdate;
 import it.infn.mw.iam.api.client.service.ClientConverter;
 import it.infn.mw.iam.api.client.service.ClientDefaultsService;
 import it.infn.mw.iam.api.client.service.ClientService;
+import static it.infn.mw.iam.api.client.util.ClientSuppliers.clientNotFound;
 import it.infn.mw.iam.api.common.client.AuthorizationGrantType;
 import it.infn.mw.iam.api.common.client.RegisteredClientDTO;
 import it.infn.mw.iam.audit.events.account.client.AccountClientOwnerAssigned;
@@ -64,6 +60,9 @@ import it.infn.mw.iam.audit.events.client.ClientRemovedEvent;
 import it.infn.mw.iam.audit.events.client.ClientUpdatedEvent;
 import it.infn.mw.iam.config.client_registration.ClientRegistrationProperties;
 import it.infn.mw.iam.config.client_registration.ClientRegistrationProperties.ClientRegistrationAuthorizationPolicy;
+import static it.infn.mw.iam.config.client_registration.ClientRegistrationProperties.ClientRegistrationAuthorizationPolicy.ADMINISTRATORS;
+import static it.infn.mw.iam.config.client_registration.ClientRegistrationProperties.ClientRegistrationAuthorizationPolicy.ANYONE;
+import static it.infn.mw.iam.config.client_registration.ClientRegistrationProperties.ClientRegistrationAuthorizationPolicy.REGISTERED_USERS;
 import it.infn.mw.iam.core.IamTokenService;
 import it.infn.mw.iam.core.oauth.scope.matchers.ScopeMatcher;
 import it.infn.mw.iam.core.oauth.scope.matchers.ScopeMatcherRegistry;
@@ -450,6 +449,8 @@ public class DefaultClientRegistrationService implements ClientRegistrationServi
     newClient.setCreatedAt(oldClient.getCreatedAt());
     newClient.setReuseRefreshToken(oldClient.isReuseRefreshToken());
     newClient.setActive(oldClient.isActive());
+    // Direct updates are disabled. Changes must be made via secret reset process
+    newClient.setClientSecret(oldClient.getClientSecret());
 
     if (registrationProperties.isAdminOnlyCustomScopes() && !accountUtils.isAdmin(authentication)) {
       removeCustomScopes(newClient);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/common/ClientViews.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/common/ClientViews.java
@@ -17,31 +17,28 @@ package it.infn.mw.iam.api.common;
 
 /**
  * Markers class used for JSON serialization
- * 
  */
-public class ClientViews {
+public final class ClientViews {
 
   private ClientViews() {
     // prevent instantiation
   }
 
-  public static class Limited {
+  public interface Limited {
   }
 
-  public static class Full extends Limited {
+  public interface Full extends Limited {
   }
 
-  public static class DynamicRegistration {
-
+  public interface DynamicRegistration {
   }
 
-  public static class ClientManagement extends DynamicRegistration {
-
+  public interface ClientManagement extends DynamicRegistration {
   }
 
-  public static class NoSecretDynamicRegistration {
+  public interface NoSecretDynamicRegistration {
   }
 
-  public static class NoSecretManagementRegistration extends NoSecretDynamicRegistration{
+  public interface NoSecretManagementRegistration extends NoSecretDynamicRegistration {
   }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/common/ClientViews.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/common/ClientViews.java
@@ -39,4 +39,9 @@ public class ClientViews {
 
   }
 
+  public static class NoSecretDynamicRegistration {
+  }
+
+  public static class NoSecretManagementRegistration extends NoSecretDynamicRegistration{
+  }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/common/ListResponseDTO.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/common/ListResponseDTO.java
@@ -31,8 +31,7 @@ import com.google.common.collect.Lists;
 
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonView(value = {ClientViews.Full.class, ClientViews.Limited.class,
-    ClientViews.ClientManagement.class, ClientViews.DynamicRegistration.class})
+@JsonView(value = {ClientViews.NoSecretDynamicRegistration.class})
 public class ListResponseDTO<T> {
 
   private final Long totalResults;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/common/client/RegisteredClientDTO.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/common/client/RegisteredClientDTO.java
@@ -73,7 +73,8 @@ public class RegisteredClientDTO {
       groups = OnDynamicClientRegistration.class)
   @ClientIdAvailable(groups = OnClientCreation.class)
   @JsonView({ClientViews.Limited.class, ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
+      ClientViews.NoSecretManagementRegistration.class})
   private String clientId;
 
   @Null(message = "must be null in client registration requests",
@@ -90,7 +91,8 @@ public class RegisteredClientDTO {
   @NotBlank(groups = {OnDynamicClientRegistration.class, OnClientCreation.class},
       message = "should not be blank")
   @JsonView({ClientViews.Limited.class, ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
+      ClientViews.NoSecretManagementRegistration.class})
   private String clientName;
 
   @Size(max = 1024,
@@ -98,12 +100,14 @@ public class RegisteredClientDTO {
           OnClientCreation.class, OnClientUpdate.class},
       message = "Invalid ength: must be at most 1024 characters")
   @JsonView({ClientViews.Limited.class, ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
+      ClientViews.NoSecretManagementRegistration.class})
   private String clientDescription;
 
   @Valid
   @JsonView({ClientViews.Limited.class, ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
+      ClientViews.NoSecretManagementRegistration.class})
   private Set<@RedirectURI(message = "not a valid URL",
       groups = {OnDynamicClientRegistration.class, OnDynamicClientUpdate.class,
           OnClientCreation.class, OnClientUpdate.class}) String> redirectUris;
@@ -114,7 +118,8 @@ public class RegisteredClientDTO {
   @URL(groups = {OnDynamicClientRegistration.class, OnDynamicClientUpdate.class,
       OnClientCreation.class, OnClientUpdate.class})
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
+      ClientViews.NoSecretManagementRegistration.class})
   private String clientUri;
 
   @Size(max = 2048,
@@ -123,22 +128,26 @@ public class RegisteredClientDTO {
   @URL(groups = {OnDynamicClientRegistration.class, OnDynamicClientUpdate.class,
       OnClientCreation.class, OnClientUpdate.class})
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
+      ClientViews.NoSecretManagementRegistration.class})
   private String tosUri;
 
   @Valid
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
+      ClientViews.NoSecretManagementRegistration.class})
   private Set<@Email(groups = {OnDynamicClientRegistration.class, OnDynamicClientUpdate.class,
       OnClientCreation.class, OnClientUpdate.class}) String> contacts;
 
   @NotEmpty(message = "Invalid client: empty grant type")
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
+      ClientViews.NoSecretManagementRegistration.class})
   private Set<AuthorizationGrantType> grantTypes;
 
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+    ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
+    ClientViews.NoSecretManagementRegistration.class})
   private Set<OAuthResponseType> responseTypes;
 
   @Size(max = 2048,
@@ -147,7 +156,8 @@ public class RegisteredClientDTO {
   @URL(groups = {OnDynamicClientRegistration.class, OnDynamicClientUpdate.class,
       OnClientCreation.class, OnClientUpdate.class})
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
+      ClientViews.NoSecretManagementRegistration.class})
   private String policyUri;
 
   @Size(max = 2048,
@@ -156,11 +166,13 @@ public class RegisteredClientDTO {
   @URL(groups = {OnDynamicClientRegistration.class, OnDynamicClientUpdate.class,
       OnClientCreation.class, OnClientUpdate.class})
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
+      ClientViews.NoSecretManagementRegistration.class})
   private String jwksUri;
 
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
+      ClientViews.NoSecretManagementRegistration.class})
   private TokenEndpointAuthenticationMethod tokenEndpointAuthMethod;
 
   @Valid
@@ -170,7 +182,8 @@ public class RegisteredClientDTO {
   @JsonSerialize(using = CollectionAsStringSerializer.class)
   @JsonDeserialize(using = StringAsSetOfStringsDeserializer.class)
   @JsonView({ClientViews.Limited.class, ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
+      ClientViews.NoSecretManagementRegistration.class})
   private Set<@NotBlank(
       groups = {OnDynamicClientRegistration.class, OnDynamicClientUpdate.class,
           OnClientCreation.class, OnClientUpdate.class},
@@ -180,86 +193,94 @@ public class RegisteredClientDTO {
               OnClientCreation.class, OnClientUpdate.class}) String> scope = Sets.newHashSet();
 
   @Min(value = 0, groups = OnClientCreation.class)
-  @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class})
+  @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
+      ClientViews.NoSecretManagementRegistration.class})
   private Integer accessTokenValiditySeconds;
 
   @Min(value = 0, groups = OnClientCreation.class)
-  @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class})
+  @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
+      ClientViews.NoSecretManagementRegistration.class})
   private Integer refreshTokenValiditySeconds;
 
   @Min(value = 0, groups = OnClientCreation.class)
-  @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class})
+  @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
+      ClientViews.NoSecretManagementRegistration.class})
   private Integer idTokenValiditySeconds;
 
   @Min(value = 0, groups = OnClientCreation.class)
-  @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class})
+  @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
+      ClientViews.NoSecretManagementRegistration.class})
   private Integer deviceCodeValiditySeconds;
 
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
+      ClientViews.NoSecretManagementRegistration.class})
   private Integer defaultMaxAge;
 
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
+      ClientViews.NoSecretManagementRegistration.class})
   private boolean reuseRefreshToken;
 
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
+      ClientViews.NoSecretManagementRegistration.class})
   private boolean dynamicallyRegistered;
 
-  @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class})
+  @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
+      ClientViews.NoSecretManagementRegistration.class})
   private boolean allowIntrospection;
 
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private boolean clearAccessTokensOnRefresh;
 
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private boolean requireAuthTime;
 
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private String registrationAccessToken;
 
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private String registrationClientUri;
 
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private Date clientSecretExpiresAt;
 
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private Date clientIdIssuedAt;
 
   @JsonView({ClientViews.Limited.class, ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private Date createdAt;
 
   @JsonView({ClientViews.Limited.class, ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   @JsonFormat(shape = JsonFormat.Shape.STRING)
   private LocalDate lastUsed;
 
   @JsonView({ClientViews.Limited.class, ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   @JsonFormat(shape = JsonFormat.Shape.STRING)
   private Date expiration;
 
   @JsonView({ClientViews.Limited.class, ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   @JsonFormat(shape = JsonFormat.Shape.STRING)
   private String entityId;
 
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   @Size(max = 2048, groups = {OnClientCreation.class, OnClientUpdate.class})
   private String jwk;
 
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   @Pattern(regexp = "^$|none|plain|S256",
       message = "must be either an empty string, none, plain or S256",
       groups = {OnClientCreation.class, OnClientUpdate.class, OnDynamicClientRegistration.class,
@@ -267,15 +288,15 @@ public class RegisteredClientDTO {
   private String codeChallengeMethod;
 
   @JsonView({ClientViews.Limited.class, ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private boolean active;
 
   @JsonView({ClientViews.Limited.class, ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private Date statusChangedOn;
 
   @JsonView({ClientViews.Limited.class, ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.DynamicRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private String statusChangedBy;
 
   public String getClientId() {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/common/client/RegisteredClientDTO.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/common/client/RegisteredClientDTO.java
@@ -59,8 +59,6 @@ import it.infn.mw.iam.api.common.ClientViews;
     OnDynamicClientRegistration.class, OnDynamicClientUpdate.class})
 @ValidTokenEndpointAuthMethod(groups = {OnClientCreation.class, OnClientUpdate.class,
     OnDynamicClientRegistration.class, OnDynamicClientUpdate.class})
-@JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-    ClientViews.DynamicRegistration.class})
 /**
  * 
  * This DTO is an annotation mess!
@@ -72,9 +70,8 @@ public class RegisteredClientDTO {
   @Null(message = "must be null in client registration requests",
       groups = OnDynamicClientRegistration.class)
   @ClientIdAvailable(groups = OnClientCreation.class)
-  @JsonView({ClientViews.Limited.class, ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
-      ClientViews.NoSecretManagementRegistration.class})
+  @JsonView({ClientViews.Limited.class, ClientViews.ClientManagement.class,
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private String clientId;
 
   @Null(message = "must be null in client registration requests",
@@ -90,24 +87,21 @@ public class RegisteredClientDTO {
       message = "Invalid length: must be between 4 and 256 characters")
   @NotBlank(groups = {OnDynamicClientRegistration.class, OnClientCreation.class},
       message = "should not be blank")
-  @JsonView({ClientViews.Limited.class, ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
-      ClientViews.NoSecretManagementRegistration.class})
+  @JsonView({ClientViews.Limited.class, ClientViews.ClientManagement.class,
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private String clientName;
 
   @Size(max = 1024,
       groups = {OnDynamicClientRegistration.class, OnDynamicClientUpdate.class,
           OnClientCreation.class, OnClientUpdate.class},
       message = "Invalid ength: must be at most 1024 characters")
-  @JsonView({ClientViews.Limited.class, ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
-      ClientViews.NoSecretManagementRegistration.class})
+  @JsonView({ClientViews.Limited.class, ClientViews.ClientManagement.class,
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private String clientDescription;
 
   @Valid
-  @JsonView({ClientViews.Limited.class, ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
-      ClientViews.NoSecretManagementRegistration.class})
+  @JsonView({ClientViews.Limited.class, ClientViews.ClientManagement.class,
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private Set<@RedirectURI(message = "not a valid URL",
       groups = {OnDynamicClientRegistration.class, OnDynamicClientUpdate.class,
           OnClientCreation.class, OnClientUpdate.class}) String> redirectUris;
@@ -118,8 +112,7 @@ public class RegisteredClientDTO {
   @URL(groups = {OnDynamicClientRegistration.class, OnDynamicClientUpdate.class,
       OnClientCreation.class, OnClientUpdate.class})
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
-      ClientViews.NoSecretManagementRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private String clientUri;
 
   @Size(max = 2048,
@@ -128,26 +121,22 @@ public class RegisteredClientDTO {
   @URL(groups = {OnDynamicClientRegistration.class, OnDynamicClientUpdate.class,
       OnClientCreation.class, OnClientUpdate.class})
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
-      ClientViews.NoSecretManagementRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private String tosUri;
 
   @Valid
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
-      ClientViews.NoSecretManagementRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private Set<@Email(groups = {OnDynamicClientRegistration.class, OnDynamicClientUpdate.class,
       OnClientCreation.class, OnClientUpdate.class}) String> contacts;
 
   @NotEmpty(message = "Invalid client: empty grant type")
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
-      ClientViews.NoSecretManagementRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private Set<AuthorizationGrantType> grantTypes;
 
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-    ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
-    ClientViews.NoSecretManagementRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private Set<OAuthResponseType> responseTypes;
 
   @Size(max = 2048,
@@ -156,8 +145,7 @@ public class RegisteredClientDTO {
   @URL(groups = {OnDynamicClientRegistration.class, OnDynamicClientUpdate.class,
       OnClientCreation.class, OnClientUpdate.class})
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
-      ClientViews.NoSecretManagementRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private String policyUri;
 
   @Size(max = 2048,
@@ -166,13 +154,11 @@ public class RegisteredClientDTO {
   @URL(groups = {OnDynamicClientRegistration.class, OnDynamicClientUpdate.class,
       OnClientCreation.class, OnClientUpdate.class})
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
-      ClientViews.NoSecretManagementRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private String jwksUri;
 
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
-      ClientViews.NoSecretManagementRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private TokenEndpointAuthenticationMethod tokenEndpointAuthMethod;
 
   @Valid
@@ -181,9 +167,8 @@ public class RegisteredClientDTO {
           OnClientCreation.class, OnClientUpdate.class})
   @JsonSerialize(using = CollectionAsStringSerializer.class)
   @JsonDeserialize(using = StringAsSetOfStringsDeserializer.class)
-  @JsonView({ClientViews.Limited.class, ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
-      ClientViews.NoSecretManagementRegistration.class})
+  @JsonView({ClientViews.Limited.class, ClientViews.ClientManagement.class,
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private Set<@NotBlank(
       groups = {OnDynamicClientRegistration.class, OnDynamicClientUpdate.class,
           OnClientCreation.class, OnClientUpdate.class},
@@ -213,18 +198,15 @@ public class RegisteredClientDTO {
   private Integer deviceCodeValiditySeconds;
 
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
-      ClientViews.NoSecretManagementRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private Integer defaultMaxAge;
 
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
-      ClientViews.NoSecretManagementRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private boolean reuseRefreshToken;
 
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
-      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class,
-      ClientViews.NoSecretManagementRegistration.class})
+      ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private boolean dynamicallyRegistered;
 
   @JsonView({ClientViews.Full.class, ClientViews.ClientManagement.class,
@@ -255,21 +237,21 @@ public class RegisteredClientDTO {
       ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private Date clientIdIssuedAt;
 
-  @JsonView({ClientViews.Limited.class, ClientViews.Full.class, ClientViews.ClientManagement.class,
+  @JsonView({ClientViews.Limited.class, ClientViews.ClientManagement.class,
       ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private Date createdAt;
 
-  @JsonView({ClientViews.Limited.class, ClientViews.Full.class, ClientViews.ClientManagement.class,
+  @JsonView({ClientViews.Limited.class, ClientViews.ClientManagement.class,
       ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   @JsonFormat(shape = JsonFormat.Shape.STRING)
   private LocalDate lastUsed;
 
-  @JsonView({ClientViews.Limited.class, ClientViews.Full.class, ClientViews.ClientManagement.class,
+  @JsonView({ClientViews.Limited.class, ClientViews.ClientManagement.class,
       ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   @JsonFormat(shape = JsonFormat.Shape.STRING)
   private Date expiration;
 
-  @JsonView({ClientViews.Limited.class, ClientViews.Full.class, ClientViews.ClientManagement.class,
+  @JsonView({ClientViews.Limited.class, ClientViews.ClientManagement.class,
       ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   @JsonFormat(shape = JsonFormat.Shape.STRING)
   private String entityId;
@@ -287,15 +269,15 @@ public class RegisteredClientDTO {
           OnDynamicClientUpdate.class})
   private String codeChallengeMethod;
 
-  @JsonView({ClientViews.Limited.class, ClientViews.Full.class, ClientViews.ClientManagement.class,
+  @JsonView({ClientViews.Limited.class, ClientViews.ClientManagement.class,
       ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private boolean active;
 
-  @JsonView({ClientViews.Limited.class, ClientViews.Full.class, ClientViews.ClientManagement.class,
+  @JsonView({ClientViews.Limited.class, ClientViews.ClientManagement.class,
       ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private Date statusChangedOn;
 
-  @JsonView({ClientViews.Limited.class, ClientViews.Full.class, ClientViews.ClientManagement.class,
+  @JsonView({ClientViews.Limited.class, ClientViews.ClientManagement.class,
       ClientViews.NoSecretDynamicRegistration.class, ClientViews.DynamicRegistration.class})
   private String statusChangedBy;
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/expression/IamMethodSecurityExpressionHandler.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/expression/IamMethodSecurityExpressionHandler.java
@@ -24,6 +24,8 @@ import org.springframework.stereotype.Component;
 import it.infn.mw.iam.api.account.AccountUtils;
 import it.infn.mw.iam.api.requests.GroupRequestUtils;
 import it.infn.mw.iam.core.userinfo.OAuth2AuthenticationScopeResolver;
+import it.infn.mw.iam.persistence.repository.client.IamAccountClientRepository;
+import it.infn.mw.iam.persistence.repository.client.IamClientRepository;
 
 @SuppressWarnings("deprecation")
 @Component
@@ -32,12 +34,17 @@ public class IamMethodSecurityExpressionHandler extends OAuth2MethodSecurityExpr
   private final AccountUtils accountUtils;
   private final GroupRequestUtils groupRequestUtils;
   private final OAuth2AuthenticationScopeResolver scopeResolver;
+  private final IamAccountClientRepository accountClientRepo;
+  private final IamClientRepository clientRepo;
 
   public IamMethodSecurityExpressionHandler(AccountUtils accountUtils,
-      GroupRequestUtils groupRequestUtils, OAuth2AuthenticationScopeResolver scopeResolver) {
+      GroupRequestUtils groupRequestUtils, OAuth2AuthenticationScopeResolver scopeResolver,
+      IamAccountClientRepository accountClientRepo, IamClientRepository clientRepo) {
     this.accountUtils = accountUtils;
     this.groupRequestUtils = groupRequestUtils;
     this.scopeResolver = scopeResolver;
+    this.accountClientRepo = accountClientRepo;
+    this.clientRepo = clientRepo;
   }
 
   @Override
@@ -46,7 +53,7 @@ public class IamMethodSecurityExpressionHandler extends OAuth2MethodSecurityExpr
 
     StandardEvaluationContext ec = super.createEvaluationContextInternal(authentication, mi);
     ec.setVariable("iam", new IamSecurityExpressionMethods(authentication, accountUtils,
-        groupRequestUtils, scopeResolver));
+        groupRequestUtils, scopeResolver, accountClientRepo, clientRepo));
     return ec;
   }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/expression/IamSecurityExpressionMethods.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/expression/IamSecurityExpressionMethods.java
@@ -20,6 +20,7 @@ import static it.infn.mw.iam.authn.ExternalAuthenticationHandlerSupport.EXT_AUTH
 import java.util.Collection;
 import java.util.Optional;
 
+import org.mitre.oauth2.model.ClientDetailsEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
@@ -31,6 +32,8 @@ import it.infn.mw.iam.core.IamGroupRequestStatus;
 import it.infn.mw.iam.core.userinfo.OAuth2AuthenticationScopeResolver;
 import it.infn.mw.iam.persistence.model.IamAccount;
 import it.infn.mw.iam.persistence.model.IamGroupRequest;
+import it.infn.mw.iam.persistence.repository.client.IamAccountClientRepository;
+import it.infn.mw.iam.persistence.repository.client.IamClientRepository;
 
 @SuppressWarnings("deprecation")
 public class IamSecurityExpressionMethods {
@@ -42,13 +45,18 @@ public class IamSecurityExpressionMethods {
   private final AccountUtils accountUtils;
   private final GroupRequestUtils groupRequestUtils;
   private final OAuth2AuthenticationScopeResolver scopeResolver;
+  private final IamAccountClientRepository accountClientRepo;
+  private final IamClientRepository clientRepo;
 
   public IamSecurityExpressionMethods(Authentication authentication, AccountUtils accountUtils,
-      GroupRequestUtils groupRequestUtils, OAuth2AuthenticationScopeResolver scopeResolver) {
+      GroupRequestUtils groupRequestUtils, OAuth2AuthenticationScopeResolver scopeResolver,
+      IamAccountClientRepository accountClientRepo, IamClientRepository clientRepo) {
     this.authentication = authentication;
     this.accountUtils = accountUtils;
     this.groupRequestUtils = groupRequestUtils;
     this.scopeResolver = scopeResolver;
+    this.accountClientRepo = accountClientRepo;
+    this.clientRepo = clientRepo;
   }
 
   public boolean isExternallyAuthenticatedWithIssuer(String issuer) {
@@ -152,5 +160,11 @@ public class IamSecurityExpressionMethods {
 
   public boolean hasAdminOrGMDashboardRoleOfGroup(String gid) {
     return (hasDashboardRole(Role.ROLE_ADMIN) || isGroupManager(gid));
+  }
+
+  public boolean isClientOwner(String clientId) {
+    Optional<IamAccount> owner = accountUtils.getAuthenticatedUserAccount();
+    Optional<ClientDetailsEntity> client = clientRepo.findByClientId(clientId);
+    return owner.isPresent() && client.isPresent() && accountClientRepo.findByAccountAndClient(owner.get(), client.get()).isPresent();
   }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/expression/IamWebSecurityExpressionHandler.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/expression/IamWebSecurityExpressionHandler.java
@@ -24,6 +24,8 @@ import org.springframework.stereotype.Component;
 import it.infn.mw.iam.api.account.AccountUtils;
 import it.infn.mw.iam.api.requests.GroupRequestUtils;
 import it.infn.mw.iam.core.userinfo.OAuth2AuthenticationScopeResolver;
+import it.infn.mw.iam.persistence.repository.client.IamAccountClientRepository;
+import it.infn.mw.iam.persistence.repository.client.IamClientRepository;
 
 @SuppressWarnings("deprecation")
 @Component
@@ -32,12 +34,17 @@ public class IamWebSecurityExpressionHandler extends OAuth2WebSecurityExpression
   private final AccountUtils accountUtils;
   private final GroupRequestUtils groupRequestUtils;
   private final OAuth2AuthenticationScopeResolver scopeResolver;
+  private final IamAccountClientRepository accountClientRepo;
+  private final IamClientRepository clientRepo;
 
   public IamWebSecurityExpressionHandler(AccountUtils accountUtils,
-      GroupRequestUtils groupRequestUtils, OAuth2AuthenticationScopeResolver scopeResolver) {
+      GroupRequestUtils groupRequestUtils, OAuth2AuthenticationScopeResolver scopeResolver,
+      IamAccountClientRepository accountClientRepo, IamClientRepository clientRepo) {
     this.accountUtils = accountUtils;
     this.groupRequestUtils = groupRequestUtils;
     this.scopeResolver = scopeResolver;
+    this.accountClientRepo = accountClientRepo;
+    this.clientRepo = clientRepo;
   }
 
   @Override
@@ -47,7 +54,7 @@ public class IamWebSecurityExpressionHandler extends OAuth2WebSecurityExpression
     StandardEvaluationContext ec =
         super.createEvaluationContextInternal(authentication, invocation);
     ec.setVariable("iam", new IamSecurityExpressionMethods(authentication, accountUtils,
-        groupRequestUtils, scopeResolver));
+        groupRequestUtils, scopeResolver, accountClientRepo, clientRepo));
     return ec;
   }
 

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/clientauth/clientauth.component.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/clientauth/clientauth.component.html
@@ -56,7 +56,6 @@
             </label>
         </div>
     </div>
-    <hr>
     <clientsecret client="$ctrl.client" new-client="$ctrl.newClient" limited="{{$ctrl.limited}}"></clientsecret>
     <hr>
     <div class="form-group">

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/clientsecret/clientsecret.component.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/clientsecret/clientsecret.component.html
@@ -15,52 +15,20 @@
     limitations under the License.
 
 -->
-<div ng-if="$ctrl.client.token_endpoint_auth_method != 'none'">
-    <div class="form-group">
-        <label for="client_secret">Client
-            secret</label>
-
-        <div class="input-group" ng-if="!$ctrl.newClient">
-            <span class="input-group-btn" ng-if="!$ctrl.showSecret">
-                <button class="btn btn-default" type="button" ng-click="$ctrl.toggleSecretVisibility()">
-                    <i class="fa fa-eye"></i>
-                </button>
-            </span>
-            <span class="input-group-btn" ng-if="$ctrl.showSecret">
-                <button class="btn btn-default" type="button" ngclipboard data-clipboard-target="#client_secret"
-                    ngclipboard-success="$ctrl.clipboardSuccess(e, 'secret');"
-                    ngclipboard-error="$ctrl.clipboardError(e);" alt="Copy secret to clipboard">
-                    <i class="fa fa-clipboard"></i>
-                </button>
-            </span>
-            <input type="password" value="################" ng-if="!$ctrl.showSecret" class="form-control" readonly>
-            <input type="text" id="client_secret" ng-model="$ctrl.client.client_secret" ng-if="$ctrl.showSecret"
-                class="form-control" readonly>
-        </div>
-        <p class="help-block" ng-if="$ctrl.newClient">
-            The secret will be generated when the client is saved.
-        </p>
-    </div>
-    <div ng-if="!$ctrl.newClient && !$ctrl.isLimited()">
-        <button class=" btn btn-primary" ng-click="$ctrl.rotateClientSecret()">Regenerate client secret</button>
-    </div>
-</div>
-
-<div ng-if="$ctrl.client.token_endpoint_auth_method == 'none'">
-    <div class="form-group">
-        <label for="client_secret">Client secret</label>
-        <p class="help-block">
-            Not defined.
-        </p>
-    </div>
-</div>
-
-<div class="form-group" ng-if="!$ctrl.newClient && !$ctrl.isLimited()">
+<div ng-if="!$ctrl.newClient && $ctrl.client.token_endpoint_auth_method != 'none'">
     <hr>
+    <div>
+        <button class=" btn btn-primary" ng-click="$ctrl.openModalRequestClientSecret()">
+            Regenerate client secret
+        </button>
+    </div>
+    <hr>
+</div>
+
+<div class="form-group" ng-if="!$ctrl.newClient">
     <label>Registration access token</label>
     <p class="help-block" ng-if="!$ctrl.newClient">
-        Registration access token provides management access to the
-        client.
+        Registration access token provides management access to the client.
     </p>
 
     <div ng-if="$ctrl.client.registration_access_token &&
@@ -82,5 +50,27 @@
 </div>
 
 <button class="btn btn-primary" ng-click="$ctrl.rotateClientRat()"
-    ng-if="!$ctrl.newClient && !$ctrl.isLimited()">Regenerate registration
-    access token</button>
+    ng-if="!$ctrl.newClient && !$ctrl.isLimited()">Regenerate registration access token
+</button>
+
+<div class="modal" id="myModal" tabindex="-1" role="dialog" ng-show="isModalOpen">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3 class="modal-title">Title</h3>
+            </div>
+            <div class="modal-body">
+                <p>Content goes here...</p>
+                <ul>
+                    <li ng-repeat="item in items">
+                        {{ item }}
+                    </li>
+                </ul>
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-primary" type="button" ng-click="ok()">OK</button>
+                <button class="btn btn-warning" type="button" ng-click="cancel()">Cancel</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/clientsecret/clientsecret.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/clientsecret/clientsecret.component.js
@@ -16,26 +16,55 @@
 (function () {
     'use strict';
 
-    function ClientSecretController(ModalService, toaster, ClientsService) {
+    function ModalClientSecretController($rootScope, $scope, $uibModal, $uibModalInstance, ClientsService, toaster, client) {
         var self = this;
         self.showSecret = false;
 
-        self.toggleSecretVisibility = toggleSecretVisibility;
         self.clipboardSuccess = clipboardSuccess;
         self.clipboardError = clipboardError;
-        self.rotateClientSecret = rotateClientSecret;
-        self.isLimited = isLimited;
-        self.rotateClientRat = rotateClientRat;
+        self.confirmation = true;
+        self.clientId = client.client_id;
+        self.clientName = client.client_name;
+        self.isNewClient = !!self.clientId;
+        self.parent = parent;
+        self.showSecret = false;
+
+        self.closeModal = function() {
+            self.isModalOpen = false;
+            $uibModalInstance.dismiss('Dismissed');
+        };
+
+        self.closeModal = function() {
+            self.isModalOpen = false;
+            $uibModalInstance.close();
+        };
+
+        self.toggleSecretVisibility = function() {
+            self.showSecret = !self.showSecret;
+        };
+
+        self.confirmRequestNewSecret = function() {
+            self.confirmation = true;
+            ClientsService.rotateClientSecret(client.client_id).then(res => {
+                self.newSecret = res.client_secret;
+                toaster.pop({
+                    type: 'success',
+                    body: 'Registration access token rotated for client ' + self.clientName
+                });
+            }).catch(error => {
+                console.error(error);
+                toaster.pop({
+                    type: 'error',
+                    body: 'Could not rotate secret for client ' + self.clientName
+                });
+            });
+        }
 
         function clipboardError(event) {
             toaster.pop({
                 type: 'error',
                 body: 'Could not copy secret to clipboard!'
             });
-        }
-
-        function isLimited() {
-            return self.limited === 'true' | self.limited;
         }
 
         function clipboardSuccess(event, source) {
@@ -45,12 +74,34 @@
             });
             event.clearSelection();
             if (source === 'secret') {
-                toggleSecretVisibility();
+                self.toggleSecretVisibility();
             }
         }
+        self.confirmRequestNewSecret();
+    }
 
-        function toggleSecretVisibility() {
-            self.showSecret = !self.showSecret;
+    function ClientSecretController($uibModal, toaster, ClientsService) {
+        var self = this;
+        self.isLimited = isLimited;
+        self.rotateClientRat = rotateClientRat;
+
+        self.openModalRequestClientSecret = function() {
+            self.isModalOpen = true;
+            const modalSecret = $uibModal.open({
+                templateUrl: '/resources/iam/apps/dashboard-app/components/clients/client/clientsecret/clientsecret.dialog.html',
+                controller: ModalClientSecretController,
+                controllerAs: '$ctrl',
+                resolve: {
+                    client: function() {
+                        return self.client;
+                    }
+                }
+            });
+            modalSecret.result.then(self.handleSuccess);
+        };
+
+        function isLimited() {
+            return self.limited === 'true' | self.limited;
         }
 
         function rotateClientRat() {
@@ -68,37 +119,6 @@
                     });
                 });
             }
-        }
-
-        function rotateClientSecret() {
-
-            var modalOptions = {
-                closeButtonText: 'Cancel',
-                actionButtonText: 'Confirm Change',
-                headerText: 'Regenerate Client Secret',
-                bodyText:
-                    `Are you sure you want to change the secret of this client: ` + self.client.client_name+ ` ?`
-            };
-
-            ModalService.showModal({}, modalOptions)
-                .then(
-                    function() {
-                        ClientsService.rotateClientSecret(self.client.client_id).then(res => {
-                            self.client = res;
-                            toaster.pop({
-                                type: 'success',
-                                body: 'Secret rotated for client ' + self.client.client_name
-                            });
-                        }).catch(res => {
-                            toaster.pop({
-                                type: 'error',
-                                body: 'Could not rotate secret for client ' + self.client.client_name
-                            });
-                        });
-                    }
-                ).catch(function(error) { 
-                    console.info("Cancel Regenerate Client Secret");
-                });
         }
 
         self.$onInit = function () {
@@ -120,7 +140,7 @@
                 newClient: "<",
                 limited: '@'
             },
-            controller: ['ModalService', 'toaster', 'ClientsService', ClientSecretController],
+            controller: ['$uibModal', 'toaster', 'ClientsService', ClientSecretController],
             controllerAs: '$ctrl'
         };
     }

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/clientsecret/clientsecret.dialog.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/clientsecret/clientsecret.dialog.html
@@ -1,14 +1,19 @@
 <!--
+
     Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
+
         http://www.apache.org/licenses/LICENSE-2.0
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
 -->
 <div class="modal-header">
     <h3 class="modal-title">Regenerate Client Secret</h3>

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/clientsecret/clientsecret.dialog.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/clientsecret/clientsecret.dialog.html
@@ -1,0 +1,44 @@
+<!--
+    Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<div class="modal-header">
+    <h3 class="modal-title">Regenerate Client Secret</h3>
+</div>
+<div class="modal-body">
+    <div class="form-group">
+        <div ng-if="!$ctrl.confirmation">
+            <p>Are you sure you want to change the secret of this client: {{$ctrl.clientName}} ?</p>
+        </div>
+        <div class="input-group" ng-if="$ctrl.confirmation">
+            <span class="input-group-btn" ng-if="!$ctrl.showSecret">
+                <button class="btn btn-default" type="button" ng-click="$ctrl.toggleSecretVisibility()">
+                    <i class="fa fa-eye"></i>
+                </button>
+            </span>
+            <span class="input-group-btn" ng-if="$ctrl.showSecret">
+                <button class="btn btn-default" type="button" ngclipboard data-clipboard-target="#client_secret"
+                    ngclipboard-success="$ctrl.clipboardSuccess(e, 'secret');"
+                    ngclipboard-error="$ctrl.clipboardError(e);" alt="Copy secret to clipboard">
+                    <i class="fa fa-clipboard"></i>
+                </button>
+            </span>
+            <input type="password" value="******" ng-if="!$ctrl.showSecret" class="form-control" readonly>
+            <input type="text" id="client_secret" ng-model="$ctrl.newSecret" ng-if="$ctrl.showSecret"
+                class="form-control" readonly>
+        </div>
+    </div>
+</div>
+<div class="modal-footer">
+    <button class="btn btn-success" type="button" ng-if="!$ctrl.confirmation"
+        ng-click="$ctrl.confirmRequestNewSecret()">Confirm</button>
+    <button class="btn btn-danger" type="button" id="modal-btn-cancel" ng-click="$ctrl.closeModal()">Close</button>
+</div>

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/newclientsecretshow/clientsecretview.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/newclientsecretshow/clientsecretview.component.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+(function () {
+    'use strict';
+
+    function ClientSecretViewController($uibModal, toaster, ClientsService, data) {
+
+        var $ctrl = this;
+
+        $ctrl.data = data;
+        $ctrl.newClient = !!data.client.clientSecret;
+        $ctrl.client = data.client
+
+        self.clipboardSuccess = clipboardSuccess;
+        self.clipboardError = clipboardError;
+
+        $ctrl.ok = function () {
+            $uibModalInstance.close($ctrl.selected);
+        };
+
+        $ctrl.closeModal = function () {
+            $uibModalInstance.dismiss('cancel');
+        };
+
+        function clipboardError(event) {
+            toaster.pop({
+                type: 'error',
+                body: 'Could not copy secret to clipboard!'
+            });
+        }
+
+        function clipboardSuccess(event, source) {
+            toaster.pop({
+                type: 'success',
+                body: 'Secret copied to clipboard!'
+            });
+            event.clearSelection();
+            if (source === 'secret') {
+                toggleSecretVisibility();
+            }
+        }
+    };
+
+    angular.module('dashboardApp')
+        .component('ClientSecretView', ClientSecretView());
+
+    function ClientSecretView() {
+        return {
+            templateUrl: "/resources/iam/apps/dashboard-app/components/clients/client/newclientsecretshow/clientsecretview.component.html",
+            bindings: {
+                client: "=",
+                newClient: "<",
+                limited: '@'
+            },
+            controller: ['$uibModal', 'toaster', 'ClientsService', 'data', ClientSecretViewController],
+            controllerAs: '$ctrl'
+        };
+    }
+}());

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/newclientsecretshow/newclientsecretshow.component.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/newclientsecretshow/newclientsecretshow.component.html
@@ -1,16 +1,20 @@
 <!--
+
     Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
+
         http://www.apache.org/licenses/LICENSE-2.0
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
--->
 
+-->
 <div class="modal-header">
     <h3 class="modal-title">{{ $ctrl.data.title }}</h3>
 </div>

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/newclientsecretshow/newclientsecretshow.component.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/newclientsecretshow/newclientsecretshow.component.html
@@ -1,0 +1,58 @@
+<!--
+    Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<div class="modal-header">
+    <h3 class="modal-title">{{ $ctrl.data.title }}</h3>
+</div>
+<div class="modal-body">
+    <p>{{ $ctrl.data.message }}</p>
+    <p>client secret</p>
+    <div ng-if="$ctrl.client.registration_access_token && !$ctrl.isLimited()">
+        <div class="input-group">
+            <span class="input-group-btn">
+                <button class="btn btn-default" type="button" ngclipboard data-clipboard-target="#rat"
+                    ngclipboard-success="$ctrl.clipboardSuccess(e);" ngclipboard-error="$ctrl.clipboardError(e);"
+                    alt="Copy registration access token to clipboard">
+                    <i class="fa fa-clipboard"></i>
+                </button>
+            </span>
+            <input type="text" id="rat" ng-model="$ctrl.client.registration_access_token" class="form-control" readonly>
+        </div>
+    </div>
+
+    <div class="input-group" ng-if="$ctrl.confirmation">
+        <span class="input-group-btn" ng-if="!$ctrl.showSecret">
+            <button class="btn btn-default" type="button" ng-click="$ctrl.toggleSecretVisibility()">
+                <i class="fa fa-eye"></i>
+            </button>
+        </span>
+        <span class="input-group-btn" ng-if="$ctrl.showSecret">
+            <button class="btn btn-default" type="button" ngclipboard data-clipboard-target="#client_secret"
+                ngclipboard-success="$ctrl.clipboardSuccess(e, 'secret');" ngclipboard-error="$ctrl.clipboardError(e);"
+                alt="Copy secret to clipboard">
+                <i class="fa fa-clipboard"></i>
+            </button>
+        </span>
+        <input type="password" value="******" ng-if="!$ctrl.showSecret" class="form-control" readonly>
+        <input type="text" id="client_secret" ng-model="$ctrl.secret" ng-if="$ctrl.showSecret" class="form-control"
+            readonly>
+    </div>
+    </br>
+    <p>client id</p>
+    <div>
+        <input type="text" id="client_id" ng-model="$ctrl.clientId" class="form-control" readonly>
+    </div>
+    <div class="modal-footer">
+        <button class="btn btn-primary" type="button" ng-click="$ctrl.ok()">Confirm</button>
+    </div>
+</div>

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/myclients/myclient/myclient.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/myclients/myclient/myclient.component.js
@@ -16,6 +16,50 @@
 (function () {
     'use strict';
 
+    function ClientSecretViewController($uibModal, $uibModalInstance, toaster, ClientsService, data) {
+        var $ctrl = this;
+        $ctrl.data = data;
+        $ctrl.isNewClient = data.isNewClient;
+        $ctrl.newClient = data.client;
+        $ctrl.secret = $ctrl.newClient.client_secret;
+        $ctrl.clientId = $ctrl.newClient.client_id;
+        $ctrl.showSecret = false;
+        $ctrl.confirmation = true;
+
+        self.clipboardSuccess = clipboardSuccess;
+        self.clipboardError = clipboardError;
+
+        $ctrl.ok = function () {
+            $uibModalInstance.close($ctrl.selected);
+        };
+
+        $ctrl.closeModal = function () {
+            $uibModalInstance.dismiss('cancel');
+        };
+
+        $ctrl.toggleSecretVisibility = function () {
+            $ctrl.showSecret = !$ctrl.showSecret;
+        };
+
+        function clipboardError(event) {
+            toaster.pop({
+                type: 'error',
+                body: 'Could not copy secret to clipboard!'
+            });
+        }
+
+        function clipboardSuccess(event, source) {
+            toaster.pop({
+                type: 'success',
+                body: 'Secret copied to clipboard!'
+            });
+            event.clearSelection();
+            if (source === 'secret') {
+                $ctrl.toggleSecretVisibility();
+            }
+        }
+    };
+
     function MyClientController($location, ClientRegistrationService, toaster, $uibModal) {
         var self = this;
 
@@ -54,7 +98,26 @@
                 type: 'success',
                 body: 'Client saved!'
             });
-            return res;
+
+            () => {
+                const modalInstance = $uibModal.open({
+                    templateUrl: 'clientsecret-view.content.html',
+                    controller: 'ModalClientSecretViewController',
+                    resolve: {
+                        data: function () {
+                            return {
+                                title: '',
+                                message: '',
+                                clientDetail: res,
+                            };
+                        }
+                    }
+                });
+
+                modalInstance.result.then(function (selectedItem) {
+                    $ctrl.selected = selectedItem;
+                });
+            };
         }
 
         function handleError(res) {
@@ -74,7 +137,35 @@
         function registerClient() {
             return ClientRegistrationService.registerClient(self.clientVal).then(res => {
                 handleSuccess(res);
-                $location.path('/home/clients');
+                const isNewClientPublic = self.clientVal.token_endpoint_auth_method === 'none';
+
+                if (isNewClientPublic) {
+                    $location.path('/home/clients');
+                    return res;
+                }
+
+                const modalSecret = $uibModal.open({
+                    templateUrl: '/resources/iam/apps/dashboard-app/components/clients/client/newclientsecretshow/newclientsecretshow.component.html',
+                    controller: ClientSecretViewController,
+                    controllerAs: '$ctrl',
+                    resolve: {
+                        data: {
+                            client: res,
+                            title: "New client credential details",
+                            message: "Save this client credential on safe before press Confirm button",
+                            isNewClient: true,
+                        }
+                    }
+                });
+                modalSecret.result
+                    .then(function() { $location.path('/home/clients'); })
+                    .catch(function() {
+                        toaster.pop({
+                            type: 'error',
+                            body: errorMsg
+                        });
+                    });
+
                 return res;
             }).catch(handleError);
         }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/client/RegistrationAccessTokenTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/client/RegistrationAccessTokenTests.java
@@ -15,17 +15,14 @@
  */
 package it.infn.mw.iam.test.api.client;
 
+import java.text.ParseException;
+
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.not;
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-
-import java.text.ParseException;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,6 +30,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTParser;
@@ -110,7 +108,7 @@ public class RegistrationAccessTokenTests extends TestSupport {
       .body()
       .as(RegisteredClientDTO.class);
 
-    assertThat(getResponse.getClientSecret(), is(registerResponse.getClientSecret()));
+    assertThat(getResponse.getClientSecret(), nullValue());
     assertThat(getResponse.getRegistrationAccessToken(), nullValue());
 
     RegisteredClientDTO rotatedRatClient =

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/client/management/ClientManagementAPIControllerTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/client/management/ClientManagementAPIControllerTests.java
@@ -15,54 +15,49 @@
  */
 package it.infn.mw.iam.test.client.management;
 
-import static it.infn.mw.iam.api.common.client.AuthorizationGrantType.CLIENT_CREDENTIALS;
-import static it.infn.mw.iam.api.common.client.TokenEndpointAuthenticationMethod.client_secret_basic;
-import static it.infn.mw.iam.api.common.client.TokenEndpointAuthenticationMethod.none;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertNull;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import org.junit.jupiter.api.Test;
+import org.mitre.oauth2.model.ClientDetailsEntity;
 import static org.mitre.oauth2.model.ClientDetailsEntity.AuthMethod.NONE;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultMatcher;
+import org.springframework.transaction.annotation.Transactional;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.mitre.oauth2.model.ClientDetailsEntity;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultMatcher;
 import org.testcontainers.shaded.com.google.common.collect.Sets;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import it.infn.mw.iam.api.client.service.ClientService;
+import it.infn.mw.iam.IamLoginService;
 import it.infn.mw.iam.api.common.client.AuthorizationGrantType;
+import static it.infn.mw.iam.api.common.client.AuthorizationGrantType.CLIENT_CREDENTIALS;
 import it.infn.mw.iam.api.common.client.RegisteredClientDTO;
 import it.infn.mw.iam.api.common.client.TokenEndpointAuthenticationMethod;
+import static it.infn.mw.iam.api.common.client.TokenEndpointAuthenticationMethod.client_secret_basic;
+import static it.infn.mw.iam.api.common.client.TokenEndpointAuthenticationMethod.none;
 import it.infn.mw.iam.persistence.repository.client.IamClientRepository;
 import it.infn.mw.iam.test.util.WithAnonymousUser;
 import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
-import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 
-
-@RunWith(SpringRunner.class)
 @IamMockMvcIntegrationTest
+@SpringBootTest(classes = {IamLoginService.class})
 class ClientManagementAPIControllerTests {
 
   @Autowired
   private MockMvc mvc;
-
-  @Autowired
-  private MockOAuth2Filter mockOAuth2Filter;
 
   @Autowired
   private ObjectMapper mapper;
@@ -70,27 +65,12 @@ class ClientManagementAPIControllerTests {
   @Autowired
   private IamClientRepository clientRepository;
 
-  @Autowired
-  private ClientService clientService;
-
   public static final String IAM_CLIENTS_API_URL = "/iam/api/clients/";
 
   public static final ResultMatcher UNAUTHORIZED = status().isUnauthorized();
   public static final ResultMatcher BAD_REQUEST = status().isBadRequest();
   public static final ResultMatcher CREATED = status().isCreated();
   public static final ResultMatcher OK = status().isOk();
-
-  @BeforeEach
-  void setup() {
-    mockOAuth2Filter.cleanupSecurityContext();
-  }
-
-  @AfterEach
-  void cleanup() {
-    mockOAuth2Filter.cleanupSecurityContext();
-    clientService.findClientByClientId("test-client-creation")
-      .ifPresent(c -> clientService.deleteClient(c));
-  }
 
   @Test
   @WithAnonymousUser
@@ -110,6 +90,7 @@ class ClientManagementAPIControllerTests {
 
   @Test
   @WithMockUser(username = "admin", roles = "ADMIN")
+  @Transactional
   void updateAuthMethodToNone() throws Exception {
 
     RegisteredClientDTO client = new RegisteredClientDTO();
@@ -132,10 +113,9 @@ class ClientManagementAPIControllerTests {
       .andExpect(OK)
       .andExpect(jsonPath("$.token_endpoint_auth_method", is("none")));
 
-    ClientDetailsEntity clientEntity = clientRepository.findByClientId("test-client-creation").get();
+    ClientDetailsEntity clientEntity =
+        clientRepository.findByClientId("test-client-creation").get();
     assertEquals(NONE, clientEntity.getTokenEndpointAuthMethod());
-    assertNull(clientEntity.getClientSecret());
-
   }
 
   @Test
@@ -162,6 +142,7 @@ class ClientManagementAPIControllerTests {
 
   @Test
   @WithMockUser(username = "admin", roles = "ADMIN")
+  @Transactional
   void createClientRaiseURIValidationException() throws Exception {
 
     final String NOT_A_URI_STRING = "This is not a URI string";
@@ -186,6 +167,7 @@ class ClientManagementAPIControllerTests {
 
   @Test
   @WithMockUser(username = "admin", roles = "ADMIN")
+  @Transactional
   void createClientPrivateJwtValidationException() throws Exception {
 
     final String URI_STRING = "http://localhost:8080/jwk";
@@ -198,13 +180,14 @@ class ClientManagementAPIControllerTests {
     client.setScope(Sets.newHashSet("test"));
     client.setTokenEndpointAuthMethod(TokenEndpointAuthenticationMethod.private_key_jwt);
 
-    String expectedMessage = "saveNewClient.client: private_key_jwt requires a jwks uri or a jwk value";
+    String expectedMessage =
+        "saveNewClient.client: private_key_jwt requires a jwks uri or a jwk value";
 
     mvc
-    .perform(post(IAM_CLIENTS_API_URL).contentType(APPLICATION_JSON)
-      .content(mapper.writeValueAsString(client)))
-    .andExpect(BAD_REQUEST)
-    .andExpect(jsonPath("$.error", is(expectedMessage)));
+      .perform(post(IAM_CLIENTS_API_URL).contentType(APPLICATION_JSON)
+        .content(mapper.writeValueAsString(client)))
+      .andExpect(BAD_REQUEST)
+      .andExpect(jsonPath("$.error", is(expectedMessage)));
 
     client.setJwk(NOT_A_JSON_STRING);
     client.setJwksUri(URI_STRING);
@@ -221,6 +204,7 @@ class ClientManagementAPIControllerTests {
 
   @Test
   @WithMockUser(username = "admin", roles = "ADMIN")
+  @Transactional
   void updateClientPrivateJwtValidationException() throws Exception {
 
     RegisteredClientDTO client = new RegisteredClientDTO();
@@ -230,21 +214,57 @@ class ClientManagementAPIControllerTests {
     client.setScope(Sets.newHashSet("test"));
 
     mvc
-    .perform(post(IAM_CLIENTS_API_URL).contentType(APPLICATION_JSON)
-      .content(mapper.writeValueAsString(client)))
-    .andExpect(CREATED);
+      .perform(post(IAM_CLIENTS_API_URL).contentType(APPLICATION_JSON)
+        .content(mapper.writeValueAsString(client)))
+      .andExpect(CREATED);
 
     client.setTokenEndpointAuthMethod(TokenEndpointAuthenticationMethod.private_key_jwt);
 
-    String expectedMessage = "updateClient.client: private_key_jwt requires a jwks uri or a jwk value";
+    String expectedMessage =
+        "updateClient.client: private_key_jwt requires a jwks uri or a jwk value";
 
     mvc
-    .perform(put(IAM_CLIENTS_API_URL + client.getClientId()).contentType(APPLICATION_JSON)
-      .content(mapper.writeValueAsString(client)))
-    .andExpect(BAD_REQUEST)
-    .andExpect(jsonPath("$.error", is(expectedMessage)));
+      .perform(put(IAM_CLIENTS_API_URL + client.getClientId()).contentType(APPLICATION_JSON)
+        .content(mapper.writeValueAsString(client)))
+      .andExpect(BAD_REQUEST)
+      .andExpect(jsonPath("$.error", is(expectedMessage)));
 
   }
 
+  @Test
+  @WithMockUser(username = "admin", roles = "ADMIN")
+  @Transactional
+  void testReturnClientSecret() throws Exception {
+    String clientPassword = "password";
 
+    RegisteredClientDTO client = new RegisteredClientDTO();
+    client.setClientName("test-client-creation");
+    client.setClientId("test-client-creation");
+    client.setGrantTypes(Sets.newHashSet(AuthorizationGrantType.CLIENT_CREDENTIALS));
+    client.setScope(Sets.newHashSet("test"));
+    client.setClientSecret(clientPassword);
+
+    String responseJson = mvc
+      .perform(post(IAM_CLIENTS_API_URL).contentType(APPLICATION_JSON)
+        .content(mapper.writeValueAsString(client)))
+      .andExpect(CREATED)
+      .andReturn()
+      .getResponse()
+      .getContentAsString();
+
+    client = mapper.readValue(responseJson, RegisteredClientDTO.class);
+    assertNotNull(client.getClientSecret());
+    assertThat(client.getClientSecret().equals(clientPassword), is(true));
+
+    responseJson = mvc
+      .perform(put(IAM_CLIENTS_API_URL + client.getClientId()).contentType(APPLICATION_JSON)
+        .content(mapper.writeValueAsString(client)))
+      .andExpect(OK)
+      .andReturn()
+      .getResponse()
+      .getContentAsString();
+
+    RegisteredClientDTO clientDto = mapper.readValue(responseJson, RegisteredClientDTO.class);
+    assertNull(clientDto.getClientSecret());
+  }
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/core/IamSecurityExpressionMethodsTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/core/IamSecurityExpressionMethodsTests.java
@@ -13,14 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package it.infn.mw.iam.test.util;
+package it.infn.mw.iam.test.core;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+
+import java.util.Optional;
 
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mitre.oauth2.model.ClientDetailsEntity;
+import org.mitre.oauth2.service.ClientDetailsEntityService;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
@@ -31,19 +37,24 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import it.infn.mw.iam.IamLoginService;
 import it.infn.mw.iam.api.account.AccountUtils;
+import it.infn.mw.iam.api.client.service.ClientService;
 import it.infn.mw.iam.api.requests.GroupRequestUtils;
 import it.infn.mw.iam.api.requests.model.GroupRequestDto;
 import it.infn.mw.iam.core.expression.IamSecurityExpressionMethods;
 import it.infn.mw.iam.core.userinfo.OAuth2AuthenticationScopeResolver;
+import it.infn.mw.iam.persistence.model.IamAccount;
+import it.infn.mw.iam.persistence.repository.IamAccountRepository;
 import it.infn.mw.iam.persistence.repository.IamGroupRequestRepository;
+import it.infn.mw.iam.persistence.repository.client.IamAccountClientRepository;
+import it.infn.mw.iam.persistence.repository.client.IamClientRepository;
 import it.infn.mw.iam.test.api.requests.GroupRequestsTestUtils;
 
+@SuppressWarnings("deprecation")
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = {IamLoginService.class}, webEnvironment = WebEnvironment.MOCK)
-public class IamSecurityExpressionsTests extends GroupRequestsTestUtils {
+public class IamSecurityExpressionMethodsTests extends GroupRequestsTestUtils {
 
-  @Autowired
-  private AccountUtils accountUtils;
+  public static final String TEST_CLIENT_ID = "client";
 
   @Autowired
   private GroupRequestUtils groupRequestUtils;
@@ -54,22 +65,46 @@ public class IamSecurityExpressionsTests extends GroupRequestsTestUtils {
   @Autowired
   private IamGroupRequestRepository repo;
 
+  @Autowired
+  private IamAccountClientRepository accountClientRepo;
+
+  @Autowired
+  private IamAccountRepository accountRepo;
+
+  @Autowired
+  private ClientService clientService;
+
+  @Autowired
+  private ClientDetailsEntityService clientDetailsService;
+
+  @Autowired
+  AccountUtils accountUtils;
+
+  @Mock
+  private IamClientRepository clientRepo;
+
   @After
   public void destroy() {
     repo.deleteAll();
+    clientService.unlinkClientFromAccount(clientDetailsService.loadClientByClientId(TEST_CLIENT_ID),
+        accountRepo.findByUsername(TEST_ADMIN).get());
+    clientService.unlinkClientFromAccount(clientDetailsService.loadClientByClientId(TEST_CLIENT_ID),
+        accountRepo.findByUsername("test_200").get());
   }
-  
+
   private IamSecurityExpressionMethods getMethods() {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-    return new IamSecurityExpressionMethods(authentication, accountUtils, groupRequestUtils, scopeResolver);
+    return new IamSecurityExpressionMethods(authentication, accountUtils, groupRequestUtils,
+        scopeResolver, accountClientRepo, clientRepo);
   }
 
   @Test
-  @WithMockUser(roles = { "ADMIN", "USER" }, username = TEST_ADMIN)
+  @WithMockUser(roles = {"ADMIN", "USER"}, username = TEST_ADMIN)
   public void testIsAdmin() {
     assertTrue(getMethods().isAdmin());
     assertTrue(getMethods().isUser(TEST_ADMIN_UUID));
     assertFalse(getMethods().isUser(TEST_USERUUID));
+
     GroupRequestDto request = savePendingGroupRequest(TEST_USERNAME, TEST_001_GROUPNAME);
     assertTrue(getMethods().canAccessGroupRequest(request.getUuid()));
     assertTrue(getMethods().canManageGroupRequest(request.getUuid()));
@@ -77,22 +112,60 @@ public class IamSecurityExpressionsTests extends GroupRequestsTestUtils {
   }
 
   @Test
-  @WithMockUser(roles = { "USER" }, username = TEST_USERNAME)
+  @WithMockUser(roles = {"USER"}, username = TEST_USERNAME)
   public void testIsNotAdmin() {
     assertFalse(getMethods().isAdmin());
     assertTrue(getMethods().isUser(TEST_USERUUID));
     assertFalse(getMethods().isUser(TEST_ADMIN_UUID));
+
     GroupRequestDto request = savePendingGroupRequest(TEST_USERNAME, TEST_001_GROUPNAME);
     assertTrue(getMethods().canAccessGroupRequest(request.getUuid()));
     assertFalse(getMethods().canManageGroupRequest(request.getUuid()));
     assertTrue(getMethods().userCanDeleteGroupRequest(request.getUuid()));
+
     GroupRequestDto approved = saveApprovedGroupRequest(TEST_USERNAME, TEST_001_GROUPNAME);
     assertTrue(getMethods().canAccessGroupRequest(approved.getUuid()));
     assertFalse(getMethods().canManageGroupRequest(approved.getUuid()));
     assertFalse(getMethods().userCanDeleteGroupRequest(approved.getUuid()));
+
     GroupRequestDto notMine = savePendingGroupRequest(TEST_100_USERNAME, TEST_001_GROUPNAME);
     assertFalse(getMethods().canAccessGroupRequest(notMine.getUuid()));
     assertFalse(getMethods().canManageGroupRequest(notMine.getUuid()));
     assertFalse(getMethods().userCanDeleteGroupRequest(notMine.getUuid()));
+  }
+
+  @Test
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  public void testIsClientOwnerNoAuthenticatedUser() {
+    assertFalse(getMethods().isClientOwner("client"));
+  }
+
+  @Test
+  @WithMockUser(roles = {"ADMIN", "USER"}, username = TEST_ADMIN)
+  public void testIsClientOwnerIsAdmin() {
+    mockLinkClientToAccount(TEST_ADMIN);
+    assertTrue(getMethods().isClientOwner(TEST_CLIENT_ID));
+  }
+
+ @Test
+  @WithMockUser(roles = {"ADMIN", "USER"}, username = "test_200")
+  public void testIsClientOwnerIsUser() {
+    mockLinkClientToAccount("test_200");
+    assertTrue(getMethods().isClientOwner(TEST_CLIENT_ID));
+  }
+
+  @Test
+  @WithMockUser(roles = {"ADMIN", "USER"}, username = TEST_ADMIN)
+  public void testIsClientOwnerIsNotUser() {
+    mockLinkClientToAccount("test_200");
+    assertFalse(getMethods().isClientOwner(TEST_CLIENT_ID));
+  }
+
+  private void mockLinkClientToAccount(String owner) {
+    ClientDetailsEntity clientTest = clientDetailsService.loadClientByClientId(TEST_CLIENT_ID);
+    Optional<IamAccount> account = accountRepo.findByUsername(owner);
+    ClientDetailsEntity clientTestUpdate = clientService.linkClientToAccount(clientTest, account.get());
+
+    doReturn(Optional.of(clientTestUpdate)).when(clientRepo).findByClientId(TEST_CLIENT_ID);
   }
 }


### PR DESCRIPTION
Remove client_secret information from the API, this information is only available upon returning from creating a new client or requesting a new client secret