### PR TITLE
Fix trust-anchor build

### DIFF
--- a/compose/trust-anchors/x509/conf.d/test0.conf
+++ b/compose/trust-anchors/x509/conf.d/test0.conf
@@ -4,6 +4,7 @@ default_bits           = 2048
 default_keyfile        = ${ENV::CA_NAME}/certs/test0.key.pem
 distinguished_name     = test0_dn
 prompt                 = no
+output_password        = pass
 default_md             = sha512
 x509_extensions        = test0_extensions
 

--- a/compose/trust-anchors/x509/conf.d/test1.conf
+++ b/compose/trust-anchors/x509/conf.d/test1.conf
@@ -4,6 +4,7 @@ default_bits           = 2048
 default_keyfile        = ${ENV::CA_NAME}/certs/test1.key.pem
 distinguished_name     = test1_dn
 prompt                 = no
+output_password        = pass
 default_md             = sha512
 x509_extensions        = test1_extensions
 

--- a/compose/trust-anchors/x509/conf.d/test2.conf
+++ b/compose/trust-anchors/x509/conf.d/test2.conf
@@ -4,6 +4,7 @@ default_bits           = 2048
 default_keyfile        = ${ENV::CA_NAME}/certs/test2.key.pem
 distinguished_name     = test2_dn
 prompt                 = no
+output_password        = pass
 default_md             = sha512
 x509_extensions        = test2_extensions
 

--- a/compose/trust-anchors/x509/conf.d/test3.conf
+++ b/compose/trust-anchors/x509/conf.d/test3.conf
@@ -4,6 +4,7 @@ default_bits           = 2048
 default_keyfile        = ${ENV::CA_NAME}/certs/test3.key.pem
 distinguished_name     = test3_dn
 prompt                 = no
+output_password        = pass
 default_md             = sha512
 x509_extensions        = test3_extensions
 

--- a/compose/trust-anchors/x509/conf.d/test4.conf
+++ b/compose/trust-anchors/x509/conf.d/test4.conf
@@ -4,6 +4,7 @@ default_bits           = 2048
 default_keyfile        = ${ENV::CA_NAME}/certs/test4.key.pem
 distinguished_name     = test4_dn
 prompt                 = no
+output_password        = pass
 default_md             = sha512
 x509_extensions        = test4_extensions
 

--- a/compose/trust-anchors/x509/conf.d/test5.conf
+++ b/compose/trust-anchors/x509/conf.d/test5.conf
@@ -4,6 +4,7 @@ default_bits           = 2048
 default_keyfile        = ${ENV::CA_NAME}/certs/test5.key.pem
 distinguished_name     = test5_dn
 prompt                 = no
+output_password        = pass
 default_md             = sha512
 x509_extensions        = test5_extensions
 


### PR DESCRIPTION
Add password to test certificates from configuration, otherwise the openssl will prompt you to set one.