### PR TITLE
Bug fix, field comparison is case sensitive

### DIFF
--- a/iam-login-service/src/main/webapp/resources/iam/apps/registration/registration.controller.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/registration/registration.controller.js
@@ -283,16 +283,16 @@ function RegistrationController(
 				if (
 					$scope.config.fields[field]["fieldBehaviour"].toLowerCase() == "mandatory"
 				) {
-					$scope.fields[field].showField = true;
-					$scope.fields[field].required = true;
+					$scope.fields[field.toLowerCase()].showField = true;
+					$scope.fields[field.toLowerCase()].required = true;
 				} else if (
 					$scope.config.fields[field]["fieldBehaviour"].toLowerCase() === "optional"
 				) {
-					$scope.fields[field].showField = true;
-					$scope.fields[field].required = false;
+					$scope.fields[field.toLowerCase()].showField = true;
+					$scope.fields[field.toLowerCase()].required = false;
 				} else {
-					$scope.fields[field].showField = false;
-					$scope.fields[field].required = false;
+					$scope.fields[field.toLowerCase()].showField = false;
+					$scope.fields[field.toLowerCase()].required = false;
 				}
 			}
 		}


### PR DESCRIPTION
Fixed the notes field and the affiliation field within the registration page. 
All fields reverted to the default values, as the `populateFieldsWithAdminPreference` function within `iam-login-service/src/main/webapp/resources/iam/apps/registration/registration.controller.js` failed. 
It failed as the assignment is case sensitive. 
Hence, the solution was `$scope.fields[field.toLowerCase()].showField = true;` 
