### PR TITLE
Don't fallback on default JWT profile

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/IamOAuth2RequestFactory.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/IamOAuth2RequestFactory.java
@@ -169,7 +169,7 @@ public class IamOAuth2RequestFactory extends ConnectOAuth2RequestFactory {
 
     handlePasswordGrantAuthenticationTimestamp(request);
 
-    profileResolver.resolveProfile(client.getScope())
+    profileResolver.resolveProfile(client.getScope(), request.getScope())
       .getRequestValidator()
       .validateRequest(request);
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/introspection/IamIntrospectionService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/introspection/IamIntrospectionService.java
@@ -169,7 +169,8 @@ public class IamIntrospectionService
       return IntrospectionResponse.inactive();
     }
     IntrospectionResponse.Builder builder = new IntrospectionResponse.Builder(true);
-    JWTProfile profile = profileResolver.resolveProfile(rt.getClient().getScope());
+    JWTProfile profile = profileResolver.resolveProfile(rt.getClient().getScope(),
+        rt.getAuthenticationHolder().getAuthentication().getOAuth2Request().getScope());
     profile.getIntrospectionResultHelper()
       .assembleIntrospectionResult(rt, authenticatedClient)
       .forEach(builder::addField);
@@ -185,7 +186,7 @@ public class IamIntrospectionService
       return IntrospectionResponse.inactive();
     }
     IntrospectionResponse.Builder builder = new IntrospectionResponse.Builder(true);
-    JWTProfile profile = profileResolver.resolveProfile(at.getClient().getScope());
+    JWTProfile profile = profileResolver.resolveProfile(at.getClient().getScope(), at.getScope());
     profile.getIntrospectionResultHelper()
       .assembleIntrospectionResult(at, authenticatedClient)
       .forEach(builder::addField);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/IamOIDCTokenService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/IamOIDCTokenService.java
@@ -108,7 +108,7 @@ public class IamOIDCTokenService implements OIDCTokenService {
     IamAccount account =
         accountRepository.findByUuid(sub).orElseThrow(() -> NoSuchAccountError.forUuid(sub));
 
-    JWTProfile profile = profileResolver.resolveProfile(client.getScope());
+    JWTProfile profile = profileResolver.resolveProfile(client.getScope(), accessToken.getScope());
 
     profile.getIDTokenCustomizer()
       .customizeIdTokenClaims(idClaims, client, request, sub, accessToken, account);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/IamTokenEnhancer.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/IamTokenEnhancer.java
@@ -130,7 +130,8 @@ public class IamTokenEnhancer extends ConnectTokenEnhancer {
 
     Instant tokenIssueInstant = clock.instant();
 
-    JWTProfile profile = profileResolver.resolveProfile(client.getScope());
+    JWTProfile profile =
+        profileResolver.resolveProfile(client.getScope(), originalAuthRequest.getScope());
 
     accessTokenEntity
       .setExpiration(computeExpTime(authentication, accessTokenEntity, tokenIssueInstant));

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/JWTProfileResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/JWTProfileResolver.java
@@ -17,8 +17,9 @@ package it.infn.mw.iam.core.oauth.profile;
 
 import java.util.Set;
 
-@FunctionalInterface
 public interface JWTProfileResolver {
 
-  JWTProfile resolveProfile(Set<String> clientScopes);
+  JWTProfile resolveProfile(Set<String> scopes);
+
+  JWTProfile resolveProfile(Set<String> clientScopes, Set<String> requestedScopes);
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/ScopeAwareProfileResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/ScopeAwareProfileResolver.java
@@ -35,18 +35,7 @@ public class ScopeAwareProfileResolver implements JWTProfileResolver {
   @Override
   public JWTProfile resolveProfile(Set<String> scopes) {
 
-    if (Objects.isNull(scopes)) {
-      throw new IllegalArgumentException("null list of scopes");
-    }
-    if (scopes.isEmpty()) {
-      return defaultProfile;
-    }
-
-    Set<JWTProfile> matchedProfiles = matches(scopes);
-    if (matchedProfiles.isEmpty() || matchedProfiles.size() > 1) {
-      return defaultProfile;
-    }
-    return matchedProfiles.iterator().next();
+    return resolveProfile(scopes, Set.of());
   }
 
   @Override
@@ -60,14 +49,18 @@ public class ScopeAwareProfileResolver implements JWTProfileResolver {
     }
 
     Set<JWTProfile> clientMatches = matches(clientScopes);
-    if (clientMatches.isEmpty() || clientMatches.size() > 1) {
-      Set<JWTProfile> requestedMatches = matches(requestedScopes);
-      if (requestedMatches.isEmpty() || requestedMatches.size() > 1) {
-        return defaultProfile;
-      }
-      return requestedMatches.iterator().next();
+    if (clientMatches.isEmpty()) {
+      return defaultProfile;
     }
-    return clientMatches.iterator().next();
+    if (clientMatches.size() == 1) {
+      return clientMatches.iterator().next();
+    }
+    // clientMatches.size() > 1
+    Set<JWTProfile> requestedMatches = matches(requestedScopes);
+    if (requestedMatches.isEmpty() || requestedMatches.size() > 1) {
+      return defaultProfile;
+    }
+    return requestedMatches.iterator().next();
   }
 
   private Set<JWTProfile> matches(Set<String> clientScopes) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/ScopeAwareProfileResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/ScopeAwareProfileResolver.java
@@ -19,6 +19,7 @@ import static java.util.stream.Collectors.toCollection;
 
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 public class ScopeAwareProfileResolver implements JWTProfileResolver {
@@ -32,22 +33,48 @@ public class ScopeAwareProfileResolver implements JWTProfileResolver {
   }
 
   @Override
-  public JWTProfile resolveProfile(Set<String> clientScopes) {
+  public JWTProfile resolveProfile(Set<String> scopes) {
 
-    if (clientScopes == null) {
+    if (Objects.isNull(scopes)) {
       throw new IllegalArgumentException("null list of scopes");
     }
-
-    Set<JWTProfile> matchedProfiles = clientScopes
-      .stream()
-      .filter(profileMap.keySet()::contains)
-      .map(profileMap::get)
-      .collect(toCollection(LinkedHashSet::new));
-
-    if (matchedProfiles.isEmpty() || matchedProfiles.size() > 1) {
+    if (scopes.isEmpty()) {
       return defaultProfile;
     }
 
+    Set<JWTProfile> matchedProfiles = matches(scopes);
+    if (matchedProfiles.isEmpty() || matchedProfiles.size() > 1) {
+      return defaultProfile;
+    }
     return matchedProfiles.iterator().next();
+  }
+
+  @Override
+  public JWTProfile resolveProfile(Set<String> clientScopes, Set<String> requestedScopes) {
+
+    if (Objects.isNull(clientScopes) || Objects.isNull(requestedScopes)) {
+      throw new IllegalArgumentException("null list of scopes");
+    }
+    if (clientScopes.isEmpty() && requestedScopes.isEmpty()) {
+      return defaultProfile;
+    }
+
+    Set<JWTProfile> clientMatches = matches(clientScopes);
+    if (clientMatches.isEmpty() || clientMatches.size() > 1) {
+      Set<JWTProfile> requestedMatches = matches(requestedScopes);
+      if (requestedMatches.isEmpty() || requestedMatches.size() > 1) {
+        return defaultProfile;
+      }
+      return requestedMatches.iterator().next();
+    }
+    return clientMatches.iterator().next();
+  }
+
+  private Set<JWTProfile> matches(Set<String> clientScopes) {
+
+    return clientScopes.stream()
+      .filter(profileMap.keySet()::contains)
+      .map(profileMap::get)
+      .collect(toCollection(LinkedHashSet::new));
   }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/ScopeAwareProfileResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/ScopeAwareProfileResolver.java
@@ -64,8 +64,7 @@ public class ScopeAwareProfileResolver implements JWTProfileResolver {
       return defaultProfile;
     }
     if (!clientMatches.containsAll(requestedMatches)) {
-      throw new IllegalArgumentException(
-          "JWT profile requested doesn't match the ones allowed for the client");
+      throw new IllegalArgumentException(MISMATCH_ERROR);
     }
     return requestedMatches.iterator().next();
   }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/ScopeAwareProfileResolver.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/ScopeAwareProfileResolver.java
@@ -24,6 +24,9 @@ import java.util.Set;
 
 public class ScopeAwareProfileResolver implements JWTProfileResolver {
 
+  public static final String MISMATCH_ERROR =
+      "JWT profile requested doesn't match the ones allowed for the client";
+
   private final Map<String, JWTProfile> profileMap;
   private final JWTProfile defaultProfile;
 
@@ -59,6 +62,10 @@ public class ScopeAwareProfileResolver implements JWTProfileResolver {
     Set<JWTProfile> requestedMatches = matches(requestedScopes);
     if (requestedMatches.isEmpty() || requestedMatches.size() > 1) {
       return defaultProfile;
+    }
+    if (!clientMatches.containsAll(requestedMatches)) {
+      throw new IllegalArgumentException(
+          "JWT profile requested doesn't match the ones allowed for the client");
     }
     return requestedMatches.iterator().next();
   }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/userinfo/IamUserInfoEndpoint.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/userinfo/IamUserInfoEndpoint.java
@@ -85,7 +85,8 @@ public class IamUserInfoEndpoint {
     LOG.debug("Userinfo endpoint: client [id={}] requested user [username={}] info", clientId,
         username);
 
-    JWTProfile profile = profileResolver.resolveProfile(client.get().getScope());
+    JWTProfile profile =
+        profileResolver.resolveProfile(client.get().getScope(), auth.getOAuth2Request().getScope());
     Set<String> scopes = scopeResolver.resolveScope(auth);
     Map<String, Object> claims =
         profile.getUserinfoHelper().resolveScopeClaims(scopes, account.get(), auth);

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/ProfileSelectorTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/ProfileSelectorTests.java
@@ -119,4 +119,22 @@ public class ProfileSelectorTests {
     assertThat(profile, is(iamProfile));
 
   }
+
+  @Test
+  public void multipleProfilesLeadToRequestedProfile() {
+
+    Set<String> clientScopes = Set.of("openid", "aarc", "wlcg");
+
+    JWTProfile profile = profileResolver.resolveProfile(clientScopes, Set.of("openid", "wlcg"));
+    assertThat(profile, is(wlcgProfile));
+
+    profile = profileResolver.resolveProfile(clientScopes, Set.of("openid", "aarc"));
+    assertThat(profile, is(aarcProfile));
+
+    profile = profileResolver.resolveProfile(Set.of("openid"));
+    assertThat(profile, is(iamProfile));
+
+    profile = profileResolver.resolveProfile(Set.of("openid", "wlcg", "aarc"));
+    assertThat(profile, is(iamProfile));
+  }
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/ProfileSelectorTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/ProfileSelectorTests.java
@@ -118,6 +118,8 @@ public class ProfileSelectorTests {
     profile = profileResolver.resolveProfile(Set.of("openid", "kc", "wlcg"));
     assertThat(profile, is(iamProfile));
 
+    profile = profileResolver.resolveProfile(Set.of());
+    assertThat(profile, is(iamProfile));
   }
 
   @Test
@@ -136,5 +138,12 @@ public class ProfileSelectorTests {
 
     profile = profileResolver.resolveProfile(clientScopes, Set.of("openid", "wlcg", "aarc"));
     assertThat(profile, is(iamProfile));
+
+    profile = profileResolver.resolveProfile(clientScopes, Set.of("openid"));
+    assertThat(profile, is(iamProfile));
+
+    profile = profileResolver.resolveProfile(Set.of(), Set.of());
+    assertThat(profile, is(iamProfile));
   }
+
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/ProfileSelectorTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/ProfileSelectorTests.java
@@ -131,10 +131,10 @@ public class ProfileSelectorTests {
     profile = profileResolver.resolveProfile(clientScopes, Set.of("openid", "aarc"));
     assertThat(profile, is(aarcProfile));
 
-    profile = profileResolver.resolveProfile(Set.of("openid"));
+    profile = profileResolver.resolveProfile(clientScopes, Set.of("openid"));
     assertThat(profile, is(iamProfile));
 
-    profile = profileResolver.resolveProfile(Set.of("openid", "wlcg", "aarc"));
+    profile = profileResolver.resolveProfile(clientScopes, Set.of("openid", "wlcg", "aarc"));
     assertThat(profile, is(iamProfile));
   }
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/ProfileSelectorTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/ProfileSelectorTests.java
@@ -144,6 +144,31 @@ public class ProfileSelectorTests {
 
     profile = profileResolver.resolveProfile(Set.of(), Set.of());
     assertThat(profile, is(iamProfile));
+
+    profile = profileResolver.resolveProfile(Set.of(), Set.of("wlcg"));
+    assertThat(profile, is(iamProfile));
+
+    profile = profileResolver.resolveProfile(Set.of(), Set.of("aarc"));
+    assertThat(profile, is(iamProfile));
+
+    profile = profileResolver.resolveProfile(Set.of(), Set.of("kc"));
+    assertThat(profile, is(iamProfile));
+  }
+
+  @Test
+  public void oneProfileLeadToCorrectJwtProfile() {
+
+    JWTProfile profile = profileResolver.resolveProfile(Set.of("openid", "wlcg"), Set.of());
+    assertThat(profile, is(wlcgProfile));
+
+    profile = profileResolver.resolveProfile(Set.of("openid", "aarc"), Set.of());
+    assertThat(profile, is(aarcProfile));
+
+    profile = profileResolver.resolveProfile(Set.of("openid", "kc"), Set.of());
+    assertThat(profile, is(kcProfile));
+
+    profile = profileResolver.resolveProfile(Set.of("openid", "iam"), Set.of());
+    assertThat(profile, is(iamProfile));
   }
 
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/ScopeAwareProfileResolverTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/ScopeAwareProfileResolverTests.java
@@ -17,15 +17,16 @@ package it.infn.mw.iam.test.oauth.profile;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.oauth2.provider.ClientDetails;
 import org.springframework.security.oauth2.provider.ClientDetailsService;
 
@@ -39,10 +40,10 @@ import it.infn.mw.iam.core.oauth.profile.keycloak.KeycloakOidcScopes;
 import it.infn.mw.iam.core.oauth.profile.wlcg.WlcgOidcScopes;
 
 @SuppressWarnings("deprecation")
-@RunWith(MockitoJUnitRunner.class)
-public class ProfileSelectorTests {
+@ExtendWith(MockitoExtension.class)
+class ScopeAwareProfileResolverTests {
 
-  public static final String CLIENT_ID = "client";
+  static final String CLIENT_ID = "client";
 
   @Mock
   ClientDetailsService clientsService;
@@ -64,8 +65,8 @@ public class ProfileSelectorTests {
 
   ScopeAwareProfileResolver profileResolver;
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     Map<String, JWTProfile> profileMap = Maps.newHashMap();
 
     profileMap.put(AarcOidcScopes.AARC, aarcProfile);
@@ -76,20 +77,20 @@ public class ProfileSelectorTests {
     profileResolver = new ScopeAwareProfileResolver(iamProfile, profileMap);
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void nullClientThrowException() throws Exception {
-    profileResolver.resolveProfile(null);
+  @Test
+  void nullClientThrowException() throws Exception {
+    assertThrows(IllegalArgumentException.class, () -> profileResolver.resolveProfile(null));
   }
 
   @Test
-  public void profileNotFoundLeadsToDefaultProfile() {
+  void profileNotFoundLeadsToDefaultProfile() {
 
     JWTProfile profile = profileResolver.resolveProfile(Set.of("openid"));
     assertThat(profile, is(iamProfile));
   }
 
   @Test
-  public void multipleProfilesLeadToDefaultProfile() {
+  void multipleProfilesLeadToDefaultProfile() {
 
     JWTProfile profile = profileResolver.resolveProfile(Set.of("openid", "iam", "wlcg"));
     assertThat(profile, is(iamProfile));
@@ -123,7 +124,7 @@ public class ProfileSelectorTests {
   }
 
   @Test
-  public void multipleProfilesLeadToRequestedProfile() {
+  void multipleProfilesLeadToRequestedProfile() {
 
     Set<String> clientScopes = Set.of("openid", "aarc", "wlcg");
 
@@ -137,6 +138,9 @@ public class ProfileSelectorTests {
     assertThat(profile, is(iamProfile));
 
     profile = profileResolver.resolveProfile(clientScopes, Set.of("openid", "wlcg", "aarc"));
+    assertThat(profile, is(iamProfile));
+
+    profile = profileResolver.resolveProfile(clientScopes, Set.of("openid", "wlcg", "kc"));
     assertThat(profile, is(iamProfile));
 
     profile = profileResolver.resolveProfile(clientScopes, Set.of("openid"));
@@ -153,10 +157,14 @@ public class ProfileSelectorTests {
 
     profile = profileResolver.resolveProfile(Set.of(), Set.of("kc"));
     assertThat(profile, is(iamProfile));
+
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+        () -> profileResolver.resolveProfile(clientScopes, Set.of("openid", "kc")));
+    assertThat(ScopeAwareProfileResolver.MISMATCH_ERROR, is(e.getMessage()));
   }
 
   @Test
-  public void oneProfileLeadToCorrectJwtProfile() {
+  void oneProfileLeadToCorrectJwtProfile() {
 
     JWTProfile profile = profileResolver.resolveProfile(Set.of("openid", "wlcg"), Set.of());
     assertThat(profile, is(wlcgProfile));

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/ScopeAwareProfileResolverTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/ScopeAwareProfileResolverTests.java
@@ -78,7 +78,7 @@ class ScopeAwareProfileResolverTests {
   }
 
   @Test
-  void nullClientThrowException() throws Exception {
+  void nullClientThrowException() {
     assertThrows(IllegalArgumentException.class, () -> profileResolver.resolveProfile(null));
   }
 
@@ -90,7 +90,7 @@ class ScopeAwareProfileResolverTests {
   }
 
   @Test
-  void multipleProfilesLeadToDefaultProfile() {
+  void multipleClientProfilesLeadToDefaultProfileWithNoRequested() {
 
     JWTProfile profile = profileResolver.resolveProfile(Set.of("openid", "iam", "wlcg"));
     assertThat(profile, is(iamProfile));
@@ -124,7 +124,7 @@ class ScopeAwareProfileResolverTests {
   }
 
   @Test
-  void multipleProfilesLeadToRequestedProfile() {
+  void multipleClientProfilesLeadToRequestedProfileIfAllowed() {
 
     Set<String> clientScopes = Set.of("openid", "aarc", "wlcg");
 
@@ -157,9 +157,16 @@ class ScopeAwareProfileResolverTests {
 
     profile = profileResolver.resolveProfile(Set.of(), Set.of("kc"));
     assertThat(profile, is(iamProfile));
+  }
+
+  @Test
+  void requestedProfileIsNotAllowed() {
+
+    Set<String> clientScopes = Set.of("openid", "aarc", "wlcg");
+    Set<String> requestedScopes = Set.of("openid", "kc");
 
     IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
-        () -> profileResolver.resolveProfile(clientScopes, Set.of("openid", "kc")));
+        () -> profileResolver.resolveProfile(clientScopes, requestedScopes));
     assertThat(ScopeAwareProfileResolver.MISMATCH_ERROR, is(e.getMessage()));
   }
 


### PR DESCRIPTION
When the client is allowed to request multiple JWT profiles but the requested scopes clarifies which is the desired profile, don't fallback on IAM profile