### PR TITLE
Clone helper-scripts inside Dockerfile

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,4 @@
 [submodule "compose/voms-replica/voms-testsuite"]
 	path = compose/voms-replica/voms-testsuite
 	url = git@github.com:italiangrid/voms-testsuite.git
-[submodule "compose/trust-anchors/helper-scripts"]
-	path = compose/trust-anchors/helper-scripts
-	url = https://baltig.infn.it/mw-devel/helper-scripts
+

--- a/compose/README.md
+++ b/compose/README.md
@@ -5,15 +5,15 @@ and development.
 
 ## Submodules
 
-The folder contains a submodule for the [voms-testsuite](https://github.com/italiangrid/voms-testsuite) and the [helper-scripts](https://baltig.infn.it/mw-devel/helper-scripts).
+The folder contains a submodule for the [voms-testsuite](https://github.com/italiangrid/voms-testsuite).
 
-If you have already cloned the [indigo-iam](https://github.com/indigo-iam/iam) repo, download the submodules with
+If you have already cloned the [indigo-iam](https://github.com/indigo-iam/iam) repo, download the submodule with
 
 ```bash
 git submodule update --init --recursive
 ```
 
-(otherwise clone the repo with the `--recurse-submodules` flag). This will populate the [voms-testsuite](./voms-replica/voms-testsuite/) and the [helper-scripts](./trust-anchors/helper-scripts/) directories.
+(otherwise clone the repo with the `--recurse-submodules` flag). This will populate the [voms-testsuite](./voms-replica/voms-testsuite/) directories.
 
 To update and commit the submodule, type
 

--- a/compose/trust-anchors/Dockerfile
+++ b/compose/trust-anchors/Dockerfile
@@ -1,13 +1,13 @@
 FROM almalinux:9
 
 COPY ./x509 /
-COPY ./helper-scripts /helper-scripts
 COPY ./setup-trust.sh /setup-trust.sh
-
-ENV PATH=/helper-scripts/x509-scripts/scripts:$PATH
 
 RUN dnf install -y epel-release && \
       dnf -y update && \
-      dnf -y install voms-clients-cpp faketime
+      dnf -y install voms-clients-cpp faketime git && \
+      git clone https://baltig.infn.it/mw-devel/helper-scripts.git
+
+ENV PATH=/helper-scripts/x509-scripts/scripts:$PATH
 
 RUN sh setup-trust.sh


### PR DESCRIPTION
The helper-scripts used to create server/user certificates were added as a git submodule, but looks like the `git submodule update --init --recursive` command does not populate the helper-scripts folder for users who doesn't have a baltig account.

Also, the feedback from users was that the way to fetch a submodule is not straight forward, so with this PR we move the clone of the helper-scripts inside the Dockerfile, such to let a docker build do the job.