### PR TITLE
Insert client certificate hash in AT if provided

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamApiSecurityConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamApiSecurityConfig.java
@@ -40,6 +40,7 @@ import org.springframework.security.web.context.SecurityContextPersistenceFilter
 
 import it.infn.mw.iam.api.proxy.ProxyCertificatesApiController;
 import it.infn.mw.iam.config.IamProperties;
+import it.infn.mw.iam.config.security.filters.MtlsTokenBindingFilter;
 import it.infn.mw.iam.config.security.IamWebSecurityConfig.UserLoginConfig;
 import it.infn.mw.iam.core.oauth.FormClientCredentialsAuthenticationFilter;
 
@@ -149,6 +150,7 @@ public class IamApiSecurityConfig {
             .accessDeniedHandler(new OAuth2AccessDeniedHandler())
         .and()
           .addFilterAfter(resourceFilter, SecurityContextPersistenceFilter.class)
+          .addFilterAfter(new MtlsTokenBindingFilter(), OAuth2AuthenticationProcessingFilter.class)
         .cors()
         .and()
         .sessionManagement()

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamApiSecurityConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamApiSecurityConfig.java
@@ -36,12 +36,13 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationProcessingFilter;
 import org.springframework.security.oauth2.provider.error.OAuth2AccessDeniedHandler;
 import org.springframework.security.oauth2.provider.error.OAuth2AuthenticationEntryPoint;
+import org.springframework.security.web.access.ExceptionTranslationFilter;
 import org.springframework.security.web.context.SecurityContextPersistenceFilter;
 
 import it.infn.mw.iam.api.proxy.ProxyCertificatesApiController;
 import it.infn.mw.iam.config.IamProperties;
-import it.infn.mw.iam.config.security.filters.MtlsTokenBindingFilter;
 import it.infn.mw.iam.config.security.IamWebSecurityConfig.UserLoginConfig;
+import it.infn.mw.iam.config.security.filters.MtlsTokenBindingFilter;
 import it.infn.mw.iam.core.oauth.FormClientCredentialsAuthenticationFilter;
 
 @SuppressWarnings("deprecation")
@@ -150,7 +151,7 @@ public class IamApiSecurityConfig {
             .accessDeniedHandler(new OAuth2AccessDeniedHandler())
         .and()
           .addFilterAfter(resourceFilter, SecurityContextPersistenceFilter.class)
-          .addFilterAfter(new MtlsTokenBindingFilter(), OAuth2AuthenticationProcessingFilter.class)
+          .addFilterAfter(new MtlsTokenBindingFilter(), ExceptionTranslationFilter.class)
         .cors()
         .and()
         .sessionManagement()

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/security/filters/MtlsTokenBindingFilter.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/security/filters/MtlsTokenBindingFilter.java
@@ -45,11 +45,11 @@ public class MtlsTokenBindingFilter extends OncePerRequestFilter {
       FilterChain chain) throws ServletException, IOException {
 
     try {
-      /* check if access token contains certificate hash */
       String auth = request.getHeader(AUTH_HEADER);
 
       if (auth == null || !auth.startsWith("Bearer ")) {
-        throw new InsufficientAuthenticationException("Missing or invalid Authorization header");
+        chain.doFilter(request, response);
+        return;
       }
 
       String tokenValue = auth.substring("Bearer ".length()).trim();
@@ -62,11 +62,18 @@ public class MtlsTokenBindingFilter extends OncePerRequestFilter {
 
         if (cnf == null || !cnf.containsKey(CERT_HASH_FIELD_NAME)) {
           chain.doFilter(request, response);
+          return;
         }
 
-        String expectedThumbprint = cnf.get(CERT_HASH_FIELD_NAME).toString();
+        Object expected = cnf.get(CERT_HASH_FIELD_NAME);
 
-        /* check if certificate hashes match */
+        if (expected == null) {
+          throw new InsufficientAuthenticationException(
+              "Missing mTLS certificate thumbprint claim");
+        }
+
+        String expectedThumbprint = expected.toString();
+
         String presentedCert = request.getHeader(CLIENT_CERT_HEADER);
 
         if (presentedCert == null || presentedCert.isBlank()) {
@@ -83,11 +90,12 @@ public class MtlsTokenBindingFilter extends OncePerRequestFilter {
           throw new InsufficientAuthenticationException("mTLS certificate thumbprint mismatch");
         }
 
+        chain.doFilter(request, response);
+
       } catch (ParseException e) {
         throw new InsufficientAuthenticationException("Invalid access token format");
       }
 
-      chain.doFilter(request, response);
     } catch (InsufficientAuthenticationException e) {
       response.sendError(HttpServletResponse.SC_UNAUTHORIZED, e.getMessage());
     }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/security/filters/MtlsTokenBindingFilter.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/security/filters/MtlsTokenBindingFilter.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.config.security.filters;
+
+import static it.infn.mw.iam.core.oauth.profile.common.BaseAccessTokenBuilder.CERT_HASH_FIELD_NAME;
+import static it.infn.mw.iam.core.oauth.profile.common.BaseAccessTokenBuilder.CLIENT_CERT_HEADER;
+import static it.infn.mw.iam.core.oauth.profile.common.BaseExtraClaimNames.CNF;
+import static it.infn.mw.iam.util.x509.X509Utils.getCertificateThumbprint;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+public class MtlsTokenBindingFilter extends OncePerRequestFilter {
+
+  private static final String AUTH_HEADER = "Authorization";
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain chain) throws ServletException, IOException {
+
+    try {
+      /* check if access token contains certificate hash */
+      String auth = request.getHeader(AUTH_HEADER);
+
+      if (auth == null || !auth.startsWith("Bearer ")) {
+        throw new InsufficientAuthenticationException("Missing or invalid Authorization header");
+      }
+
+      String tokenValue = auth.substring("Bearer ".length()).trim();
+
+      try {
+        SignedJWT jwt = SignedJWT.parse(tokenValue);
+        JWTClaimsSet claims = jwt.getJWTClaimsSet();
+
+        Map<String, Object> cnf = claims.getJSONObjectClaim(CNF);
+
+        if (cnf == null || !cnf.containsKey(CERT_HASH_FIELD_NAME)) {
+          chain.doFilter(request, response);
+        }
+
+        String expectedThumbprint = cnf.get(CERT_HASH_FIELD_NAME).toString();
+
+        /* check if certificate hashes match */
+        String presentedCert = request.getHeader(CLIENT_CERT_HEADER);
+
+        if (presentedCert == null || presentedCert.isBlank()) {
+          throw new InsufficientAuthenticationException("Missing mTLS certificate");
+        }
+
+        Optional<String> presentedThumbprint = getCertificateThumbprint(presentedCert);
+
+        if (presentedThumbprint.isEmpty()) {
+          throw new InsufficientAuthenticationException("Missing mTLS certificate thumbprint");
+        }
+
+        if (!expectedThumbprint.equals(presentedThumbprint.get())) {
+          throw new InsufficientAuthenticationException("mTLS certificate thumbprint mismatch");
+        }
+
+      } catch (ParseException e) {
+        throw new InsufficientAuthenticationException("Invalid access token format");
+      }
+
+      chain.doFilter(request, response);
+    } catch (InsufficientAuthenticationException e) {
+      response.sendError(HttpServletResponse.SC_UNAUTHORIZED, e.getMessage());
+    }
+  }
+}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/common/BaseAccessTokenBuilder.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/common/BaseAccessTokenBuilder.java
@@ -21,7 +21,9 @@ import static it.infn.mw.iam.core.oauth.IamOAuthRequestParameters.AUD_KEY;
 import static it.infn.mw.iam.core.oauth.granters.TokenExchangeTokenGranter.TOKEN_EXCHANGE_GRANT_TYPE;
 import static it.infn.mw.iam.core.oauth.profile.common.BaseExtraClaimNames.ACR;
 import static it.infn.mw.iam.core.oauth.profile.common.BaseExtraClaimNames.ACT;
+import static it.infn.mw.iam.core.oauth.profile.common.BaseExtraClaimNames.CNF;
 import static it.infn.mw.iam.core.oauth.profile.common.BaseExtraClaimNames.EXTERNAL_AUTHN;
+import static it.infn.mw.iam.util.x509.X509Utils.getCertificateThumbprint;
 import static java.util.Objects.isNull;
 import static java.util.stream.Collectors.joining;
 
@@ -39,12 +41,16 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.oauth2.common.exceptions.InvalidRequestException;
 import org.springframework.security.oauth2.core.oidc.StandardClaimNames;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.OAuth2Request;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 import com.google.common.collect.Maps;
 import com.nimbusds.jwt.JWT;
@@ -73,6 +79,8 @@ public abstract class BaseAccessTokenBuilder implements AccessTokenBuilder {
 
   protected static final String SPACE = " ";
   protected static final String SUBJECT_TOKEN = "subject_token";
+  public static final String CERT_HASH_FIELD_NAME = "x5t#S256";
+  public static final String CLIENT_CERT_HEADER = "X-SSL-Client-cert";
 
   private final IamProperties properties;
   private final ScopeFilter scopeFilter;
@@ -179,6 +187,13 @@ public abstract class BaseAccessTokenBuilder implements AccessTokenBuilder {
     /* include the additional authentication claims if configured */
     if (isIncludeAuthnInfo() && account.isPresent()) {
       includeAdditionalAuthnInfoClaims(builder, token, authentication, account.get());
+    }
+
+    /* include the client certificate hash if present */
+    Optional<String> clientCertificateHash = getClientCertificateThumbprint();
+    if (clientCertificateHash.isPresent()) {
+      Map<String, Object> cnfValue = Map.of(CERT_HASH_FIELD_NAME, clientCertificateHash.get());
+      builder.claim(CNF, cnfValue);
     }
 
     /* include the required claims if set */
@@ -343,5 +358,18 @@ public abstract class BaseAccessTokenBuilder implements AccessTokenBuilder {
       return !coll.isEmpty();
     }
     return value != null;
+  }
+
+  private Optional<String> getClientCertificateThumbprint() {
+    HttpServletRequest request =
+        ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+    
+    String clientCert = request.getHeader(CLIENT_CERT_HEADER);
+
+    if (clientCert == null || clientCert.isBlank()) {
+      return Optional.empty();
+    }
+
+    return getCertificateThumbprint(clientCert);
   }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/common/BaseExtraClaimNames.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/common/BaseExtraClaimNames.java
@@ -29,4 +29,6 @@ public interface BaseExtraClaimNames extends StandardClaimNames {
 
   String EXTERNAL_AUTHN = "external_authn";
 
+  String CNF = "cnf";
+
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/util/x509/X509Utils.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/util/x509/X509Utils.java
@@ -16,10 +16,13 @@
 package it.infn.mw.iam.util.x509;
 
 import java.io.ByteArrayInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Base64;
+import java.util.Optional;
 
 import eu.emi.security.authn.x509.impl.X500NameUtils;
 import it.infn.mw.iam.api.scim.exception.ScimValidationException;
@@ -66,6 +69,20 @@ public class X509Utils {
   public static String getCertificateSubject(String certValueAsString) {
 
     return getCertificateSubject(getX509CertificateFromString(certValueAsString));
+  }
+
+  public static Optional<String> getCertificateThumbprint(String cert) {
+    String sanitized = cert.replace("-----BEGIN CERTIFICATE-----", "")
+      .replace("-----END CERTIFICATE-----", "")
+      .replaceAll("\\s", "");
+    try {
+      byte[] der = Base64.getDecoder().decode(sanitized);
+      byte[] sha256 = MessageDigest.getInstance("SHA-256").digest(der);
+      String hash = Base64.getUrlEncoder().withoutPadding().encodeToString(sha256);
+      return Optional.of(hash);
+    } catch (NoSuchAlgorithmException e) {
+      return Optional.empty();
+    }
   }
 
 }


### PR DESCRIPTION
__RFC 8705__ integration: if the client establishes a mTLS connection using a valid certificate, the thumbprint of that certificate is included in the Access Token. When the client requests protected resources, it must establish a mTLS connection using the same valid certificate, if not the request is rejected.