### PR TITLE
Client configuration, changed naming of button and pop-up window for clarification

### DIFF
--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/client.component.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/client.component.html
@@ -84,7 +84,7 @@
                     <button class="btn btn-danger" ng-click="$ctrl.deleteClient()" ng-if="!$ctrl.newClient">Delete
                         client</button>
                     <button class="btn btn-danger" ng-click="$ctrl.revokeTokens()" >Revoke tokens</button>
-                    <button class="btn btn-danger" ng-click="$ctrl.resetClient()" >Reset client</button>
+                    <button class="btn btn-danger" ng-click="$ctrl.resetClient()" >Security Reset</button>
 					<client-status client="$ctrl.clientVal" ng-if="!$ctrl.newClient"></client-status>	
                     <button class="btn btn-default" ng-click="$ctrl.resetVal()" ng-if="!$ctrl.newClient">Reset</button>
                     <button class="btn btn-default" ng-click="$ctrl.cancel()">Cancel</button>

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/resetclient/confirmresetclient.component.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/resetclient/confirmresetclient.component.html
@@ -23,7 +23,13 @@
 
 <div class="modal-body">
     <p class="text-justify text-wrapped">
-        The following client will be reset:
+        <p style="color:red;"><b>Resetting the client will do the following:</b> </p>
+        <ul>
+            <li> Revokes all the tokens created by the client</li>
+            <li> Rotates the client secret</li>
+        </ul>
+
+        <p style="color:red;"><b>The following client will be reset:</b> </p>
     </p>
     <dl>
         <dt>Name</dt>


### PR DESCRIPTION
The `Reset Client` button has been changed to `Security Reset` for clarification. 

Furthermore, the pop-up window that appears has the following information now:

<img width="1655" height="1363" alt="image" src="https://github.com/user-attachments/assets/c483c8ad-c31c-4c55-9792-23b17e398074" />
