### PR TITLE
Evaluate all SAML id resolvers

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/DefaultExternalAccountLinker.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/DefaultExternalAccountLinker.java
@@ -81,7 +81,9 @@ public class DefaultExternalAccountLinker implements ExternalAccountLinker {
         (SAMLCredential) token.getExternalAuthentication().getCredentials();
 
     final IamSamlId iamSamlId = samlUserIdResolver.resolveSamlUserIdentifier(credential)
-      .getResolvedId()
+      .getResolvedIds()
+      .stream()
+      .findFirst()
       .orElseThrow(() -> new UsernameNotFoundException(
           "Could not extract a user identifier from the SAML assertion"));
 
@@ -110,5 +112,4 @@ public class DefaultExternalAccountLinker implements ExternalAccountLinker {
     repo.save(targetAccount);
 
   }
-
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/IamSamlAuthenticationProvider.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/IamSamlAuthenticationProvider.java
@@ -17,7 +17,6 @@ package it.infn.mw.iam.authn.saml;
 
 import static it.infn.mw.iam.authn.multi_factor_authentication.IamAuthenticationMethodReference.AuthenticationMethodReferenceValues.EXT_SAML_PROVIDER;
 
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -81,7 +80,7 @@ public class IamSamlAuthenticationProvider extends SAMLAuthenticationProvider {
   private Supplier<AuthenticationServiceException> handleResolutionFailure(
       SamlUserIdentifierResolutionResult result) {
 
-    List<String> errorMessages = result.getErrorMessages().orElse(Collections.emptyList());
+    List<String> errorMessages = result.getErrorMessages();
 
     return () -> new AuthenticationServiceException(joiner.join(errorMessages));
   }
@@ -103,7 +102,8 @@ public class IamSamlAuthenticationProvider extends SAMLAuthenticationProvider {
     SamlUserIdentifierResolutionResult result =
         userIdResolver.resolveSamlUserIdentifier(samlCredentials);
 
-    IamSamlId samlId = result.getResolvedId().orElseThrow(handleResolutionFailure(result));
+    IamSamlId samlId =
+        result.getResolvedIds().stream().findFirst().orElseThrow(handleResolutionFailure(result));
 
     validator.validateAuthentication(token);
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/SAMLUserDetailsServiceSupport.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/SAMLUserDetailsServiceSupport.java
@@ -22,7 +22,6 @@ import java.util.List;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.saml.SAMLCredential;
 
 import it.infn.mw.iam.authn.ExternalAuthenticationHandlerSupport;
@@ -37,9 +36,10 @@ public class SAMLUserDetailsServiceSupport {
   private final InactiveAccountAuthenticationHander inactiveAccountHandler;
   private final SamlUserIdentifierResolver resolver;
 
-  protected SAMLUserDetailsServiceSupport(InactiveAccountAuthenticationHander inactiveAccountHandler,
+  protected SAMLUserDetailsServiceSupport(
+      InactiveAccountAuthenticationHander inactiveAccountHandler,
       SamlUserIdentifierResolver resolver) {
-    
+
     this.inactiveAccountHandler = inactiveAccountHandler;
     this.resolver = resolver;
   }
@@ -63,9 +63,7 @@ public class SAMLUserDetailsServiceSupport {
         Arrays.asList(ExternalAuthenticationHandlerSupport.EXT_AUTHN_UNREGISTERED_USER_AUTH));
   }
 
-  protected IamSamlId resolveSamlId(SAMLCredential credential) {
-    return resolver.resolveSamlUserIdentifier(credential).getResolvedId()
-      .orElseThrow(() -> new UsernameNotFoundException(
-          "Could not extract a user identifier from the SAML assertion"));
+  protected List<IamSamlId> resolveSamlIds(SAMLCredential credential) {
+    return resolver.resolveSamlUserIdentifier(credential).getResolvedIds();
   }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/SamlExternalAuthenticationToken.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/SamlExternalAuthenticationToken.java
@@ -107,10 +107,6 @@ public class SamlExternalAuthenticationToken
     visitor.linkToIamAccount(account, this);
   }
 
-  public IamSamlId getSamlId() {
-    return samlId;
-  }
-
   @Override
   public Map<String, String> buildAuthnInfoMap() {
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/AttributeUserIdentifierResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/AttributeUserIdentifierResolver.java
@@ -17,6 +17,8 @@ package it.infn.mw.iam.authn.saml.util;
 
 import static java.lang.String.format;
 
+import java.util.List;
+
 import org.springframework.security.saml.SAMLCredential;
 
 import it.infn.mw.iam.persistence.model.IamSamlId;
@@ -38,8 +40,8 @@ public class AttributeUserIdentifierResolver extends AbstractSamlUserIdentifierR
 
     if (attributeValue == null) {
       return SamlUserIdentifierResolutionResult
-        .resolutionFailure(format("Attribute '%s:%s' not found in assertion", attribute.getAlias(),
-            attribute.getAttributeName()));
+        .failure(List.of(format("Attribute '%s:%s' not found in assertion", attribute.getAlias(),
+            attribute.getAttributeName())));
     }
 
     IamSamlId samlId = new IamSamlId();
@@ -47,7 +49,7 @@ public class AttributeUserIdentifierResolver extends AbstractSamlUserIdentifierR
     samlId.setAttributeId(attribute.getAttributeName());
     samlId.setUserId(attributeValue);
 
-    return SamlUserIdentifierResolutionResult.resolutionSuccess(samlId);
+    return SamlUserIdentifierResolutionResult.success(List.of(samlId));
 
   }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/ChainedCollectingSamlIdResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/ChainedCollectingSamlIdResolver.java
@@ -24,14 +24,13 @@ import org.springframework.security.saml.SAMLCredential;
 
 import it.infn.mw.iam.persistence.model.IamSamlId;
 
-public class FirstApplicableChainedSamlIdResolver implements SamlUserIdentifierResolver {
+public class ChainedCollectingSamlIdResolver implements SamlUserIdentifierResolver {
 
-  public static final Logger LOG =
-      LoggerFactory.getLogger(FirstApplicableChainedSamlIdResolver.class);
+  public static final Logger LOG = LoggerFactory.getLogger(ChainedCollectingSamlIdResolver.class);
 
   private final List<SamlUserIdentifierResolver> resolvers;
 
-  public FirstApplicableChainedSamlIdResolver(List<SamlUserIdentifierResolver> resolvers) {
+  public ChainedCollectingSamlIdResolver(List<SamlUserIdentifierResolver> resolvers) {
     this.resolvers = resolvers;
   }
 
@@ -62,10 +61,6 @@ public class FirstApplicableChainedSamlIdResolver implements SamlUserIdentifierR
           result.getErrorMessages().forEach(LOG::debug);
         }
       }
-    }
-
-    if (!collectedIds.isEmpty()) {
-      return SamlUserIdentifierResolutionResult.success(collectedIds);
     }
 
     if (!collectedIds.isEmpty()) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/FirstApplicableChainedSamlIdResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/FirstApplicableChainedSamlIdResolver.java
@@ -22,9 +22,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.saml.SAMLCredential;
 
+import it.infn.mw.iam.persistence.model.IamSamlId;
+
 public class FirstApplicableChainedSamlIdResolver implements SamlUserIdentifierResolver {
 
-  public static final Logger LOG = LoggerFactory.getLogger(FirstApplicableChainedSamlIdResolver.class);
+  public static final Logger LOG =
+      LoggerFactory.getLogger(FirstApplicableChainedSamlIdResolver.class);
 
   private final List<SamlUserIdentifierResolver> resolvers;
 
@@ -33,36 +36,44 @@ public class FirstApplicableChainedSamlIdResolver implements SamlUserIdentifierR
   }
 
   @Override
-  public SamlUserIdentifierResolutionResult resolveSamlUserIdentifier(SAMLCredential samlCredential) {
+  public SamlUserIdentifierResolutionResult resolveSamlUserIdentifier(
+      SAMLCredential samlCredential) {
 
+    List<IamSamlId> collectedIds = new ArrayList<>();
     List<String> errorMessages = new ArrayList<>();
-    
+
     for (SamlUserIdentifierResolver resolver : resolvers) {
       LOG.debug("Attempting SAML user id resolution with resolver {}",
           resolver.getClass().getName());
 
-      SamlUserIdentifierResolutionResult result = resolver
-          .resolveSamlUserIdentifier(samlCredential);
-      
-      if (result.getResolvedId().isPresent()){
-        LOG.debug("Resolved SAML user id: {}", result.getResolvedId().get());
-        return result;
+      SamlUserIdentifierResolutionResult result =
+          resolver.resolveSamlUserIdentifier(samlCredential);
+
+      if (!result.getResolvedIds().isEmpty()) {
+        collectedIds.addAll(result.getResolvedIds());
+        LOG.debug("Resolved SAML user id: {}", result.getResolvedIds().get(0).getAttributeId());
       }
-      
-      result.getErrorMessages().ifPresent(messages -> {
-        errorMessages.addAll(messages);
+
+      if (!result.getErrorMessages().isEmpty()) {
+        errorMessages.addAll(result.getErrorMessages());
         if (LOG.isDebugEnabled()) {
           LOG.debug("SAML user id resolution with resolver {} failed with the following errors",
               resolver.getClass().getName());
-          messages.forEach(LOG::debug);
+          result.getErrorMessages().forEach(LOG::debug);
         }
-      });
+      }
     }
 
-    LOG.debug(
-        "All configured user id resolvers could not resolve the user id from SAML credential");
+    if (!collectedIds.isEmpty()) {
+      return SamlUserIdentifierResolutionResult.success(collectedIds);
+    }
 
-    return SamlUserIdentifierResolutionResult.resolutionFailure(errorMessages);
+    if (!collectedIds.isEmpty()) {
+      return SamlUserIdentifierResolutionResult.success(collectedIds);
+    }
+
+    LOG
+      .debug("All configured user id resolvers could not resolve the user id from SAML credential");
+    return SamlUserIdentifierResolutionResult.failure(errorMessages);
   }
-
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/NameIdUserIdentifierResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/NameIdUserIdentifierResolver.java
@@ -16,8 +16,10 @@
 package it.infn.mw.iam.authn.saml.util;
 
 import static com.google.common.base.Verify.verifyNotNull;
-import static it.infn.mw.iam.authn.saml.util.SamlUserIdentifierResolutionResult.resolutionFailure;
-import static it.infn.mw.iam.authn.saml.util.SamlUserIdentifierResolutionResult.resolutionSuccess;
+import static it.infn.mw.iam.authn.saml.util.SamlUserIdentifierResolutionResult.failure;
+import static it.infn.mw.iam.authn.saml.util.SamlUserIdentifierResolutionResult.success;
+
+import java.util.List;
 
 import org.opensaml.saml2.core.NameID;
 import org.springframework.security.saml.SAMLCredential;
@@ -46,11 +48,11 @@ public class NameIdUserIdentifierResolver extends AbstractSamlUserIdentifierReso
       samlId.setUserId(nameId.getValue());
       samlId.setIdpId(samlCredential.getRemoteEntityID());
 
-      return resolutionSuccess(samlId);
+      return success(List.of(samlId));
 
     }
     
-    return resolutionFailure("NameID resolution failure");
+    return failure(List.of("NameID resolution failure"));
   }
 
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/PersistentNameIdUserIdentifierResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/PersistentNameIdUserIdentifierResolver.java
@@ -15,9 +15,11 @@
  */
 package it.infn.mw.iam.authn.saml.util;
 
-import static it.infn.mw.iam.authn.saml.util.SamlUserIdentifierResolutionResult.resolutionFailure;
-import static it.infn.mw.iam.authn.saml.util.SamlUserIdentifierResolutionResult.resolutionSuccess;
+import static it.infn.mw.iam.authn.saml.util.SamlUserIdentifierResolutionResult.failure;
+import static it.infn.mw.iam.authn.saml.util.SamlUserIdentifierResolutionResult.success;
 import static java.util.Objects.isNull;
+
+import java.util.List;
 
 import org.opensaml.saml2.core.NameID;
 import org.opensaml.saml2.core.NameIDType;
@@ -38,22 +40,23 @@ public class PersistentNameIdUserIdentifierResolver extends AbstractSamlUserIden
       SAMLCredential samlCredential) {
 
     if (isNull(samlCredential.getNameID())) {
-      return resolutionFailure(
-          "PersistentNameID resolution failure: NameID element not found in samlAssertion");
+      return failure(List
+        .of("PersistentNameID resolution failure: NameID element not found in samlAssertion"));
     }
 
     NameID nameId = samlCredential.getNameID();
 
     if (!nameId.getFormat().equals(NameIDType.PERSISTENT)) {
-      return resolutionFailure(
-          "PersistentNameID resolution failure: resolved NameID is not persistent: "+nameId.getFormat());
+      return failure(
+          List.of("PersistentNameID resolution failure: resolved NameID is not persistent: "
+              + nameId.getFormat()));
     }
-    
+
     IamSamlId samlId = new IamSamlId();
     samlId.setAttributeId(nameId.getFormat());
     samlId.setUserId(nameId.getValue());
     samlId.setIdpId(samlCredential.getRemoteEntityID());
 
-    return resolutionSuccess(samlId);
+    return success(List.of(samlId));
   }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/SamlUserIdentifierResolutionResult.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/saml/util/SamlUserIdentifierResolutionResult.java
@@ -15,52 +15,34 @@
  */
 package it.infn.mw.iam.authn.saml.util;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import it.infn.mw.iam.persistence.model.IamSamlId;
 
 public class SamlUserIdentifierResolutionResult {
-  
-  
-  final Optional<IamSamlId> resolvedId;
-  final Optional<List<String>> errorMessages;
-  
-  private SamlUserIdentifierResolutionResult(IamSamlId resolvedId){
-    this.resolvedId = Optional.of(resolvedId);
-    this.errorMessages = Optional.empty();
-  }
-  
-  private SamlUserIdentifierResolutionResult(String errorMessage){
-    this.resolvedId = Optional.empty();
-    List<String> errors = new ArrayList<>();
-    errors.add(errorMessage);
-    this.errorMessages = Optional.of(errors);
-  }
-  
-  private SamlUserIdentifierResolutionResult(List<String> errorMessages){
-    this.resolvedId = Optional.empty();
-    this.errorMessages = Optional.of(errorMessages);
+
+  private final List<IamSamlId> resolvedIds;
+  private final List<String> errorMessages;
+
+  private SamlUserIdentifierResolutionResult(List<IamSamlId> resolvedIds,
+      List<String> errorMessages) {
+    this.resolvedIds = List.copyOf(resolvedIds);
+    this.errorMessages = List.copyOf(errorMessages);
   }
 
-  public Optional<IamSamlId> getResolvedId() {
-    return resolvedId;
+  public List<IamSamlId> getResolvedIds() {
+    return resolvedIds;
   }
-  
-  public Optional<List<String>> getErrorMessages() {
+
+  public List<String> getErrorMessages() {
     return errorMessages;
   }
 
-  public static SamlUserIdentifierResolutionResult resolutionSuccess(IamSamlId resolvedId){
-    return new SamlUserIdentifierResolutionResult(resolvedId);
+  public static SamlUserIdentifierResolutionResult success(List<IamSamlId> ids) {
+    return new SamlUserIdentifierResolutionResult(ids, List.of());
   }
-  
-  public static SamlUserIdentifierResolutionResult resolutionFailure(String errorMessage){
-    return new SamlUserIdentifierResolutionResult(errorMessage);
-  }
-  
-  public static SamlUserIdentifierResolutionResult resolutionFailure(List<String> errorMessages) {
-    return new SamlUserIdentifierResolutionResult(errorMessages);
+
+  public static SamlUserIdentifierResolutionResult failure(List<String> errors) {
+    return new SamlUserIdentifierResolutionResult(List.of(), errors);
   }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/saml/SamlConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/saml/SamlConfig.java
@@ -143,7 +143,7 @@ import it.infn.mw.iam.authn.saml.profile.DefaultSSOProfileOptionsResolver;
 import it.infn.mw.iam.authn.saml.profile.IamSSOProfile;
 import it.infn.mw.iam.authn.saml.profile.IamSSOProfileOptions;
 import it.infn.mw.iam.authn.saml.profile.SSOProfileOptionsResolver;
-import it.infn.mw.iam.authn.saml.util.FirstApplicableChainedSamlIdResolver;
+import it.infn.mw.iam.authn.saml.util.ChainedCollectingSamlIdResolver;
 import it.infn.mw.iam.authn.saml.util.IamSamlBootstrap;
 import it.infn.mw.iam.authn.saml.util.IamSamlEntryPoint;
 import it.infn.mw.iam.authn.saml.util.SamlIdResolvers;
@@ -292,7 +292,7 @@ public class SamlConfig extends WebSecurityConfigurerAdapter
         throw new IllegalStateException("Could not configure SAML id resolvers");
       }
 
-      return new FirstApplicableChainedSamlIdResolver(resolvers);
+      return new ChainedCollectingSamlIdResolver(resolvers);
     }
 
     @Bean

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/DefaultSAMLUserDetailsServiceTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/DefaultSAMLUserDetailsServiceTests.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.ext_authn.saml;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.saml.SAMLCredential;
+
+import it.infn.mw.iam.authn.InactiveAccountAuthenticationHander;
+import it.infn.mw.iam.authn.saml.DefaultSAMLUserDetailsService;
+import it.infn.mw.iam.authn.saml.util.SamlUserIdentifierResolutionResult;
+import it.infn.mw.iam.authn.saml.util.SamlUserIdentifierResolver;
+import it.infn.mw.iam.persistence.model.IamAccount;
+import it.infn.mw.iam.persistence.model.IamAuthority;
+import it.infn.mw.iam.persistence.model.IamSamlId;
+import it.infn.mw.iam.persistence.repository.IamAccountRepository;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultSAMLUserDetailsServiceTests {
+
+  @Mock
+  private IamAccountRepository repo;
+
+  @Mock
+  private SamlUserIdentifierResolver resolver;
+
+  @Mock
+  private InactiveAccountAuthenticationHander handler;
+
+  private DefaultSAMLUserDetailsService service;
+
+  @Before
+  public void setup() {
+    service = new DefaultSAMLUserDetailsService(resolver, repo, handler);
+  }
+
+  @Test
+  public void loadUserBySAMLFindsAccountRegardlessOfSamlIdOrder() {
+    SAMLCredential credential = mock(SAMLCredential.class);
+
+    IamSamlId firstId = new IamSamlId("first", "first", "first");
+    IamSamlId secondId = new IamSamlId("second", "second", "second");
+
+    List<IamSamlId> samlIds = Arrays.asList(firstId, secondId);
+
+    SamlUserIdentifierResolutionResult resolvedIds = mock(SamlUserIdentifierResolutionResult.class);
+    when(resolver.resolveSamlUserIdentifier(credential)).thenReturn(resolvedIds);
+    when(resolvedIds.getResolvedIds()).thenReturn(samlIds);
+
+    IamAccount account = new IamAccount();
+    account.setUsername("testsamluser");
+    account.setPassword("password");
+    account.setAuthorities(Set.of(new IamAuthority("ROLE_USER")));
+    when(repo.findBySamlId(firstId)).thenReturn(Optional.empty());
+    when(repo.findBySamlId(secondId)).thenReturn(Optional.of(account));
+
+    Object userDetails = service.loadUserBySAML(credential);
+
+    assertNotNull(userDetails);
+    assertEquals("testsamluser", ((UserDetails) userDetails).getUsername());
+    verify(repo).findBySamlId(firstId);
+    verify(repo).findBySamlId(secondId);
+  }
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/ResolverTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/ResolverTests.java
@@ -42,7 +42,7 @@ import org.opensaml.xml.schema.XSAny;
 import org.springframework.security.saml.SAMLCredential;
 
 import it.infn.mw.iam.authn.saml.util.EPTIDUserIdentifierResolver;
-import it.infn.mw.iam.authn.saml.util.FirstApplicableChainedSamlIdResolver;
+import it.infn.mw.iam.authn.saml.util.ChainedCollectingSamlIdResolver;
 import it.infn.mw.iam.authn.saml.util.NameIdUserIdentifierResolver;
 import it.infn.mw.iam.authn.saml.util.NamedSamlUserIdentifierResolver;
 import it.infn.mw.iam.authn.saml.util.PersistentNameIdUserIdentifierResolver;
@@ -216,7 +216,7 @@ public class ResolverTests {
       .thenReturn("test@test.org");
     when(cred.getRemoteEntityID()).thenReturn("entityId");
 
-    SamlUserIdentifierResolver resolver = new FirstApplicableChainedSamlIdResolver(
+    SamlUserIdentifierResolver resolver = new ChainedCollectingSamlIdResolver(
         asList(subjectIdResolver, uniqueIdResolver, persistentNameIdResolver));
 
     SamlUserIdentifierResolutionResult result = resolver.resolveSamlUserIdentifier(cred);
@@ -252,7 +252,7 @@ public class ResolverTests {
       .thenReturn("123456789@test.org");
     when(cred.getRemoteEntityID()).thenReturn("entityId");
 
-    SamlUserIdentifierResolver resolver = new FirstApplicableChainedSamlIdResolver(
+    SamlUserIdentifierResolver resolver = new ChainedCollectingSamlIdResolver(
         asList(subjectIdResolver, uniqueIdResolver, persistentNameIdResolver));
 
     SamlUserIdentifierResolutionResult result = resolver.resolveSamlUserIdentifier(cred);
@@ -278,7 +278,7 @@ public class ResolverTests {
     when(cred.getAttributeAsString(Saml2Attribute.SUBJECT_ID.getAttributeName()))
       .thenReturn("subject_id");
 
-    SamlUserIdentifierResolver resolver = new FirstApplicableChainedSamlIdResolver(
+    SamlUserIdentifierResolver resolver = new ChainedCollectingSamlIdResolver(
         asList(subjectIdResolver, uniqueIdResolver, persistentNameIdResolver));
 
     SamlUserIdentifierResolutionResult result = resolver.resolveSamlUserIdentifier(cred);

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/ResolverTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/ResolverTests.java
@@ -41,8 +41,8 @@ import org.opensaml.xml.XMLObject;
 import org.opensaml.xml.schema.XSAny;
 import org.springframework.security.saml.SAMLCredential;
 
-import it.infn.mw.iam.authn.saml.util.EPTIDUserIdentifierResolver;
 import it.infn.mw.iam.authn.saml.util.ChainedCollectingSamlIdResolver;
+import it.infn.mw.iam.authn.saml.util.EPTIDUserIdentifierResolver;
 import it.infn.mw.iam.authn.saml.util.NameIdUserIdentifierResolver;
 import it.infn.mw.iam.authn.saml.util.NamedSamlUserIdentifierResolver;
 import it.infn.mw.iam.authn.saml.util.PersistentNameIdUserIdentifierResolver;
@@ -200,7 +200,7 @@ public class ResolverTests {
   }
 
   @Test
-  public void firstApplicableChainedResolverTest() {
+  public void ChainedResolverReturnsErrorsIfNoMatchedSamlIds() {
 
     SamlIdResolvers resolvers = new SamlIdResolvers();
 
@@ -236,7 +236,7 @@ public class ResolverTests {
   }
 
   @Test
-  public void firstApplicableChainedResolverTestSuccess() {
+  public void ChainedResolverTestSuccess() {
 
     SamlIdResolvers resolvers = new SamlIdResolvers();
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/ResolverTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/ResolverTests.java
@@ -54,7 +54,6 @@ import it.infn.mw.iam.persistence.model.IamSamlId;
 
 public class ResolverTests {
 
-
   @Test
   public void testSamlIdResolverAttributeResolution() {
     SamlIdResolvers resolvers = new SamlIdResolvers();
@@ -62,7 +61,6 @@ public class ResolverTests {
     for (Saml2Attribute a : Saml2Attribute.values()) {
       Assert.assertNotNull(resolvers.byName(a.getAlias()));
     }
-
   }
 
   @Test
@@ -73,10 +71,10 @@ public class ResolverTests {
 
     SamlUserIdentifierResolver resolver = new NameIdUserIdentifierResolver();
 
-    Optional<IamSamlId> resolvedId = resolver.resolveSamlUserIdentifier(cred).getResolvedId();
+    Optional<IamSamlId> resolvedId =
+        resolver.resolveSamlUserIdentifier(cred).getResolvedIds().stream().findFirst();
 
     Assert.assertFalse(resolvedId.isPresent());
-
   }
 
   @Test
@@ -92,8 +90,11 @@ public class ResolverTests {
 
     SamlUserIdentifierResolver resolver = new NameIdUserIdentifierResolver();
 
-    IamSamlId resolvedId = resolver.resolveSamlUserIdentifier(cred).getResolvedId().orElseThrow(
-        () -> new AssertionError("Could not resolve nameid SAML ID"));
+    IamSamlId resolvedId = resolver.resolveSamlUserIdentifier(cred)
+      .getResolvedIds()
+      .stream()
+      .findFirst()
+      .orElseThrow(() -> new AssertionError("Could not resolve nameid SAML ID"));
 
     assertThat(resolvedId.getUserId(), Matchers.equalTo("nameid"));
     assertThat(resolvedId.getIdpId(), Matchers.equalTo("entityId"));
@@ -113,9 +114,9 @@ public class ResolverTests {
     SamlUserIdentifierResolver resolver = new PersistentNameIdUserIdentifierResolver();
 
     SamlUserIdentifierResolutionResult result = resolver.resolveSamlUserIdentifier(cred);
-    assertThat(result.getResolvedId().isPresent(), is(false));
-    assertThat(result.getErrorMessages().isPresent(), is(true));
-    assertThat(result.getErrorMessages().get().get(0),
+    assertThat(result.getResolvedIds().isEmpty(), is(true));
+    assertThat(result.getErrorMessages().isEmpty(), is(false));
+    assertThat(result.getErrorMessages().get(0),
         containsString("resolved NameID is not persistent"));
   }
 
@@ -128,9 +129,9 @@ public class ResolverTests {
     SamlUserIdentifierResolver resolver = new PersistentNameIdUserIdentifierResolver();
 
     SamlUserIdentifierResolutionResult result = resolver.resolveSamlUserIdentifier(cred);
-    assertThat(result.getResolvedId().isPresent(), is(false));
-    assertThat(result.getErrorMessages().isPresent(), is(true));
-    assertThat(result.getErrorMessages().get().get(0),
+    assertThat(result.getResolvedIds().isEmpty(), is(true));
+    assertThat(result.getErrorMessages().isEmpty(), is(false));
+    assertThat(result.getErrorMessages().get(0),
         containsString("NameID element not found in samlAssertion"));
   }
 
@@ -147,10 +148,9 @@ public class ResolverTests {
     SamlUserIdentifierResolver resolver = new PersistentNameIdUserIdentifierResolver();
 
     SamlUserIdentifierResolutionResult result = resolver.resolveSamlUserIdentifier(cred);
-    assertThat(result.getResolvedId().isPresent(), is(true));
-    assertThat(result.getErrorMessages().isPresent(), is(false));
-    assertThat(result.getResolvedId().get().getUserId(), is("nameid"));
-
+    assertThat(result.getResolvedIds().isEmpty(), is(false));
+    assertThat(result.getErrorMessages().isEmpty(), is(true));
+    assertThat(result.getResolvedIds().get(0).getUserId(), is("nameid"));
   }
 
   @Test
@@ -166,8 +166,11 @@ public class ResolverTests {
       .thenReturn("test@test.org");
     Mockito.when(cred.getRemoteEntityID()).thenReturn("entityId");
 
-    IamSamlId resolvedId = resolver.resolveSamlUserIdentifier(cred).getResolvedId().orElseThrow(
-        () -> new AssertionError("Could not resolve email address SAML ID"));
+    IamSamlId resolvedId = resolver.resolveSamlUserIdentifier(cred)
+      .getResolvedIds()
+      .stream()
+      .findFirst()
+      .orElseThrow(() -> new AssertionError("Could not resolve email address SAML ID"));
 
     assertThat(resolvedId.getUserId(), equalTo("test@test.org"));
     assertThat(resolvedId.getAttributeId(), equalTo(Saml2Attribute.MAIL.getAttributeName()));
@@ -188,13 +191,12 @@ public class ResolverTests {
     Mockito.when(cred.getRemoteEntityID()).thenReturn("entityId");
 
     SamlUserIdentifierResolutionResult result = resolver.resolveSamlUserIdentifier(cred);
-    assertThat(result.getResolvedId().isPresent(), is(false));
-    assertThat(result.getErrorMessages().isPresent(), is(true));
+    assertThat(result.getResolvedIds().isEmpty(), is(true));
+    assertThat(result.getErrorMessages().isEmpty(), is(false));
 
-    assertThat(result.getErrorMessages().get().get(0),
+    assertThat(result.getErrorMessages().get(0),
         containsString(format("Attribute '%s:%s' not found in assertion",
             Saml2Attribute.SUBJECT_ID.getAlias(), Saml2Attribute.SUBJECT_ID.getAttributeName())));
-
   }
 
   @Test
@@ -218,18 +220,18 @@ public class ResolverTests {
         asList(subjectIdResolver, uniqueIdResolver, persistentNameIdResolver));
 
     SamlUserIdentifierResolutionResult result = resolver.resolveSamlUserIdentifier(cred);
-    assertThat(result.getResolvedId().isPresent(), is(false));
-    assertThat(result.getErrorMessages().isPresent(), is(true));
-    assertThat(result.getErrorMessages().get().size(), is(3));
-    assertThat(result.getErrorMessages().get().get(0),
+    assertThat(result.getResolvedIds().isEmpty(), is(true));
+    assertThat(result.getErrorMessages().isEmpty(), is(false));
+    assertThat(result.getErrorMessages().size(), is(3));
+    assertThat(result.getErrorMessages().get(0),
         containsString(format("Attribute '%s:%s' not found in assertion",
             Saml2Attribute.SUBJECT_ID.getAlias(), Saml2Attribute.SUBJECT_ID.getAttributeName())));
 
-    assertThat(result.getErrorMessages().get().get(1),
+    assertThat(result.getErrorMessages().get(1),
         containsString(format("Attribute '%s:%s' not found in assertion",
             Saml2Attribute.EPUID.getAlias(), Saml2Attribute.EPUID.getAttributeName())));
 
-    assertThat(result.getErrorMessages().get().get(2),
+    assertThat(result.getErrorMessages().get(2),
         containsString("NameID element not found in samlAssertion"));
   }
 
@@ -254,9 +256,36 @@ public class ResolverTests {
         asList(subjectIdResolver, uniqueIdResolver, persistentNameIdResolver));
 
     SamlUserIdentifierResolutionResult result = resolver.resolveSamlUserIdentifier(cred);
-    assertThat(result.getResolvedId().isPresent(), is(true));
-    assertThat(result.getResolvedId().get().getUserId(), is("123456789@test.org"));
+    assertThat(result.getResolvedIds().isEmpty(), is(false));
+    assertThat(result.getResolvedIds().get(0).getUserId(), is("123456789@test.org"));
+  }
 
+  @Test
+  public void returnAllMatchedSamlIdResolvers() {
+
+    SamlIdResolvers resolvers = new SamlIdResolvers();
+
+    SamlUserIdentifierResolver subjectIdResolver = resolvers.byAttribute(Saml2Attribute.SUBJECT_ID);
+
+    SamlUserIdentifierResolver uniqueIdResolver = resolvers.byAttribute(Saml2Attribute.EPUID);
+
+    SamlUserIdentifierResolver persistentNameIdResolver =
+        new PersistentNameIdUserIdentifierResolver();
+
+    SAMLCredential cred = Mockito.mock(SAMLCredential.class);
+    when(cred.getAttributeAsString(Saml2Attribute.EPUID.getAttributeName()))
+      .thenReturn("123456789@test.org");
+    when(cred.getAttributeAsString(Saml2Attribute.SUBJECT_ID.getAttributeName()))
+      .thenReturn("subject_id");
+
+    SamlUserIdentifierResolver resolver = new FirstApplicableChainedSamlIdResolver(
+        asList(subjectIdResolver, uniqueIdResolver, persistentNameIdResolver));
+
+    SamlUserIdentifierResolutionResult result = resolver.resolveSamlUserIdentifier(cred);
+    assertThat(result.getResolvedIds().isEmpty(), is(false));
+    assertThat(result.getResolvedIds().size(), is(2));
+    assertThat(result.getResolvedIds().get(0).getUserId(), is("subject_id"));
+    assertThat(result.getResolvedIds().get(1).getUserId(), is("123456789@test.org"));
   }
 
   @Test
@@ -266,7 +295,6 @@ public class ResolverTests {
     NamedSamlUserIdentifierResolver subjectIdResolver =
         resolvers.byAttribute(Saml2Attribute.SUBJECT_ID);
     assertThat(subjectIdResolver.getName(), is(Saml2Attribute.SUBJECT_ID.name()));
-
   }
 
 
@@ -276,7 +304,6 @@ public class ResolverTests {
     SamlIdResolvers resolvers = new SamlIdResolvers();
     SamlUserIdentifierResolver resolver = resolvers.byAttribute(Saml2Attribute.EPTID);
     assertThat(resolver, is(instanceOf(EPTIDUserIdentifierResolver.class)));
-
   }
 
   @Test
@@ -288,12 +315,11 @@ public class ResolverTests {
     SamlUserIdentifierResolver resolver = new EPTIDUserIdentifierResolver();
 
     SamlUserIdentifierResolutionResult result = resolver.resolveSamlUserIdentifier(cred);
-    assertThat(result.getResolvedId().isPresent(), is(false));
-    assertThat(result.getErrorMessages().isPresent(), is(true));
-    assertThat(result.getErrorMessages().get().get(0),
+    assertThat(result.getResolvedIds().isEmpty(), is(true));
+    assertThat(result.getErrorMessages().isEmpty(), is(false));
+    assertThat(result.getErrorMessages().get(0),
         is("Attribute 'eduPersonTargetedId:urn:oid:1.3.6.1.4.1.5923.1.1.1.10' not found in "
             + "assertion"));
-
   }
 
   @Test
@@ -304,7 +330,7 @@ public class ResolverTests {
     XSAny attributeValue = mock(XSAny.class);
     NameID nameid = mock(NameID.class);
     XMLObject object = mock(XMLObject.class);
-    
+
 
     when(cred.getAttribute(Saml2Attribute.EPTID.getAttributeName())).thenReturn(attribute);
 
@@ -312,73 +338,73 @@ public class ResolverTests {
     SamlUserIdentifierResolver resolver = new EPTIDUserIdentifierResolver();
 
     SamlUserIdentifierResolutionResult result = resolver.resolveSamlUserIdentifier(cred);
-    assertThat(result.getResolvedId().isPresent(), is(false));
-    assertThat(result.getErrorMessages().isPresent(), is(true));
-    assertThat(result.getErrorMessages().get().get(0),
-        is("Malformed assertion while looking for attribute 'eduPersonTargetedId:urn:oid:1.3.6.1.4.1.5923.1.1.1.10': "
+    assertThat(result.getResolvedIds().isEmpty(), is(true));
+    assertThat(result.getErrorMessages().isEmpty(), is(false));
+    assertThat(result.getErrorMessages().get(0), is(
+        "Malformed assertion while looking for attribute 'eduPersonTargetedId:urn:oid:1.3.6.1.4.1.5923.1.1.1.10': "
             + "remoteEntityID null or empty"));
-    
+
     when(cred.getRemoteEntityID()).thenReturn("entityId");
-    
+
     result = resolver.resolveSamlUserIdentifier(cred);
-    assertThat(result.getResolvedId().isPresent(), is(false));
-    assertThat(result.getErrorMessages().isPresent(), is(true));
-    assertThat(result.getErrorMessages().get().get(0),
+    assertThat(result.getResolvedIds().isEmpty(), is(true));
+    assertThat(result.getErrorMessages().isEmpty(), is(false));
+    assertThat(result.getErrorMessages().get(0),
         is("Attribute 'eduPersonTargetedId:urn:oid:1.3.6.1.4.1.5923.1.1.1.10' is malformed: "
             + "null or empty list of values"));
 
     when(attribute.getAttributeValues()).thenReturn(emptyList());
     result = resolver.resolveSamlUserIdentifier(cred);
 
-    assertThat(result.getResolvedId().isPresent(), is(false));
-    assertThat(result.getErrorMessages().isPresent(), is(true));
-    assertThat(result.getErrorMessages().get().get(0),
+    assertThat(result.getResolvedIds().isEmpty(), is(true));
+    assertThat(result.getErrorMessages().isEmpty(), is(false));
+    assertThat(result.getErrorMessages().get(0),
         is("Attribute 'eduPersonTargetedId:urn:oid:1.3.6.1.4.1.5923.1.1.1.10' is malformed: "
             + "null or empty list of values"));
 
     when(attribute.getAttributeValues()).thenReturn(asList(nameid, nameid, nameid));
     result = resolver.resolveSamlUserIdentifier(cred);
 
-    assertThat(result.getResolvedId().isPresent(), is(false));
-    assertThat(result.getErrorMessages().isPresent(), is(true));
-    assertThat(result.getErrorMessages().get().get(0),
+    assertThat(result.getResolvedIds().isEmpty(), is(true));
+    assertThat(result.getErrorMessages().isEmpty(), is(false));
+    assertThat(result.getErrorMessages().get(0),
         is("Attribute 'eduPersonTargetedId:urn:oid:1.3.6.1.4.1.5923.1.1.1.10' is malformed: "
             + "more than one value found"));
 
     when(attribute.getAttributeValues()).thenReturn(asList(object));
     result = resolver.resolveSamlUserIdentifier(cred);
-    assertThat(result.getResolvedId().isPresent(), is(false));
-    assertThat(result.getErrorMessages().isPresent(), is(true));
-    assertThat(result.getErrorMessages().get().get(0),
+    assertThat(result.getResolvedIds().isEmpty(), is(true));
+    assertThat(result.getErrorMessages().isEmpty(), is(false));
+    assertThat(result.getErrorMessages().get(0),
         is("Attribute 'eduPersonTargetedId:urn:oid:1.3.6.1.4.1.5923.1.1.1.10' is malformed: "
             + "attribute value is not an XSAny"));
 
-    
+
     when(attribute.getAttributeValues()).thenReturn(asList(attributeValue));
     when(attribute.hasChildren()).thenReturn(false);
     result = resolver.resolveSamlUserIdentifier(cred);
-    assertThat(result.getResolvedId().isPresent(), is(false));
-    assertThat(result.getErrorMessages().isPresent(), is(true));
-    assertThat(result.getErrorMessages().get().get(0),
+    assertThat(result.getResolvedIds().isEmpty(), is(true));
+    assertThat(result.getErrorMessages().isEmpty(), is(false));
+    assertThat(result.getErrorMessages().get(0),
         is("Attribute 'eduPersonTargetedId:urn:oid:1.3.6.1.4.1.5923.1.1.1.10' is malformed: "
             + "attribute value has no children elements"));
-    
+
     when(attributeValue.hasChildren()).thenReturn(true);
     when(attributeValue.getOrderedChildren()).thenReturn(asList(object));
     result = resolver.resolveSamlUserIdentifier(cred);
-    assertThat(result.getResolvedId().isPresent(), is(false));
-    assertThat(result.getErrorMessages().isPresent(), is(true));
-    assertThat(result.getErrorMessages().get().get(0),
+    assertThat(result.getResolvedIds().isEmpty(), is(true));
+    assertThat(result.getErrorMessages().isEmpty(), is(false));
+    assertThat(result.getErrorMessages().get(0),
         is("Attribute 'eduPersonTargetedId:urn:oid:1.3.6.1.4.1.5923.1.1.1.10' is malformed: "
             + "attribute value first children value is not a NameID"));
-    
+
     when(attributeValue.getOrderedChildren()).thenReturn(asList(nameid));
     when(nameid.getFormat()).thenReturn(NameIDType.UNSPECIFIED);
 
     result = resolver.resolveSamlUserIdentifier(cred);
-    assertThat(result.getResolvedId().isPresent(), is(false));
-    assertThat(result.getErrorMessages().isPresent(), is(true));
-    assertThat(result.getErrorMessages().get().get(0),
+    assertThat(result.getResolvedIds().isEmpty(), is(true));
+    assertThat(result.getErrorMessages().isEmpty(), is(false));
+    assertThat(result.getErrorMessages().get(0),
         is("Attribute 'eduPersonTargetedId:urn:oid:1.3.6.1.4.1.5923.1.1.1.10' is malformed: "
             + "resolved NameID is not persistent: " + NameIDType.UNSPECIFIED));
   }
@@ -395,7 +421,7 @@ public class ResolverTests {
     when(attribute.getAttributeValues()).thenReturn(asList(attributeValue));
     when(attributeValue.hasChildren()).thenReturn(true);
     when(attributeValue.getOrderedChildren()).thenReturn(asList(nameid));
-    
+
     when(nameid.getFormat()).thenReturn(NameIDType.PERSISTENT);
     when(nameid.getValue()).thenReturn("nameid");
     when(nameid.getNameQualifier()).thenReturn("nameIdNameQualifier");
@@ -404,12 +430,12 @@ public class ResolverTests {
     SamlUserIdentifierResolver resolver = new EPTIDUserIdentifierResolver();
     SamlUserIdentifierResolutionResult result = resolver.resolveSamlUserIdentifier(cred);
 
-    assertThat(result.getResolvedId().isPresent(), is(true));
-    assertThat(result.getErrorMessages().isPresent(), is(false));
-    assertThat(result.getResolvedId().get().getUserId(), is("nameid"));
-    assertThat(result.getResolvedId().get().getIdpId(), is("entityId"));
+    assertThat(result.getResolvedIds().isEmpty(), is(false));
+    assertThat(result.getErrorMessages().isEmpty(), is(true));
+    assertThat(result.getResolvedIds().get(0).getUserId(), is("nameid"));
+    assertThat(result.getResolvedIds().get(0).getIdpId(), is("entityId"));
   }
-  
+
   @Test
   public void eptidResolutionSuccessNameidWithoutFormatAttribute() {
     Attribute attribute = mock(Attribute.class);
@@ -422,7 +448,7 @@ public class ResolverTests {
     when(attribute.getAttributeValues()).thenReturn(asList(attributeValue));
     when(attributeValue.hasChildren()).thenReturn(true);
     when(attributeValue.getOrderedChildren()).thenReturn(asList(nameid));
-    
+
     when(nameid.getValue()).thenReturn("nameid");
     when(nameid.getNameQualifier()).thenReturn("nameIdNameQualifier");
     when(nameid.getSPNameQualifier()).thenReturn("nameIdSPNameQualifier");
@@ -430,10 +456,9 @@ public class ResolverTests {
     SamlUserIdentifierResolver resolver = new EPTIDUserIdentifierResolver();
     SamlUserIdentifierResolutionResult result = resolver.resolveSamlUserIdentifier(cred);
 
-    assertThat(result.getResolvedId().isPresent(), is(true));
-    assertThat(result.getErrorMessages().isPresent(), is(false));
-    assertThat(result.getResolvedId().get().getUserId(), is("nameid"));
-    assertThat(result.getResolvedId().get().getIdpId(), is("entityId"));
+    assertThat(result.getResolvedIds().isEmpty(), is(false));
+    assertThat(result.getErrorMessages().isEmpty(), is(true));
+    assertThat(result.getResolvedIds().get(0).getUserId(), is("nameid"));
+    assertThat(result.getResolvedIds().get(0).getIdpId(), is("entityId"));
   }
-
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/jit_account_provisioning/JitUserDetailServiceTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/jit_account_provisioning/JitUserDetailServiceTests.java
@@ -15,7 +15,7 @@
  */
 package it.infn.mw.iam.test.ext_authn.saml.jit_account_provisioning;
 
-import static it.infn.mw.iam.authn.saml.util.SamlUserIdentifierResolutionResult.resolutionSuccess;
+import static it.infn.mw.iam.authn.saml.util.SamlUserIdentifierResolutionResult.success;
 import static it.infn.mw.iam.test.ext_authn.saml.SamlAuthenticationTestSupport.DEFAULT_IDP_ID;
 import static it.infn.mw.iam.test.ext_authn.saml.SamlAuthenticationTestSupport.T1_EPUID;
 import static it.infn.mw.iam.test.ext_authn.saml.SamlAuthenticationTestSupport.T1_GIVEN_NAME;
@@ -27,6 +27,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -68,7 +69,7 @@ public class JitUserDetailServiceTests extends JitUserDetailsServiceTestsSupport
 
   @Mock
   private InactiveAccountAuthenticationHander inactiveAccountHander;
-  
+
   @Mock
   private MappingPropertiesResolver mpResolver;
 
@@ -90,12 +91,12 @@ public class JitUserDetailServiceTests extends JitUserDetailsServiceTestsSupport
     });
 
     when(resolver.resolveSamlUserIdentifier(any()))
-      .thenReturn(SamlUserIdentifierResolutionResult.resolutionFailure("No suitable user id found"));
+      .thenReturn(SamlUserIdentifierResolutionResult.failure(List.of("No suitable user id found")));
 
     AttributeMappingProperties defaultMappingProps = new AttributeMappingProperties();
-    
+
     when(mpResolver.resolveMappingProperties(Mockito.any())).thenReturn(defaultMappingProps);
-    
+
     userDetailsService = new JustInTimeProvisioningSAMLUserDetailsService(resolver, accountService,
         inactiveAccountHander, accountRepo, Optional.empty(), mpResolver);
   }
@@ -124,7 +125,7 @@ public class JitUserDetailServiceTests extends JitUserDetailsServiceTestsSupport
 
   @Test(expected = UsernameNotFoundException.class)
   public void testMissingEmailSamlCredentialSanityCheck() {
-    when(resolver.resolveSamlUserIdentifier(cred)).thenReturn(resolutionSuccess(T1_SAML_ID));
+    when(resolver.resolveSamlUserIdentifier(cred)).thenReturn(success(List.of(T1_SAML_ID)));
     try {
       userDetailsService.loadUserBySAML(cred);
     } catch (UsernameNotFoundException e) {
@@ -137,7 +138,7 @@ public class JitUserDetailServiceTests extends JitUserDetailsServiceTestsSupport
 
   @Test(expected = UsernameNotFoundException.class)
   public void testMissingGivenNameSamlCredentialSanityCheck() {
-    when(resolver.resolveSamlUserIdentifier(cred)).thenReturn(resolutionSuccess(T1_SAML_ID));
+    when(resolver.resolveSamlUserIdentifier(cred)).thenReturn(success(List.of(T1_SAML_ID)));
     when(cred.getAttributeAsString(Saml2Attribute.MAIL.getAttributeName())).thenReturn(T1_MAIL);
 
     try {
@@ -152,7 +153,7 @@ public class JitUserDetailServiceTests extends JitUserDetailsServiceTestsSupport
 
   @Test(expected = UsernameNotFoundException.class)
   public void testMissingFamilyNameSamlCredentialSanityCheck() {
-    when(resolver.resolveSamlUserIdentifier(cred)).thenReturn(resolutionSuccess(T1_SAML_ID));
+    when(resolver.resolveSamlUserIdentifier(cred)).thenReturn(success(List.of(T1_SAML_ID)));
     when(cred.getAttributeAsString(Saml2Attribute.MAIL.getAttributeName())).thenReturn(T1_MAIL);
     when(cred.getAttributeAsString(Saml2Attribute.GIVEN_NAME.getAttributeName()))
       .thenReturn(T1_GIVEN_NAME);
@@ -169,7 +170,7 @@ public class JitUserDetailServiceTests extends JitUserDetailsServiceTestsSupport
 
   @Test
   public void testSamlIdIsUsedForUsername() {
-    when(resolver.resolveSamlUserIdentifier(cred)).thenReturn(resolutionSuccess(T1_SAML_ID));
+    when(resolver.resolveSamlUserIdentifier(cred)).thenReturn(success(List.of(T1_SAML_ID)));
     when(cred.getAttributeAsString(Saml2Attribute.MAIL.getAttributeName())).thenReturn(T1_MAIL);
     when(cred.getAttributeAsString(Saml2Attribute.GIVEN_NAME.getAttributeName()))
       .thenReturn(T1_GIVEN_NAME);
@@ -182,7 +183,7 @@ public class JitUserDetailServiceTests extends JitUserDetailsServiceTestsSupport
 
   @Test
   public void uuidIsUsedForAccountUsernameIfResolvedIdLongerThan128Chars() {
-    when(resolver.resolveSamlUserIdentifier(cred)).thenReturn(resolutionSuccess(LONG_SAML_ID));
+    when(resolver.resolveSamlUserIdentifier(cred)).thenReturn(success(List.of(LONG_SAML_ID)));
     when(cred.getAttributeAsString(Saml2Attribute.MAIL.getAttributeName())).thenReturn(T1_MAIL);
     when(cred.getAttributeAsString(Saml2Attribute.GIVEN_NAME.getAttributeName()))
       .thenReturn(T1_GIVEN_NAME);
@@ -198,7 +199,7 @@ public class JitUserDetailServiceTests extends JitUserDetailsServiceTestsSupport
     userDetailsService = new JustInTimeProvisioningSAMLUserDetailsService(resolver, accountService,
         inactiveAccountHander, accountRepo, Optional.of(trustedIdps), mpResolver);
 
-    when(resolver.resolveSamlUserIdentifier(cred)).thenReturn(resolutionSuccess(T1_SAML_ID));
+    when(resolver.resolveSamlUserIdentifier(cred)).thenReturn(success(List.of(T1_SAML_ID)));
     when(cred.getRemoteEntityID()).thenReturn(SamlAuthenticationTestSupport.DEFAULT_IDP_ID);
 
     try {
@@ -217,7 +218,7 @@ public class JitUserDetailServiceTests extends JitUserDetailsServiceTestsSupport
     userDetailsService = new JustInTimeProvisioningSAMLUserDetailsService(resolver, accountService,
         inactiveAccountHander, accountRepo, Optional.of(trustedIdps), mpResolver);
 
-    when(resolver.resolveSamlUserIdentifier(cred)).thenReturn(resolutionSuccess(T1_SAML_ID));
+    when(resolver.resolveSamlUserIdentifier(cred)).thenReturn(success(List.of(T1_SAML_ID)));
     when(cred.getRemoteEntityID()).thenReturn(SamlAuthenticationTestSupport.DEFAULT_IDP_ID);
     when(cred.getAttributeAsString(Saml2Attribute.MAIL.getAttributeName())).thenReturn(T1_MAIL);
     when(cred.getAttributeAsString(Saml2Attribute.GIVEN_NAME.getAttributeName()))

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/jit_account_provisioning/SamlJitAccountProvisioningTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/jit_account_provisioning/SamlJitAccountProvisioningTests.java
@@ -184,7 +184,6 @@ public class SamlJitAccountProvisioningTests extends SamlAuthenticationTestSuppo
 
     assertThat(newProvisionedAccount.getUuid(), equalTo(provisionedAccount.getUuid()));
     assertThat(accountCreatedEventListener.getCount(), equalTo(1L));
-
   }
 
   @Test


### PR DESCRIPTION
When the user authenticates to IAM via a SAML IdP, all `IAM_SAML_ID_RESOLVERS` are evaluated and collected to verify whether the user has already been registered and mapped to one of those resolvers. If not, the user is registered by selecting the first resolver found.