### PR TITLE
Fix UserInfo response and epoch timestamps

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcClaimValueHelper.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcClaimValueHelper.java
@@ -61,7 +61,7 @@ public class AarcClaimValueHelper extends IamClaimValueHelper {
 
   private String encodeGroup(IamGroup group) {
 
-    var aarcConfig = getProperties().getAarcProfile();
+    var aarcConfig = properties.getAarcProfile();
 
     String urnNid = aarcConfig.getUrnNid();
     String urnDelegatedNamespace = aarcConfig.getUrnDelegatedNamespace();
@@ -93,10 +93,10 @@ public class AarcClaimValueHelper extends IamClaimValueHelper {
           return resolveGroups(account.get().getUserInfo());
         case AarcExtraClaimNames.VOPERSON_ID:
           return format(SCOPED_FORMAT, account.get().getUserInfo().getSub(),
-              getProperties().getOrganisation().getName());
+              properties.getOrganisation().getName());
         case AarcExtraClaimNames.EDUPERSON_SCOPED_AFFILIATION:
           return format(SCOPED_FORMAT, DEFAULT_AFFILIATION_TYPE,
-              getProperties().getOrganisation().getName());
+              properties.getOrganisation().getName());
         case AarcExtraClaimNames.VOPERSON_EXTERNAL_AFFILIATION:
           Optional<SavedUserAuthentication> userAuth =
               AuthenticationUtils.getExternalAuthenticationInfo(auth.getUserAuthentication());
@@ -105,7 +105,7 @@ public class AarcClaimValueHelper extends IamClaimValueHelper {
             if (account.get().getUserInfo().getAffiliation() != null) {
               scopedAffiliations
                 .add(format(SCOPED_FORMAT, account.get().getUserInfo().getAffiliation(),
-                    getProperties().getOrganisation().getName()));
+                    properties.getOrganisation().getName()));
             }
             String externalScopedAffiliation = firstOf(userAuth.get().getAdditionalInfo(),
                 Set.of("VPSA", "voPersonScopedAffiliation", "urn:oid:1.3.6.1.4.1.34998.3.3.1.12"));

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/common/BaseClaimValueHelper.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/common/BaseClaimValueHelper.java
@@ -116,6 +116,9 @@ public abstract class BaseClaimValueHelper implements ClaimValueHelper {
     if (value instanceof Collection<?> coll) {
       return !coll.isEmpty();
     }
+    if (value instanceof String s) {
+      return !s.trim().isEmpty();
+    }
     return value != null;
   }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/common/BaseClaimValueHelper.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/common/BaseClaimValueHelper.java
@@ -99,7 +99,9 @@ public abstract class BaseClaimValueHelper implements ClaimValueHelper {
       case StandardClaimNames.LOCALE:
         return account.get().getUserInfo().getLocale();
       case StandardClaimNames.UPDATED_AT:
-        return account.get().getLastUpdateTime().getTime();
+        return account.get().getLastUpdateTime() != null
+            ? account.get().getLastUpdateTime().getTime() / 1000
+            : null;
       case StandardClaimNames.ADDRESS:
         return account.get().getUserInfo().getAddress();
       case StandardClaimNames.PHONE_NUMBER:

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/common/BaseClaimValueHelper.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/common/BaseClaimValueHelper.java
@@ -99,9 +99,8 @@ public abstract class BaseClaimValueHelper implements ClaimValueHelper {
       case StandardClaimNames.LOCALE:
         return account.get().getUserInfo().getLocale();
       case StandardClaimNames.UPDATED_AT:
-        return account.get().getLastUpdateTime() != null
-            ? account.get().getLastUpdateTime().getTime() / 1000
-            : null;
+        /* account.get().getLastUpdateTime() cannot be null */
+        return account.get().getLastUpdateTime().getTime() / 1000;
       case StandardClaimNames.ADDRESS:
         return account.get().getUserInfo().getAddress();
       case StandardClaimNames.PHONE_NUMBER:

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/common/BaseIntrospectionHelper.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/common/BaseIntrospectionHelper.java
@@ -80,7 +80,7 @@ public abstract class BaseIntrospectionHelper implements IntrospectionResultHelp
     JWTClaimsSet claims = getClaimsSet(accessToken.getJwt());
     Map<String, Object> result = assembleCommonClaims(claims, client, TokenTypeHint.ACCESS_TOKEN);
     result.put(SUB, claims.getSubject());
-    result.put(IAT, claims.getIssueTime());
+    result.put(IAT, claims.getIssueTime().getTime() / 1000);
     result.put(ISS, claims.getIssuer());
     if (nonNull(accessToken.getScope())) {
       result.put(SCOPE, accessToken.getScope().stream().map(String::valueOf).collect(joining(" ")));
@@ -117,7 +117,7 @@ public abstract class BaseIntrospectionHelper implements IntrospectionResultHelp
     result.put(TOKEN_TYPE, tokenType);
     result.put(CLIENT_ID, client.getClientId());
     if (nonNull(claims.getExpirationTime())) {
-      result.put(EXP, claims.getExpirationTime().getTime());
+      result.put(EXP, claims.getExpirationTime().getTime() / 1000);
     }
     result.put(JTI, claims.getJWTID());
     Optional<IamAccount> account = loadUserFrom(claims.getSubject());
@@ -125,7 +125,7 @@ public abstract class BaseIntrospectionHelper implements IntrospectionResultHelp
       result.put(USERNAME, account.get().getUsername());
     }
     if (nonNull(claims.getNotBeforeTime())) {
-      result.put(NBF, claims.getNotBeforeTime().getTime());
+      result.put(NBF, claims.getNotBeforeTime().getTime() / 1000);
     }
     /*
      * For OAuth 2.0 Token Introspection (RFC 7662), the AUD claim follows the same rules as in JWT

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/common/BaseUserinfoHelper.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/common/BaseUserinfoHelper.java
@@ -68,6 +68,8 @@ public abstract class BaseUserinfoHelper implements UserInfoHelper {
     Set<String> claimNames = new HashSet<>();
     claimNames.addAll(getRequiredClaims());
     claimNames.addAll(scopeTranslationService.getClaimsForScopeSet(scopes));
-    return claimValueHelper.resolveClaims(claimNames, auth, Optional.of(account));
+    Map<String, Object> claims = claimValueHelper.resolveClaims(claimNames, auth, Optional.of(account));
+    claims.put("scope", scopes);
+    return claims;
   }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/iam/IamClaimValueHelper.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/iam/IamClaimValueHelper.java
@@ -45,10 +45,10 @@ import it.infn.mw.iam.persistence.model.IamSshKey;
 @SuppressWarnings("deprecation")
 public class IamClaimValueHelper extends BaseClaimValueHelper {
 
-  private final IamProperties properties;
-  private final SshKeyConverter sshConverter;
-  private final AttributeMapHelper attrHelper;
-  private final ScopeClaimTranslationService scopeClaimTranslationService;
+  protected final IamProperties properties;
+  protected final SshKeyConverter sshConverter;
+  protected final AttributeMapHelper attrHelper;
+  protected final ScopeClaimTranslationService scopeClaimTranslationService;
 
   public IamClaimValueHelper(IamProperties properties, SshKeyConverter sshConverter,
       AttributeMapHelper attrHelper, ScopeClaimTranslationService scopeClaimTranslationService) {
@@ -56,22 +56,6 @@ public class IamClaimValueHelper extends BaseClaimValueHelper {
     this.sshConverter = sshConverter;
     this.attrHelper = attrHelper;
     this.scopeClaimTranslationService = scopeClaimTranslationService;
-  }
-
-  protected IamProperties getProperties() {
-    return properties;
-  }
-
-  protected SshKeyConverter getSshConverter() {
-    return sshConverter;
-  }
-
-  protected AttributeMapHelper getAttrHelper() {
-    return attrHelper;
-  }
-
-  public ScopeClaimTranslationService getScopeClaimTranslationService() {
-    return scopeClaimTranslationService;
   }
 
   @Override

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/iam/IamClaimValueHelper.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/iam/IamClaimValueHelper.java
@@ -82,7 +82,9 @@ public class IamClaimValueHelper extends BaseClaimValueHelper {
       case ORGANISATION_NAME:
         return properties.getOrganisation().getName();
       case LAST_LOGIN_AT:
-        return account.isPresent() ? account.get().getLastLoginTime() : null;
+        return account.isPresent() && account.get().getLastLoginTime() != null
+            ? account.get().getLastLoginTime().getTime() / 1000
+            : null;
       case AFFILIATION:
         return account.isPresent() ? account.get().getUserInfo().getAffiliation() : null;
       case GROUPS:
@@ -90,7 +92,8 @@ public class IamClaimValueHelper extends BaseClaimValueHelper {
       case SSH_KEYS:
         return account.isPresent() ? getSshKeysFilteredSet(account.get().getSshKeys()) : null;
       case ATTR:
-        return account.isPresent() ? attrHelper.getAttributeMapFromUserInfo(account.get().getUserInfo())
+        return account.isPresent()
+            ? attrHelper.getAttributeMapFromUserInfo(account.get().getUserInfo())
             : null;
       case EXTERNAL_AUTHN:
         Optional<SavedUserAuthentication> userAuth =

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/wlcg/WlcgClaimValueHelper.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/wlcg/WlcgClaimValueHelper.java
@@ -50,7 +50,9 @@ public class WlcgClaimValueHelper extends IamClaimValueHelper {
         return account.isPresent() ? WlcgGroupHelper.resolveGroupNames(auth.getOAuth2Request().getScope(),
             account.get().getUserInfo().getGroups()) : null;
       case AUTH_TIME:
-        return account.isPresent() ? account.get().getLastLoginTime() : null;
+        return account.isPresent() && account.get().getLastLoginTime() != null
+            ? account.get().getLastLoginTime().getTime() / 1000
+            : null;
       case GROUPS:
         /* remove inherited groups from allowed claims */
         return null;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/userinfo/IamUserInfoEndpoint.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/userinfo/IamUserInfoEndpoint.java
@@ -15,9 +15,6 @@
  */
 package it.infn.mw.iam.core.userinfo;
 
-import static java.lang.String.valueOf;
-import static org.springframework.security.oauth2.core.oidc.StandardClaimNames.SUB;
-
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -93,9 +90,7 @@ public class IamUserInfoEndpoint {
     Map<String, Object> claims =
         profile.getUserinfoHelper().resolveScopeClaims(scopes, account.get(), auth);
 
-    UserInfoResponse.Builder builder = new UserInfoResponse.Builder(valueOf(claims.get(SUB)));
-    claims.forEach(builder::addField);
-    return builder.build();
+    return new UserInfoResponse(claims);
   }
 
   @ResponseStatus(value = HttpStatus.NOT_FOUND)

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/WLCGProfileIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/WLCGProfileIntegrationTests.java
@@ -911,8 +911,9 @@ public class WLCGProfileIntegrationTests extends EndpointsTestUtils {
 
     mvc.perform(get("/userinfo"))
       .andExpect(status().isOk())
-      .andExpect(jsonPath("$.*", hasSize(1)))
-      .andExpect(jsonPath("$.sub").exists());
+      .andExpect(jsonPath("$.*", hasSize(2)))
+      .andExpect(jsonPath("$.sub").exists())
+      .andExpect(jsonPath("$.scope").exists());
   }
 
   @Test

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/userinfo/UserInfoEndpointTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/userinfo/UserInfoEndpointTests.java
@@ -18,6 +18,7 @@ package it.infn.mw.iam.test.oauth.userinfo;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -25,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.hamcrest.Matchers;
@@ -45,6 +47,7 @@ import com.fasterxml.jackson.core.JsonToken;
 import it.infn.mw.iam.authn.ExternalAuthenticationRegistrationInfo.ExternalAuthenticationType;
 import it.infn.mw.iam.core.oauth.profile.iam.IamExtraClaimNames;
 import it.infn.mw.iam.core.user.IamAccountService;
+import it.infn.mw.iam.core.userinfo.UserInfoResponse;
 import it.infn.mw.iam.persistence.model.IamAccount;
 import it.infn.mw.iam.persistence.model.IamSshKey;
 import it.infn.mw.iam.persistence.repository.IamAccountRepository;
@@ -80,6 +83,15 @@ public class UserInfoEndpointTests {
   @After
   public void teardown() {
     mockOAuth2Filter.cleanupSecurityContext();
+  }
+
+  @Test
+  public void testUserInfoResponseCreationWithoutSub() {
+
+    Map<String, Object> claims = Map.of("iss", "https://iam-example.org/");
+    assertThrows(IllegalArgumentException.class, () -> {
+      new UserInfoResponse(claims);
+    });
   }
 
   @Test

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/userinfo/UserInfoEndpointTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/userinfo/UserInfoEndpointTests.java
@@ -193,7 +193,7 @@ public class UserInfoEndpointTests {
   @WithMockOAuthUser(clientId = "password-grant", user = "test", authorities = {"ROLE_USER"},
       scopes = {"openid", "profile"})
   @Transactional
-  public void testUserInfoEndpointRetursNoEmptyClaims() throws Exception {
+  public void testUserInfoEndpointReturnsNoEmptyClaims() throws Exception {
 
     IamAccount test = accountRepo.findByUsername("test")
         .orElseThrow(() -> new AssertionError("Expected account not found"));
@@ -208,8 +208,7 @@ public class UserInfoEndpointTests {
       .andExpect(jsonPath("$.scope", Matchers.hasSize(2)))
       .andExpect(jsonPath("$.scope", containsInAnyOrder("openid", "profile")))
       .andExpect(jsonPath("$." + IamExtraClaimNames.ORGANISATION_NAME, is("indigo-dc")))
-      .andExpect(jsonPath("$." + IamExtraClaimNames.AFFILIATION, is("indigo")))
-      .andReturn();
+      .andExpect(jsonPath("$." + IamExtraClaimNames.AFFILIATION, is("indigo")));
   }
 
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/userinfo/UserInfoEndpointTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/userinfo/UserInfoEndpointTests.java
@@ -16,11 +16,16 @@
 package it.infn.mw.iam.test.oauth.userinfo;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -30,6 +35,12 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 
 import it.infn.mw.iam.authn.ExternalAuthenticationRegistrationInfo.ExternalAuthenticationType;
 import it.infn.mw.iam.core.oauth.profile.iam.IamExtraClaimNames;
@@ -74,6 +85,7 @@ public class UserInfoEndpointTests {
   @Test
   @WithMockOAuthUser(clientId = "client-cred", scopes = {"openid"}, authorities = {"ROLE_CLIENT"})
   public void testUserInfoEndpointReturs404ForClientCredentialsToken() throws Exception {
+
     mvc.perform(get("/userinfo")).andExpect(status().isForbidden());
   }
 
@@ -82,12 +94,14 @@ public class UserInfoEndpointTests {
       scopes = {"openid"})
   public void testUserInfoEndpointRetursOk() throws Exception {
 
-    // @formatter:off
     mvc.perform(get("/userinfo"))
       .andExpect(status().isOk())
-      .andExpect(jsonPath("$.*", Matchers.hasSize(1)))
-      .andExpect(jsonPath("$.sub").exists());
-    // @formatter:on
+      .andExpect(jsonPath("$.*", Matchers.hasSize(2)))
+      .andExpect(jsonPath("$.sub").exists())
+      .andExpect(jsonPath("$.scope").exists())
+      .andExpect(jsonPath("$.scope", Matchers.hasSize(1)))
+      .andExpect(jsonPath("$.scope", containsInAnyOrder("openid")));
+
   }
 
   @Test
@@ -95,13 +109,15 @@ public class UserInfoEndpointTests {
       scopes = {"openid", "profile"})
   public void testUserInfoEndpointRetursAllExpectedInfo() throws Exception {
 
-    // @formatter:off
     mvc.perform(get("/userinfo"))
       .andExpect(status().isOk())
       .andExpect(jsonPath("$.sub").exists())
+      .andExpect(jsonPath("$.scope").exists())
+      .andExpect(jsonPath("$.scope", Matchers.hasSize(2)))
+      .andExpect(jsonPath("$.scope", containsInAnyOrder("openid", "profile")))
       .andExpect(jsonPath("$." + IamExtraClaimNames.ORGANISATION_NAME, is("indigo-dc")))
-      .andExpect(jsonPath("$." + IamExtraClaimNames.AFFILIATION, is("indigo")));
-    // @formatter:on
+      .andExpect(jsonPath("$." + IamExtraClaimNames.AFFILIATION, is("indigo")))
+      .andReturn();
   }
 
   @Test
@@ -110,12 +126,17 @@ public class UserInfoEndpointTests {
       externalAuthenticationType = ExternalAuthenticationType.OIDC)
   public void testUserInfoEndpointRetursExtAuthnClaim() throws Exception {
 
-    // @formatter:off
-    mvc.perform(get("/userinfo"))
+    MvcResult result = mvc.perform(get("/userinfo"))
       .andExpect(status().isOk())
+      .andExpect(jsonPath("$.sub").exists())
+      .andExpect(jsonPath("$.scope").exists())
+      .andExpect(jsonPath("$.scope", Matchers.hasSize(2)))
+      .andExpect(jsonPath("$.scope", containsInAnyOrder("openid", "profile")))
       .andExpect(jsonPath("$.external_authn").exists())
-      .andExpect(jsonPath("$.external_authn.type", equalTo("oidc")));  
-    // @formatter:on
+      .andExpect(jsonPath("$.external_authn.type", equalTo("oidc")))
+      .andReturn();
+
+    checkNoRootKeyDuplicates(result.getResponse().getContentAsString());
   }
 
   @Test
@@ -134,6 +155,10 @@ public class UserInfoEndpointTests {
     accountService.addSshKey(test, key);
     mvc.perform(get("/userinfo"))
       .andExpect(status().isOk())
+      .andExpect(jsonPath("$.sub").exists())
+      .andExpect(jsonPath("$.scope").exists())
+      .andExpect(jsonPath("$.scope", Matchers.hasSize(2)))
+      .andExpect(jsonPath("$.scope", containsInAnyOrder("openid", "profile")))
       .andExpect(jsonPath("$.ssh_keys").doesNotExist());
 
   }
@@ -153,12 +178,56 @@ public class UserInfoEndpointTests {
     accountService.addSshKey(test, key);
     mvc.perform(get("/userinfo"))
       .andExpect(status().isOk())
+      .andExpect(jsonPath("$.sub").exists())
+      .andExpect(jsonPath("$.scope").exists())
+      .andExpect(jsonPath("$.scope", Matchers.hasSize(3)))
+      .andExpect(jsonPath("$.scope", containsInAnyOrder("openid", "profile", "ssh-keys")))
       .andExpect(jsonPath("$.ssh_keys").isArray())
-      .andExpect(jsonPath("$.ssh_keys", hasSize(1)))
+      .andExpect(jsonPath("$.ssh_keys", Matchers.hasSize(1)))
       .andExpect(
           jsonPath("$.ssh_keys[0].fingerprint", is(RSAPublicKeyUtils.getSHA256Fingerprint("test"))))
       .andExpect(jsonPath("$.ssh_keys[0].value", is("test")));
-
   }
 
+  @Test
+  @WithMockOAuthUser(clientId = "password-grant", user = "test", authorities = {"ROLE_USER"},
+      scopes = {"openid", "profile"})
+  @Transactional
+  public void testUserInfoEndpointRetursNoEmptyClaims() throws Exception {
+
+    IamAccount test = accountRepo.findByUsername("test")
+        .orElseThrow(() -> new AssertionError("Expected account not found"));
+    test.getUserInfo().setPicture("  ");
+    accountRepo.save(test);
+
+    mvc.perform(get("/userinfo"))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.sub").exists())
+      .andExpect(jsonPath("$.picture").doesNotExist())
+      .andExpect(jsonPath("$.scope").exists())
+      .andExpect(jsonPath("$.scope", Matchers.hasSize(2)))
+      .andExpect(jsonPath("$.scope", containsInAnyOrder("openid", "profile")))
+      .andExpect(jsonPath("$." + IamExtraClaimNames.ORGANISATION_NAME, is("indigo-dc")))
+      .andExpect(jsonPath("$." + IamExtraClaimNames.AFFILIATION, is("indigo")))
+      .andReturn();
+  }
+
+
+  private void checkNoRootKeyDuplicates(String content) throws IOException {
+
+    JsonParser parser = (new JsonFactory()).createParser(content);
+
+    Set<String> rootKeys = new HashSet<>();
+    parser.nextToken();
+
+    while (parser.nextToken() != JsonToken.END_OBJECT) {
+      String fieldName = parser.getCurrentName();
+      parser.nextToken();
+      if (!rootKeys.add(fieldName)) {
+        fail("Duplicate root key detected: " + fieldName);
+      }
+      parser.skipChildren();
+    }
+    parser.close();
+  }
 }


### PR DESCRIPTION
* Fixed duplicated sub key #1080 
* Restore scope claim which was removed since IAM v1.13.0 from UserInfo response
* Ignore empty strings when adding claims to prevent empty claims in the response
* Fixed unit of some epoch timestamps from millisecs to secs.