### PR TITLE
Fix for populating fields via idp

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamWebSecurityConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamWebSecurityConfig.java
@@ -20,6 +20,8 @@ import static it.infn.mw.iam.authn.ExternalAuthenticationRegistrationInfo.Extern
 import static it.infn.mw.iam.authn.multi_factor_authentication.MfaVerifyController.MFA_VERIFY_URL;
 import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
 
+import java.util.Optional;
+
 import javax.servlet.RequestDispatcher;
 
 import org.mitre.openid.connect.assertion.JWTBearerClientAssertionTokenEndpointFilter;
@@ -253,16 +255,11 @@ public class IamWebSecurityConfig {
 
 
     private UserLoginConfig userLoginConfig;
-    private GenericFilterBean authorizationRequestFilter;
     private IamProperties iamProperties;
 
-
     @Autowired
-    public RegistrationConfig(UserLoginConfig userLoginConfig,
-        @Qualifier("mitreAuthzRequestFilter") GenericFilterBean authorizationRequestFilter,
-        IamProperties iamProperties) {
+    public RegistrationConfig(UserLoginConfig userLoginConfig, IamProperties iamProperties) {
       this.userLoginConfig = userLoginConfig;
-      this.authorizationRequestFilter = authorizationRequestFilter;
       this.iamProperties = iamProperties;
     }
 
@@ -291,31 +288,22 @@ public class IamWebSecurityConfig {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
 
-      boolean registrationCertField = iamProperties.getRegistration().getFields() != null
-          && !iamProperties.getRegistration().getFields().isEmpty()
-          && iamProperties.getRegistration().getFields().get(RegistrationField.CERTIFICATE) != null
-          && iamProperties.getRegistration()
-            .getFields()
-            .get(RegistrationField.CERTIFICATE)
-            .getFieldBehaviour() != null;
+      // One can not assume the certificate registration field is provided
 
-      if (registrationCertField && !iamProperties.getRegistration()
-        .getFields()
-        .get(RegistrationField.CERTIFICATE)
-        .getFieldBehaviour()
-        .equals(ExternalAuthAttributeSectionBehaviour.HIDDEN)) {
+      boolean certificateVisible = Optional.ofNullable(iamProperties.getRegistration())
+        .map(IamProperties.RegistrationProperties::getFields)
+        .map(f -> f.get(RegistrationField.CERTIFICATE))
+        .map(IamProperties.RegistrationFieldProperties::getFieldBehaviour)
+        .orElse(
+            ExternalAuthAttributeSectionBehaviour.HIDDEN) != ExternalAuthAttributeSectionBehaviour.HIDDEN;
+
+      if (certificateVisible) {
         http.requestMatchers()
           .antMatchers(START_REGISTRATION_ENDPOINT)
           .and()
           .sessionManagement()
           .enableSessionUrlRewriting(false)
           .and()
-          .addFilterBefore(authorizationRequestFilter, SecurityContextPersistenceFilter.class)
-          .anonymous()
-          .and()
-          .csrf()
-          .requireCsrfProtectionMatcher(new AntPathRequestMatcher("/authorize"))
-          .disable()
           .addFilter(userLoginConfig.iamX509Filter());
       } else {
         http.requestMatchers()
@@ -324,8 +312,6 @@ public class IamWebSecurityConfig {
           .sessionManagement()
           .enableSessionUrlRewriting(false);
       }
-
-
 
       if (iamProperties.getRegistration().isRequireExternalAuthentication()) {
         http.authorizeRequests()
@@ -359,6 +345,12 @@ public class IamWebSecurityConfig {
     @Qualifier("OIDCAuthenticationFilter")
     private OidcClientFilter oidcFilter;
 
+    @Autowired
+    private UserLoginConfig userLoginConfig;
+
+    @Autowired
+    private IamProperties iamProperties;
+
     @Override
     public AuthenticationManager authenticationManagerBean() throws Exception {
 
@@ -377,7 +369,33 @@ public class IamWebSecurityConfig {
     @Override
     protected void configure(final HttpSecurity http) throws Exception {
 
-      // @formatter:off
+      boolean certificateVisible = Optional.ofNullable(iamProperties.getRegistration())
+        .map(IamProperties.RegistrationProperties::getFields)
+        .map(f -> f.get(RegistrationField.CERTIFICATE))
+        .map(IamProperties.RegistrationFieldProperties::getFieldBehaviour)
+        .orElse(
+            ExternalAuthAttributeSectionBehaviour.HIDDEN) != ExternalAuthAttributeSectionBehaviour.HIDDEN;
+
+      if (certificateVisible) {
+        // @formatter:off
+      http
+        .antMatcher("/openid_connect_login**")
+          .exceptionHandling()
+            .authenticationEntryPoint(authenticationEntryPoint())
+        .and()
+          .addFilter(userLoginConfig.iamX509Filter())
+          .addFilterAfter(oidcFilter, SecurityContextPersistenceFilter.class)
+          .authorizeRequests()
+        .antMatchers("/openid_connect_login**")
+          .permitAll()
+        .and()
+          .sessionManagement()
+          .enableSessionUrlRewriting(false)
+          .sessionCreationPolicy(SessionCreationPolicy.ALWAYS);
+      // @formatter:on
+
+      } else {
+        // @formatter:off
       http
         .antMatcher("/openid_connect_login**")
           .exceptionHandling()
@@ -392,6 +410,7 @@ public class IamWebSecurityConfig {
           .enableSessionUrlRewriting(false)
           .sessionCreationPolicy(SessionCreationPolicy.ALWAYS);
       // @formatter:on
+      }
     }
   }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamWebSecurityConfig.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/security/IamWebSecurityConfig.java
@@ -342,14 +342,18 @@ public class IamWebSecurityConfig {
     OidcAuthenticationProvider authProvider;
 
     @Autowired
-    @Qualifier("OIDCAuthenticationFilter")
-    private OidcClientFilter oidcFilter;
+    private IamProperties iamProperties;
 
-    @Autowired
+    private OidcClientFilter oidcFilter;
     private UserLoginConfig userLoginConfig;
 
     @Autowired
-    private IamProperties iamProperties;
+    public ExternalOidcLogin(
+        @Qualifier("OIDCAuthenticationFilter") OidcClientFilter oidcClientFilter,
+        UserLoginConfig userLoginConfig) {
+      this.oidcFilter = oidcClientFilter;
+      this.userLoginConfig = userLoginConfig;
+    }
 
     @Override
     public AuthenticationManager authenticationManagerBean() throws Exception {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/registration/DefaultRegistrationRequestService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/registration/DefaultRegistrationRequestService.java
@@ -60,7 +60,6 @@ import it.infn.mw.iam.authn.x509.IamX509AuthenticationCredential;
 import it.infn.mw.iam.config.IamProperties;
 import it.infn.mw.iam.config.IamProperties.ExternalAuthAttributeSectionBehaviour;
 import it.infn.mw.iam.config.IamProperties.RegistrationField;
-import it.infn.mw.iam.config.IamProperties.RegistrationProperties;
 import it.infn.mw.iam.config.lifecycle.LifecycleProperties;
 import it.infn.mw.iam.core.IamRegistrationRequestStatus;
 import it.infn.mw.iam.core.user.IamAccountService;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/registration/DefaultRegistrationRequestService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/registration/DefaultRegistrationRequestService.java
@@ -178,7 +178,7 @@ public class DefaultRegistrationRequestService
           .get(RegistrationField.CERTIFICATE)
           .getFieldBehaviour()
           .equals(ExternalAuthAttributeSectionBehaviour.OPTIONAL)
-            && dto.getRegisterCertificate().equals("true"))) {
+            && dto.getCertificate().equals("true"))) {
 
       certificateSanityCheck(request);
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/registration/DefaultRegistrationRequestService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/registration/DefaultRegistrationRequestService.java
@@ -60,6 +60,7 @@ import it.infn.mw.iam.authn.x509.IamX509AuthenticationCredential;
 import it.infn.mw.iam.config.IamProperties;
 import it.infn.mw.iam.config.IamProperties.ExternalAuthAttributeSectionBehaviour;
 import it.infn.mw.iam.config.IamProperties.RegistrationField;
+import it.infn.mw.iam.config.IamProperties.RegistrationProperties;
 import it.infn.mw.iam.config.lifecycle.LifecycleProperties;
 import it.infn.mw.iam.core.IamRegistrationRequestStatus;
 import it.infn.mw.iam.core.user.IamAccountService;
@@ -168,16 +169,15 @@ public class DefaultRegistrationRequestService
 
     IamAccount account;
 
-    if (iamProperties.getRegistration()
-      .getFields()
-      .get(RegistrationField.CERTIFICATE)
-      .getFieldBehaviour()
-      .equals(ExternalAuthAttributeSectionBehaviour.MANDATORY)
-        || (iamProperties.getRegistration()
-          .getFields()
-          .get(RegistrationField.CERTIFICATE)
-          .getFieldBehaviour()
-          .equals(ExternalAuthAttributeSectionBehaviour.OPTIONAL)
+    ExternalAuthAttributeSectionBehaviour ceritificateVisability =
+        Optional.ofNullable(iamProperties.getRegistration())
+          .map(IamProperties.RegistrationProperties::getFields)
+          .map(f -> f.get(RegistrationField.CERTIFICATE))
+          .map(IamProperties.RegistrationFieldProperties::getFieldBehaviour)
+          .orElse(ExternalAuthAttributeSectionBehaviour.HIDDEN);
+
+    if (ceritificateVisability.equals(ExternalAuthAttributeSectionBehaviour.MANDATORY)
+        || (ceritificateVisability.equals(ExternalAuthAttributeSectionBehaviour.OPTIONAL)
             && dto.getCertificate().equals("true"))) {
 
       certificateSanityCheck(request);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/registration/RegistrationRequestDto.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/registration/RegistrationRequestDto.java
@@ -96,7 +96,7 @@ public class RegistrationRequestDto implements Serializable {
 
   @JsonView({RegistrationViews.RegistrationExtendDetail.class,
       RegistrationViews.RegistrationDetail.class})
-  private String registerCertificate;
+  private String certificate;
 
   @JsonView({RegistrationViews.RegistrationExtendDetail.class,
       RegistrationViews.RegistrationDetail.class})
@@ -109,7 +109,7 @@ public class RegistrationRequestDto implements Serializable {
       @JsonProperty(value = "givenname", required = true) String givenname,
       @JsonProperty(value = "familyname", required = true) String familyname,
       @JsonProperty(value = "email", required = true) String email,
-      @JsonProperty(value = "registerCertificate", required = false) String registerCertificate,
+      @JsonProperty(value = "certificate", required = false) String certificate,
       @JsonProperty("notes") String notes, @JsonProperty("uuid") String uuid,
       @JsonProperty("birthdate") String birthdate, @JsonProperty("accountId") String accountId,
       @JsonProperty("creationTime") Date creationTime, @JsonProperty("status") String status,
@@ -117,7 +117,7 @@ public class RegistrationRequestDto implements Serializable {
       @JsonProperty("affiliation") String affiliation,
       @JsonProperty("labels") List<LabelDTO> labels) {
     super();
-    this.registerCertificate = registerCertificate;
+    this.certificate = certificate;
     this.username = username;
     this.givenname = givenname;
     this.familyname = familyname;
@@ -241,12 +241,12 @@ public class RegistrationRequestDto implements Serializable {
     this.notes = notes;
   }
 
-  public String getRegisterCertificate() {
-    return this.registerCertificate;
+  public String getCertificate() {
+    return this.certificate;
   }
 
-  public void setRegisterCertificate(String registerCertificate) {
-    this.registerCertificate = registerCertificate;
+  public void setCertificate(String certificate) {
+    this.certificate = certificate;
   }
 
   public String getAffiliation() {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/registration/validation/RegistrationFieldsValidationService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/registration/validation/RegistrationFieldsValidationService.java
@@ -147,7 +147,7 @@ public class RegistrationFieldsValidationService implements RegistrationRequestV
       case NOTES:
         return dto.getNotes() != null && !dto.getNotes().isBlank();
       case CERTIFICATE:
-        return dto.getRegisterCertificate() != null && !dto.getRegisterCertificate().isBlank();
+        return dto.getCertificate() != null && !dto.getCertificate().isBlank();
       default:
         return false;
     }

--- a/iam-login-service/src/main/webapp/resources/iam/apps/registration/registration.controller.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/registration/registration.controller.js
@@ -187,7 +187,13 @@ function RegistrationController(
 				}
 			});
 
-			modalInstance.result.then(self.handleSuccess);
+			modalInstance.result.then(self.handleSuccess)
+				.catch(function (reason) {
+					if (reason === 'Dismissed') {
+						return;
+					}
+					console.error('Modal dismissed with error:', reason);
+				});
 		}
 	};
 

--- a/iam-login-service/src/main/webapp/resources/iam/apps/registration/registration.controller.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/registration/registration.controller.js
@@ -128,7 +128,7 @@ function RegistrationController(
 			required: true,
 			showField: true,
 		},
-		registerCertificate: {
+		certificate: {
 			type: "certificate",
 			required: false,
 			showField: true,
@@ -149,7 +149,7 @@ function RegistrationController(
 	vm.populateFieldsWithAdminPreference = populateFieldsWithAdminPreference;
 	vm.getFieldErrorMessage = getFieldErrorMessage;
 	vm.openExpiringCertificateDialog = openExpiringCertificateDialog;
-	vm.registerCertificate = true;
+	vm.certificate = true;
 
 	vm.activate();
 	vm.openExpiringCertificateDialog();
@@ -261,7 +261,7 @@ function RegistrationController(
 				email: populateValue(info, 'email'),
 				affiliation: populateValue(info, 'affiliation'),
 				notes: '',
-				registerCertificate: true,
+				certificate: true,
 			};
 
 			if (info.type === 'OIDC') {
@@ -316,7 +316,7 @@ function RegistrationController(
 			username: '',
 			email: '',
 			notes: '',
-			registerCertificate: true,
+			certificate: true,
 			affiliation: '',
 		};
 	}
@@ -359,6 +359,7 @@ function RegistrationController(
 					$scope.fields[field.toLowerCase()].showField = true;
 					$scope.fields[field.toLowerCase()].required = false;
 				} else {
+					//Think it is failing, because certificate isn't properly a part
 					$scope.fields[field.toLowerCase()].showField = false;
 					$scope.fields[field.toLowerCase()].required = false;
 				}

--- a/iam-login-service/src/main/webapp/resources/iam/apps/registration/registration.controller.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/registration/registration.controller.js
@@ -242,8 +242,8 @@ function RegistrationController(
 
 	function populateValue(info, name) {
 		const fieldName = name.toUpperCase();
-		const hasExternalAttributeDefined = Boolean(typeof $scope.config.fields != 'undefined' 
-			&& typeof $scope.config.fields[fieldName] != 'undefined' 
+		const hasExternalAttributeDefined = Boolean(typeof $scope.config.fields != 'undefined'
+			&& typeof $scope.config.fields[fieldName] != 'undefined'
 			&& typeof $scope.config.fields[fieldName].externalAuthAttribute != 'undefined');
 		if (hasExternalAttributeDefined) {
 			return lookupAuthInfo(info, $scope.config.fields[fieldName].externalAuthAttribute);
@@ -359,7 +359,6 @@ function RegistrationController(
 					$scope.fields[field.toLowerCase()].showField = true;
 					$scope.fields[field.toLowerCase()].required = false;
 				} else {
-					//Think it is failing, because certificate isn't properly a part
 					$scope.fields[field.toLowerCase()].showField = false;
 					$scope.fields[field.toLowerCase()].required = false;
 				}

--- a/iam-login-service/src/main/webapp/resources/iam/apps/registration/registration.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/registration/registration.html
@@ -134,40 +134,40 @@
 
 					<chekbox ng-if="field.type === 'certificate'">
 						<div id="checkbox"
-							ng-attr-title="{{(request.registerCertificate) ? 'Un-check to not link your certificate to the account' : 'Check to link your certificate to the account'}}"
+							ng-attr-title="{{(request.certificate) ? 'Un-check to not link your certificate to the account' : 'Check to link your certificate to the account'}}"
 							ng-if="iamX509Required === 'OPTIONAL'">
 
 							<label for="register-certificate"
-								ng-style="(request.registerCertificate && (iamX509SuspendedAccount || iamX509CanLogin)) ? {'color' : 'red'} : {}">
+								ng-style="(request.certificate && (iamX509SuspendedAccount || iamX509CanLogin)) ? {'color' : 'red'} : {}">
 								Register certificate
 							</label><br>
 
 							<input type="checkbox" id="register-certificate" name="register-certificate"
-								ng-model="request.registerCertificate">
+								ng-model="request.certificate">
 
 							<!-- Certificate is already linked -->
 							<span
-								ng-if="(iamX509Required === 'OPTIONAL') && iamX509CanLogin && request.registerCertificate"
+								ng-if="(iamX509Required === 'OPTIONAL') && iamX509CanLogin && request.certificate"
 								style="color: red;">
 								Certificate is already linked to an account. It can not be linked
 							</span>
 
 							<!-- Certificate is linked to a blocked account -->
 							<span
-								ng-if="(iamX509Required === 'OPTIONAL') && iamX509SuspendedAccount && request.registerCertificate"
+								ng-if="(iamX509Required === 'OPTIONAL') && iamX509SuspendedAccount && request.certificate"
 								style="color: red;">
 								Certificate is linked to an suspended account. It can not be linked
 							</span>
 
 							<!-- Certificate is not present in the browser -->
-							<span ng-if="(iamX509Required === 'OPTIONAL') &&!iamX509Cred && request.registerCertificate"
+							<span ng-if="(iamX509Required === 'OPTIONAL') &&!iamX509Cred && request.certificate"
 								style="color: red;">
 								No certificate present to link. Not possible to link certificate
 							</span>
 
 							<!-- No errors or the box is not checked -->
 							<span
-								ng-if="(iamX509Required === 'OPTIONAL') && ((!iamX509SuspendedAccount && !iamX509CanLogin && iamX509Cred && request.registerCertificate) || !request.registerCertificate)">
+								ng-if="(iamX509Required === 'OPTIONAL') && ((!iamX509SuspendedAccount && !iamX509CanLogin && iamX509Cred && request.certificate) || !request.certificate)">
 								Link your certificate to the account
 							</span>
 
@@ -221,7 +221,7 @@
 			<div class="form-group"
 				ng-if="!(iamX509Required === 'MANDATORY') || (iamX509Cred && !iamX509CanLogin && !iamX509SuspendedAccount)">
 				<button class="btn btn-primary" type="submit" id="register-submit-btn" name="register"
-					ng-disabled="!registrationForm.$valid || busy || (iamX509Required === 'OPTIONAL' && request.registerCertificate && (iamX509CanLogin || iamX509SuspendedAccount || !iamX509Cred))"
+					ng-disabled="!registrationForm.$valid || busy || (iamX509Required === 'OPTIONAL' && request.certificate && (iamX509CanLogin || iamX509SuspendedAccount || !iamX509Cred))"
 					ng-click="rc.submit()">Register</button>
 				<button class="btn btn-warning" type="button" id="register-reset-btn" name="reset" ng-click="rc.reset()"
 					ng-disabled="registrationForm.$pristine">Reset Form</button>
@@ -229,7 +229,7 @@
 			</div>
 			<div id="x509-authn-info"
 				ng-if="iamX509Cred && (iamX509Required === 'OPTIONAL' || (iamX509Required === 'MANDATORY' && !iamX509CanLogin && !iamX509SuspendedAccount))">
-				You have been succesfully authenticated as, {{registerCertificate}}<br>
+				You have been succesfully authenticated as, {{certificate}}<br>
 				<strong>{{iamX509Subject}}</strong>
 
 				<p ng-if="!iamX509CanLogin && !iamX509SuspendedAccount">

--- a/iam-login-service/src/main/webapp/resources/iam/apps/registration/registration.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/registration/registration.html
@@ -28,7 +28,9 @@
 			You have been succesfully authenticated, but your credentials are <strong>not</strong>
 			yet linked to an <strong>{{organisationName}}</strong> account.
 		</p>
-		<p>To proceed with the registration please fill in your personal
+		<p
+			ng-if="iamX509Required === 'HIDDEN' || iamX509Required === 'OPTIONAL' || (iamX509Required === 'MANDATORY' && iamX509Cred && !iamX509CanLogin && !iamX509SuspendedAccount) ">
+			To proceed with the registration please fill in your personal
 			information below.</p>
 		<p>
 			To abort this registration click <a href="/reset-session">here</a>.
@@ -42,7 +44,10 @@
 			"Sign in with" button of
 			your preferred identity provider.
 		</p>
+	</div>
 
+	<!-- The following X509 Certificate a relevant wether it's through OIDC or not -->
+	<div class="ext-authn-info">
 
 		<!-- In case certificate is MANDATORY, but none were provided  -->
 		<p ng-if="!iamX509Cred && iamX509Required === 'MANDATORY'"
@@ -61,7 +66,6 @@
 				This certificate will expire within a month <br>
 				Specifically at {{iamX509ExpirationDate}} <br> <br>
 			</p>
-
 		</div>
 
 		<!-- In case certificate is MANDATORY and it is linked to another account -->
@@ -80,9 +84,8 @@
 			account is suspended.
 		</p>
 
-
 		<p
-			ng-if="iamX509Required === 'HIDDEN' || iamX509Required === 'OPTIONAL' || (iamX509Required === 'MANDATORY' && iamX509Cred && !iamX509CanLogin && !iamX509SuspendedAccount) ">
+			ng-if="(iamX509Required === 'HIDDEN' || iamX509Required === 'OPTIONAL' || (iamX509Required === 'MANDATORY' && iamX509Cred && !iamX509CanLogin && !iamX509SuspendedAccount)) && extAuthInfo == null ">
 			To proceed with the registration please fill in your personal
 			information below.</p>
 	</div>
@@ -146,8 +149,7 @@
 								ng-model="request.certificate">
 
 							<!-- Certificate is already linked -->
-							<span
-								ng-if="(iamX509Required === 'OPTIONAL') && iamX509CanLogin && request.certificate"
+							<span ng-if="(iamX509Required === 'OPTIONAL') && iamX509CanLogin && request.certificate"
 								style="color: red;">
 								Certificate is already linked to an account. It can not be linked
 							</span>

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/x509/X509PreauthenticationProcessingFilterTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/x509/X509PreauthenticationProcessingFilterTests.java
@@ -57,7 +57,7 @@ class X509PreauthenticationProcessingFilterTests {
     private static final String TEST_0_SUBJECT = "CN=test0,O=IGI,C=IT";
     private static final String TEST_0_ISSUER = "CN=Test CA,O=IGI,C=IT";
 
-    // "Sat Sep 24 17:39:34 CEST 2022";
+    // "Sat Sep 24 17:39:34 CEST 2022"
     private static final Date TEST_0_END_DATE = new Date(1664033974000L);
     private static final String TEST_0_CERT = """
             -----BEGIN CERTIFICATE-----

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/x509/X509PreauthenticationProcessingFilterTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/x509/X509PreauthenticationProcessingFilterTests.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.ext_authn.x509;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+
+
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import it.infn.mw.iam.authn.x509.IamX509AuthenticationCredential;
+import it.infn.mw.iam.authn.x509.IamX509PreauthenticationProcessingFilter;
+import it.infn.mw.iam.authn.x509.X509AuthenticationCredentialExtractor;
+import it.infn.mw.iam.config.IamProperties.ExternalAuthAttributeSectionBehaviour;
+import it.infn.mw.iam.persistence.model.IamAccount;
+import it.infn.mw.iam.persistence.model.IamX509Certificate;
+import it.infn.mw.iam.persistence.repository.IamX509CertificateRepository;
+
+
+@AutoConfigureMockMvc
+@SpringBootTest(properties = "iam.registration.fields.certificate.field-behaviour = OPTIONAL")
+class X509PreauthenticationProcessingFilterTests {
+
+    private static final String TEST_0_SUBJECT = "CN=test0,O=IGI,C=IT";
+    private static final String TEST_0_ISSUER = "CN=Test CA,O=IGI,C=IT";
+
+    // "Sat Sep 24 17:39:34 CEST 2022";
+    private static final Date TEST_0_END_DATE = new Date(1664033974000L);
+    private static final String TEST_0_CERT = """
+            -----BEGIN CERTIFICATE-----
+            MIIDnjCCAoagAwIBAgIBCTANBgkqhkiG9w0BAQUFADAtMQswCQYDVQQGEwJJVDEM
+            MAoGA1UECgwDSUdJMRAwDgYDVQQDDAdUZXN0IENBMB4XDTEyMDkyNjE1MzkzNFoX
+            DTIyMDkyNDE1MzkzNFowKzELMAkGA1UEBhMCSVQxDDAKBgNVBAoTA0lHSTEOMAwG
+            A1UEAxMFdGVzdDAwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDKxtrw
+            hoZ27SxxISjlRqWmBWB6U+N/xW2kS1uUfrQRav6auVtmtEW45J44VTi3WW6Y113R
+            BwmS6oW+3lzyBBZVPqnhV9/VkTxLp83gGVVvHATgGgkjeTxIsOE+TkPKAoZJ/QFc
+            CfPh3WdZ3ANI14WYkAM9VXsSbh2okCsWGa4o6pzt3Pt1zKkyO4PW0cBkletDImJK
+            2vufuDVNm7Iz/y3/8pY8p3MoiwbF/PdSba7XQAxBWUJMoaleh8xy8HSROn7tF2al
+            xoDLH4QWhp6UDn2rvOWseBqUMPXFjsUi1/rkw1oHAjMroTk5lL15GI0LGd5dTVop
+            kKXFbTTYxSkPz1MLAgMBAAGjgcowgccwDAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQU
+            fLdB5+jO9LyWN2/VCNYgMa0jvHEwDgYDVR0PAQH/BAQDAgXgMD4GA1UdJQQ3MDUG
+            CCsGAQUFBwMBBggrBgEFBQcDAgYKKwYBBAGCNwoDAwYJYIZIAYb4QgQBBggrBgEF
+            BQcDBDAfBgNVHSMEGDAWgBSRdzZ7LrRp8yfqt/YIi0ojohFJxjAnBgNVHREEIDAe
+            gRxhbmRyZWEuY2VjY2FudGlAY25hZi5pbmZuLml0MA0GCSqGSIb3DQEBBQUAA4IB
+            AQANYtWXetheSeVpCfnId9TkKyKTAp8RahNZl4XFrWWn2S9We7ACK/G7u1DebJYx
+            d8POo8ClscoXyTO2BzHHZLxauEKIzUv7g2GehI+SckfZdjFyRXjD0+wMGwzX7MDu
+            SL3CG2aWsYpkBnj6BMlr0P3kZEMqV5t2+2Tj0+aXppBPVwzJwRhnrSJiO5WIZAZf
+            49YhMn61sQIrepvhrKEUR4XVorH2Bj8ek1/iLlgcmFMBOds+PrehSRR8Gn0IjlEg
+            C68EY6KPE+FKySuS7Ur7lTAjNdddfdAgKV6hJyST6/dx8ymIkb8nxCPnxCcT2I2N
+            vDxcPMc/wmnMa+smNal0sJ6m
+            -----END CERTIFICATE-----""";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private X509AuthenticationCredentialExtractor credentialExtractor;
+
+    @MockBean
+    private IamX509CertificateRepository certificateRepo;
+
+    @Test
+    void x509_filter_is_triggered_when_credential_is_present() throws Exception {
+
+        IamX509AuthenticationCredential cred = mock(IamX509AuthenticationCredential.class);
+
+        when(cred.failedVerification()).thenReturn(false);
+        when(cred.getSubject()).thenReturn(TEST_0_SUBJECT);
+        when(cred.getIssuer()).thenReturn(TEST_0_ISSUER);
+        X509Certificate userCert = loadTestCertificate();
+
+        when(cred.getCertificateChain()).thenReturn(new X509Certificate[] {userCert});
+
+        when(credentialExtractor.extractX509Credential(any())).thenReturn(Optional.of(cred));
+
+        IamAccount account = mock(IamAccount.class);
+        when(account.isActive()).thenReturn(true);
+
+        IamX509Certificate cert = mock(IamX509Certificate.class);
+        when(cert.getAccount()).thenReturn(account);
+
+        when(certificateRepo.findBySubjectDnAndIssuerDn(any(), any()))
+            .thenReturn(Optional.of(cert));
+
+        mockMvc.perform(get("/").param("x509ClientAuth", "true"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrlPattern("**/login**"))
+            .andExpect(request()
+                .attribute(IamX509PreauthenticationProcessingFilter.X509_ALMOST_EXPIRED, true))
+            .andExpect(request().sessionAttribute(
+                    IamX509PreauthenticationProcessingFilter.X509_ALMOST_EXPIRED, true))
+            .andExpect(request().attribute(IamX509PreauthenticationProcessingFilter.X509_REQUIRED,
+                    ExternalAuthAttributeSectionBehaviour.OPTIONAL))
+            .andExpect(request().sessionAttribute(
+                    IamX509PreauthenticationProcessingFilter.X509_REQUIRED,
+                    ExternalAuthAttributeSectionBehaviour.OPTIONAL))
+            .andExpect(request().attribute(
+                    IamX509PreauthenticationProcessingFilter.X509_EXPIRATION_DATE, TEST_0_END_DATE))
+            .andExpect(request().sessionAttribute(
+                    IamX509PreauthenticationProcessingFilter.X509_EXPIRATION_DATE, TEST_0_END_DATE))
+            .andExpect(request().sessionAttribute(
+                    IamX509PreauthenticationProcessingFilter.X509_CREDENTIAL_SESSION_KEY,
+                    notNullValue()));
+
+        verify(certificateRepo).findBySubjectDnAndIssuerDn(TEST_0_SUBJECT, TEST_0_ISSUER);
+    }
+
+    private static X509Certificate loadTestCertificate() throws Exception {
+        CertificateFactory cf = CertificateFactory.getInstance("X.509");
+
+        return (X509Certificate) cf.generateCertificate(
+                new ByteArrayInputStream(TEST_0_CERT.getBytes(StandardCharsets.US_ASCII)));
+    }
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/RegistrationFieldsValidationServiceTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/RegistrationFieldsValidationServiceTests.java
@@ -24,6 +24,7 @@ import static it.infn.mw.iam.config.IamProperties.RegistrationField.NAME;
 import static it.infn.mw.iam.config.IamProperties.RegistrationField.NOTES;
 import static it.infn.mw.iam.config.IamProperties.RegistrationField.SURNAME;
 import static it.infn.mw.iam.config.IamProperties.RegistrationField.USERNAME;
+import static it.infn.mw.iam.config.IamProperties.RegistrationField.CERTIFICATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -52,304 +53,382 @@ import it.infn.mw.iam.registration.validation.RegistrationRequestValidationResul
 @ExtendWith(SpringExtension.class)
 class RegistrationFieldsValidationServiceTests {
 
-  private final String TEST_USERNAME = "unregistereduser";
-  private final String TEST_EMAIL = TEST_USERNAME + "@example.com";
-  private final String TEST_GIVEN_NAME = "unregistered";
-  private final String TEST_FAMILY_NAME = "unregistered";
-  private final String TEST_NOTES = "This is a note";
+    private final String TEST_USERNAME = "unregistereduser";
+    private final String TEST_EMAIL = TEST_USERNAME + "@example.com";
+    private final String TEST_GIVEN_NAME = "unregistered";
+    private final String TEST_FAMILY_NAME = "unregistered";
+    private final String TEST_NOTES = "This is a note";
+    private final String TEST_CERT = """
+                      -----BEGIN CERTIFICATE-----
+            MIIDkDCCAnigAwIBAgIUIRiHqEUe9NMkryEsI23CTkMamdgwDQYJKoZIhvcNAQEL
+            BQAwLDELMAkGA1UEBhMCSVQxDDAKBgNVBAoMA0lHSTEPMA0GA1UEAwwGdGVzdDAx
+            MB4XDTI1MDcwMTEzMjgwMFoXDTM1MDYyOTEzMjgwMFowLDELMAkGA1UEBhMCSVQx
+            DDAKBgNVBAoMA0lHSTEPMA0GA1UEAwwGdGVzdDAxMIIBIjANBgkqhkiG9w0BAQEF
+            AAOCAQ8AMIIBCgKCAQEA2RuUgUXeAFM9/wOiAMrhttRp2zImtZVRkYFNwawPVxve
+            5SCENZjEivQ3f1PtmFGxG0YboZGu0dR2n9MV3GGNFJkrhAet7fAwoZr8BvoQaEjr
+            yC9I5z3fpwwwabfpsFPe04CeWfXHmSMQoHLXYQqxLi8etzcJZ1tsBT1yAUwbkqNx
+            95bgl4FBaU7iv+jqdxf4aoa5n8QUeM0+CtM/RSQQLQtlKItQRyib8MxYDeRcc3pB
+            VaysLLj1I0bsVZgFM7Qg/2oftsQAMiRqRM0byz2VNBvuaSgZ3gZpOyB/+0P/SGPK
+            WHnxLZMV/Wy5RDckoG4zHVIxIiEeYDD0txnhLsNIxwIDAQABo4GpMIGmMAwGA1Ud
+            EwQFMAMBAf8wDgYDVR0PAQH/BAQDAgGGMB0GA1UdDgQWBBTMwWkWHGWur+WQk7BR
+            VNguNPY5MDBnBgNVHSMEYDBegBTMwWkWHGWur+WQk7BRVNguNPY5MKEwpC4wLDEL
+            MAkGA1UEBhMCSVQxDDAKBgNVBAoMA0lHSTEPMA0GA1UEAwwGdGVzdDAxghQhGIeo
+            RR700ySvISwjbcJOQxqZ2DANBgkqhkiG9w0BAQsFAAOCAQEApWB8P+CQCeJCsOKA
+            65DBE6jCoXS1He+iG5eFfw/GuKZhRe7zLZsObAH+DKqbjkCLsHsRoEUo8EPErmvY
+            GDE58Zrv8fsqakcNseRBcLHgBmPiZgDEIk3yd9S/3mAFaY4D7KLb/2uOHSBc72Ax
+            C3zYT8VA6C7wEiSW+Fg9gbXwMb34Xj6xGIm2+74iogwrQd9l2geyfSLirpUvZe24
+            otjNLk3d7XQ1mSjiUx+6+blzwdIkaoVjbS0WsYOdtaPo+wuPGQieyzWvnIdOl8sd
+            9ovNoFyB1LkUaWImlLucqRKdhuAy/e+9lurYpQ1uft86ep1p6pimEmb7bOQYcKEo
+            jARH0w==
+            -----END CERTIFICATE-----
+                      """;
 
-  @Mock
-  private IamProperties iamProperties;
+    @Mock
+    private IamProperties iamProperties;
 
-  @Mock
-  private ApplicationEventPublisher eventPublisher;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
-  @Mock
-  private IamProperties.RegistrationProperties registrationProperties;
+    @Mock
+    private IamProperties.RegistrationProperties registrationProperties;
 
-  @Mock
-  private RegistrationFieldProperties notesFieldProperties;
+    @Mock
+    private RegistrationFieldProperties notesFieldProperties;
 
-  private RegistrationFieldsValidationService service;
+    private RegistrationFieldsValidationService service;
 
-  @BeforeEach
-  void setup() {
-    MockitoAnnotations.openMocks(this);
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
 
-    // Mock the registration properties and fields map
-    when(iamProperties.getRegistration()).thenReturn(registrationProperties);
-    service = new RegistrationFieldsValidationService(iamProperties, eventPublisher);
-  }
+        // Mock the registration properties and fields map
+        when(iamProperties.getRegistration()).thenReturn(registrationProperties);
+        service = new RegistrationFieldsValidationService(iamProperties, eventPublisher);
+    }
 
-  private RegistrationFieldProperties buildFieldProperties(boolean isReadOnly,
-      ExternalAuthAttributeSectionBehaviour behaviour, String externalAuthAttribute) {
-    RegistrationFieldProperties fieldProperties = new RegistrationFieldProperties();
-    fieldProperties.setReadOnly(isReadOnly);
-    fieldProperties.setFieldBehaviour(behaviour);
-    fieldProperties.setExternalAuthAttribute(externalAuthAttribute);
-    return fieldProperties;
-  }
+    private RegistrationFieldProperties buildFieldProperties(boolean isReadOnly,
+            ExternalAuthAttributeSectionBehaviour behaviour, String externalAuthAttribute) {
+        RegistrationFieldProperties fieldProperties = new RegistrationFieldProperties();
+        fieldProperties.setReadOnly(isReadOnly);
+        fieldProperties.setFieldBehaviour(behaviour);
+        fieldProperties.setExternalAuthAttribute(externalAuthAttribute);
+        return fieldProperties;
+    }
 
-  private RegistrationRequestDto getDefaultFullRegistrationRequest() {
-    RegistrationRequestDto request = new RegistrationRequestDto();
-    request.setGivenname(TEST_GIVEN_NAME);
-    request.setFamilyname(TEST_FAMILY_NAME);
-    request.setEmail(TEST_EMAIL);
-    request.setUsername(TEST_USERNAME);
-    request.setNotes(TEST_NOTES);
-    return request;
-  }
+    private RegistrationRequestDto getDefaultFullRegistrationRequest() {
+        RegistrationRequestDto request = new RegistrationRequestDto();
+        request.setGivenname(TEST_GIVEN_NAME);
+        request.setFamilyname(TEST_FAMILY_NAME);
+        request.setEmail(TEST_EMAIL);
+        request.setUsername(TEST_USERNAME);
+        request.setNotes(TEST_NOTES);
+        request.setCertificate(TEST_CERT);
+        return request;
+    }
 
-  @Test
-  void testAllMandatoryFieldsAreProvided() {
+    @Test
+    void testAllMandatoryFieldsAreProvided() {
 
-    RegistrationRequestDto request;
-    RegistrationRequestValidationResult result;
+        RegistrationRequestDto request;
+        RegistrationRequestValidationResult result;
 
-    // Hidden or Optional: null is ignored
-    request = getDefaultFullRegistrationRequest();
+        // Hidden or Optional: null is ignored
+        request = getDefaultFullRegistrationRequest();
 
-    Map<RegistrationField, RegistrationFieldProperties> fields =
-        new EnumMap<>(RegistrationField.class);
-    fields.put(NAME, buildFieldProperties(false, MANDATORY, null));
-    fields.put(SURNAME, buildFieldProperties(false, MANDATORY, null));
-    fields.put(EMAIL, buildFieldProperties(false, MANDATORY, null));
-    fields.put(USERNAME, buildFieldProperties(false, MANDATORY, null));
-    fields.put(NOTES, buildFieldProperties(false, MANDATORY, null));
-    when(iamProperties.getRegistration().getFields()).thenReturn(fields);
+        Map<RegistrationField, RegistrationFieldProperties> fields =
+                new EnumMap<>(RegistrationField.class);
+        fields.put(NAME, buildFieldProperties(false, MANDATORY, null));
+        fields.put(SURNAME, buildFieldProperties(false, MANDATORY, null));
+        fields.put(EMAIL, buildFieldProperties(false, MANDATORY, null));
+        fields.put(USERNAME, buildFieldProperties(false, MANDATORY, null));
+        fields.put(NOTES, buildFieldProperties(false, MANDATORY, null));
+        fields.put(CERTIFICATE, buildFieldProperties(false, MANDATORY, null));
+        when(iamProperties.getRegistration().getFields()).thenReturn(fields);
 
-    result = service.validateRegistrationRequest(request, Optional.empty());
-    assertTrue(result.isOk());
-  }
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertTrue(result.isOk());
+    }
 
-  @Test
-  void testGivenNameWithDifferentBehaviours() {
+    @Test
+    void testGivenNameWithDifferentBehaviours() {
 
-    RegistrationRequestDto request;
-    RegistrationRequestValidationResult result;
+        RegistrationRequestDto request;
+        RegistrationRequestValidationResult result;
 
-    // Hidden or Optional: null is ignored
-    request = getDefaultFullRegistrationRequest();
-    request.setGivenname(null);
+        // Hidden or Optional: null is ignored
+        request = getDefaultFullRegistrationRequest();
+        request.setGivenname(null);
 
-    Map<RegistrationField, RegistrationFieldProperties> fields =
-        new EnumMap<>(RegistrationField.class);
-    fields.put(NAME, buildFieldProperties(false, HIDDEN, null));
-    fields.put(SURNAME, buildFieldProperties(false, MANDATORY, null));
-    fields.put(EMAIL, buildFieldProperties(false, MANDATORY, null));
-    fields.put(USERNAME, buildFieldProperties(false, MANDATORY, null));
-    fields.put(NOTES, buildFieldProperties(false, MANDATORY, null));
-    when(iamProperties.getRegistration().getFields()).thenReturn(fields);
+        Map<RegistrationField, RegistrationFieldProperties> fields =
+                new EnumMap<>(RegistrationField.class);
+        fields.put(NAME, buildFieldProperties(false, HIDDEN, null));
+        fields.put(SURNAME, buildFieldProperties(false, MANDATORY, null));
+        fields.put(EMAIL, buildFieldProperties(false, MANDATORY, null));
+        fields.put(USERNAME, buildFieldProperties(false, MANDATORY, null));
+        fields.put(NOTES, buildFieldProperties(false, MANDATORY, null));
+        fields.put(CERTIFICATE, buildFieldProperties(false, MANDATORY, null));
+        when(iamProperties.getRegistration().getFields()).thenReturn(fields);
 
-    result = service.validateRegistrationRequest(request, Optional.empty());
-    assertTrue(result.isOk());
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertTrue(result.isOk());
 
-    fields.get(NAME).setFieldBehaviour(OPTIONAL);
-    result = service.validateRegistrationRequest(request, Optional.empty());
-    assertTrue(result.isOk());
+        fields.get(NAME).setFieldBehaviour(OPTIONAL);
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertTrue(result.isOk());
 
-    // Mandatory: expected error
-    fields.get(NAME).setFieldBehaviour(MANDATORY);
-    result = service.validateRegistrationRequest(request, Optional.empty());
-    assertFalse(result.isOk());
-    assertEquals("Mandatory name field cannot be null or an empty string",
-        result.getErrorMessage());
+        // Mandatory: expected error
+        fields.get(NAME).setFieldBehaviour(MANDATORY);
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertFalse(result.isOk());
+        assertEquals("Mandatory name field cannot be null or an empty string",
+                result.getErrorMessage());
 
-    request.setGivenname("");
-    result = service.validateRegistrationRequest(request, Optional.empty());
-    assertFalse(result.isOk());
-    assertEquals("Mandatory name field cannot be null or an empty string",
-        result.getErrorMessage());
+        request.setGivenname("");
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertFalse(result.isOk());
+        assertEquals("Mandatory name field cannot be null or an empty string",
+                result.getErrorMessage());
 
-    request.setGivenname("   ");
-    result = service.validateRegistrationRequest(request, Optional.empty());
-    assertFalse(result.isOk());
-    assertEquals("Mandatory name field cannot be null or an empty string",
-        result.getErrorMessage());
-  }
+        request.setGivenname("   ");
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertFalse(result.isOk());
+        assertEquals("Mandatory name field cannot be null or an empty string",
+                result.getErrorMessage());
+    }
 
-  @Test
-  void testFamilyNameWithDifferentBehaviours() {
+    @Test
+    void testFamilyNameWithDifferentBehaviours() {
 
-    RegistrationRequestDto request;
-    RegistrationRequestValidationResult result;
+        RegistrationRequestDto request;
+        RegistrationRequestValidationResult result;
 
-    // Hidden or Optional: null is ignored
-    request = getDefaultFullRegistrationRequest();
-    request.setFamilyname(null);
+        // Hidden or Optional: null is ignored
+        request = getDefaultFullRegistrationRequest();
+        request.setFamilyname(null);
 
-    Map<RegistrationField, RegistrationFieldProperties> fields =
-        new EnumMap<>(RegistrationField.class);
-    fields.put(NAME, buildFieldProperties(false, MANDATORY, null));
-    fields.put(SURNAME, buildFieldProperties(false, HIDDEN, null));
-    fields.put(EMAIL, buildFieldProperties(false, MANDATORY, null));
-    fields.put(USERNAME, buildFieldProperties(false, MANDATORY, null));
-    fields.put(NOTES, buildFieldProperties(false, MANDATORY, null));
-    when(iamProperties.getRegistration().getFields()).thenReturn(fields);
+        Map<RegistrationField, RegistrationFieldProperties> fields =
+                new EnumMap<>(RegistrationField.class);
+        fields.put(NAME, buildFieldProperties(false, MANDATORY, null));
+        fields.put(SURNAME, buildFieldProperties(false, HIDDEN, null));
+        fields.put(EMAIL, buildFieldProperties(false, MANDATORY, null));
+        fields.put(USERNAME, buildFieldProperties(false, MANDATORY, null));
+        fields.put(NOTES, buildFieldProperties(false, MANDATORY, null));
+        fields.put(CERTIFICATE, buildFieldProperties(false, MANDATORY, null));
+        when(iamProperties.getRegistration().getFields()).thenReturn(fields);
 
-    result = service.validateRegistrationRequest(request, Optional.empty());
-    assertTrue(result.isOk());
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertTrue(result.isOk());
 
-    fields.get(SURNAME).setFieldBehaviour(OPTIONAL);
-    result = service.validateRegistrationRequest(request, Optional.empty());
-    assertTrue(result.isOk());
+        fields.get(SURNAME).setFieldBehaviour(OPTIONAL);
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertTrue(result.isOk());
 
-    // Mandatory: expected error
-    fields.get(SURNAME).setFieldBehaviour(MANDATORY);
-    result = service.validateRegistrationRequest(request, Optional.empty());
-    assertFalse(result.isOk());
-    assertEquals("Mandatory surname field cannot be null or an empty string",
-        result.getErrorMessage());
+        // Mandatory: expected error
+        fields.get(SURNAME).setFieldBehaviour(MANDATORY);
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertFalse(result.isOk());
+        assertEquals("Mandatory surname field cannot be null or an empty string",
+                result.getErrorMessage());
 
-    request.setFamilyname("");
-    result = service.validateRegistrationRequest(request, Optional.empty());
-    assertFalse(result.isOk());
-    assertEquals("Mandatory surname field cannot be null or an empty string",
-        result.getErrorMessage());
+        request.setFamilyname("");
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertFalse(result.isOk());
+        assertEquals("Mandatory surname field cannot be null or an empty string",
+                result.getErrorMessage());
 
-    request.setFamilyname("   ");
-    result = service.validateRegistrationRequest(request, Optional.empty());
-    assertFalse(result.isOk());
-    assertEquals("Mandatory surname field cannot be null or an empty string",
-        result.getErrorMessage());
-  }
+        request.setFamilyname("   ");
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertFalse(result.isOk());
+        assertEquals("Mandatory surname field cannot be null or an empty string",
+                result.getErrorMessage());
+    }
 
-  @Test
-  void testEmailWithDifferentBehaviours() {
+    @Test
+    void testEmailWithDifferentBehaviours() {
 
-    RegistrationRequestDto request;
-    RegistrationRequestValidationResult result;
+        RegistrationRequestDto request;
+        RegistrationRequestValidationResult result;
 
-    // Hidden or Optional: null is ignored
-    request = getDefaultFullRegistrationRequest();
-    request.setEmail(null);
+        // Hidden or Optional: null is ignored
+        request = getDefaultFullRegistrationRequest();
+        request.setEmail(null);
 
-    Map<RegistrationField, RegistrationFieldProperties> fields =
-        new EnumMap<>(RegistrationField.class);
-    fields.put(NAME, buildFieldProperties(false, MANDATORY, null));
-    fields.put(SURNAME, buildFieldProperties(false, MANDATORY, null));
-    fields.put(EMAIL, buildFieldProperties(false, HIDDEN, null));
-    fields.put(USERNAME, buildFieldProperties(false, MANDATORY, null));
-    fields.put(NOTES, buildFieldProperties(false, MANDATORY, null));
-    when(iamProperties.getRegistration().getFields()).thenReturn(fields);
+        Map<RegistrationField, RegistrationFieldProperties> fields =
+                new EnumMap<>(RegistrationField.class);
+        fields.put(NAME, buildFieldProperties(false, MANDATORY, null));
+        fields.put(SURNAME, buildFieldProperties(false, MANDATORY, null));
+        fields.put(EMAIL, buildFieldProperties(false, HIDDEN, null));
+        fields.put(USERNAME, buildFieldProperties(false, MANDATORY, null));
+        fields.put(NOTES, buildFieldProperties(false, MANDATORY, null));
+        fields.put(CERTIFICATE, buildFieldProperties(false, MANDATORY, null));
+        when(iamProperties.getRegistration().getFields()).thenReturn(fields);
 
-    result = service.validateRegistrationRequest(request, Optional.empty());
-    assertTrue(result.isOk());
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertTrue(result.isOk());
 
-    fields.get(EMAIL).setFieldBehaviour(OPTIONAL);
-    result = service.validateRegistrationRequest(request, Optional.empty());
-    assertTrue(result.isOk());
+        fields.get(EMAIL).setFieldBehaviour(OPTIONAL);
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertTrue(result.isOk());
 
-    // Mandatory: expected error
-    fields.get(EMAIL).setFieldBehaviour(MANDATORY);
-    result = service.validateRegistrationRequest(request, Optional.empty());
-    assertFalse(result.isOk());
-    assertEquals("Mandatory email field cannot be null or an empty string",
-        result.getErrorMessage());
+        // Mandatory: expected error
+        fields.get(EMAIL).setFieldBehaviour(MANDATORY);
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertFalse(result.isOk());
+        assertEquals("Mandatory email field cannot be null or an empty string",
+                result.getErrorMessage());
 
-    request.setEmail("");
-    result = service.validateRegistrationRequest(request, Optional.empty());
-    assertFalse(result.isOk());
-    assertEquals("Mandatory email field cannot be null or an empty string",
-        result.getErrorMessage());
+        request.setEmail("");
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertFalse(result.isOk());
+        assertEquals("Mandatory email field cannot be null or an empty string",
+                result.getErrorMessage());
 
-    request.setEmail("   ");
-    result = service.validateRegistrationRequest(request, Optional.empty());
-    assertFalse(result.isOk());
-    assertEquals("Mandatory email field cannot be null or an empty string",
-        result.getErrorMessage());
-  }
+        request.setEmail("   ");
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertFalse(result.isOk());
+        assertEquals("Mandatory email field cannot be null or an empty string",
+                result.getErrorMessage());
+    }
 
-  @Test
-  void testUsernameWithDifferentBehaviours() {
+    @Test
+    void testUsernameWithDifferentBehaviours() {
 
-    RegistrationRequestDto request;
-    RegistrationRequestValidationResult result;
+        RegistrationRequestDto request;
+        RegistrationRequestValidationResult result;
 
-    // Hidden or Optional: null is ignored
-    request = getDefaultFullRegistrationRequest();
-    request.setUsername(null);
+        // Hidden or Optional: null is ignored
+        request = getDefaultFullRegistrationRequest();
+        request.setUsername(null);
 
-    Map<RegistrationField, RegistrationFieldProperties> fields =
-        new EnumMap<>(RegistrationField.class);
-    fields.put(NAME, buildFieldProperties(false, MANDATORY, null));
-    fields.put(SURNAME, buildFieldProperties(false, MANDATORY, null));
-    fields.put(EMAIL, buildFieldProperties(false, MANDATORY, null));
-    fields.put(USERNAME, buildFieldProperties(false, HIDDEN, null));
-    fields.put(NOTES, buildFieldProperties(false, MANDATORY, null));
-    when(iamProperties.getRegistration().getFields()).thenReturn(fields);
+        Map<RegistrationField, RegistrationFieldProperties> fields =
+                new EnumMap<>(RegistrationField.class);
+        fields.put(NAME, buildFieldProperties(false, MANDATORY, null));
+        fields.put(SURNAME, buildFieldProperties(false, MANDATORY, null));
+        fields.put(EMAIL, buildFieldProperties(false, MANDATORY, null));
+        fields.put(USERNAME, buildFieldProperties(false, HIDDEN, null));
+        fields.put(NOTES, buildFieldProperties(false, MANDATORY, null));
+        fields.put(CERTIFICATE, buildFieldProperties(false, MANDATORY, null));
+        when(iamProperties.getRegistration().getFields()).thenReturn(fields);
 
-    result = service.validateRegistrationRequest(request, Optional.empty());
-    assertTrue(result.isOk());
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertTrue(result.isOk());
 
-    fields.get(USERNAME).setFieldBehaviour(OPTIONAL);
-    result = service.validateRegistrationRequest(request, Optional.empty());
-    assertTrue(result.isOk());
+        fields.get(USERNAME).setFieldBehaviour(OPTIONAL);
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertTrue(result.isOk());
 
-    // Mandatory: expected error
-    fields.get(USERNAME).setFieldBehaviour(MANDATORY);
-    result = service.validateRegistrationRequest(request, Optional.empty());
-    assertFalse(result.isOk());
-    assertEquals("Mandatory username field cannot be null or an empty string",
-        result.getErrorMessage());
+        // Mandatory: expected error
+        fields.get(USERNAME).setFieldBehaviour(MANDATORY);
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertFalse(result.isOk());
+        assertEquals("Mandatory username field cannot be null or an empty string",
+                result.getErrorMessage());
 
-    request.setUsername("");
-    result = service.validateRegistrationRequest(request, Optional.empty());
-    assertFalse(result.isOk());
-    assertEquals("Mandatory username field cannot be null or an empty string",
-        result.getErrorMessage());
+        request.setUsername("");
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertFalse(result.isOk());
+        assertEquals("Mandatory username field cannot be null or an empty string",
+                result.getErrorMessage());
 
-    request.setUsername("   ");
-    result = service.validateRegistrationRequest(request, Optional.empty());
-    assertFalse(result.isOk());
-    assertEquals("Mandatory username field cannot be null or an empty string",
-        result.getErrorMessage());
-  }
+        request.setUsername("   ");
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertFalse(result.isOk());
+        assertEquals("Mandatory username field cannot be null or an empty string",
+                result.getErrorMessage());
+    }
 
-  @Test
-  void testNotesWithDifferentBehaviours() {
+    @Test
+    void testNotesWithDifferentBehaviours() {
 
-    RegistrationRequestDto request;
-    RegistrationRequestValidationResult result;
+        RegistrationRequestDto request;
+        RegistrationRequestValidationResult result;
 
-    // Hidden or Optional: null is ignored
-    request = getDefaultFullRegistrationRequest();
-    request.setNotes(null);
+        // Hidden or Optional: null is ignored
+        request = getDefaultFullRegistrationRequest();
+        request.setNotes(null);
 
-    Map<RegistrationField, RegistrationFieldProperties> fields =
-        new EnumMap<>(RegistrationField.class);
-    fields.put(NAME, buildFieldProperties(false, MANDATORY, null));
-    fields.put(SURNAME, buildFieldProperties(false, MANDATORY, null));
-    fields.put(EMAIL, buildFieldProperties(false, MANDATORY, null));
-    fields.put(USERNAME, buildFieldProperties(false, MANDATORY, null));
-    fields.put(NOTES, buildFieldProperties(false, HIDDEN, null));
-    when(iamProperties.getRegistration().getFields()).thenReturn(fields);
+        Map<RegistrationField, RegistrationFieldProperties> fields =
+                new EnumMap<>(RegistrationField.class);
+        fields.put(NAME, buildFieldProperties(false, MANDATORY, null));
+        fields.put(SURNAME, buildFieldProperties(false, MANDATORY, null));
+        fields.put(EMAIL, buildFieldProperties(false, MANDATORY, null));
+        fields.put(USERNAME, buildFieldProperties(false, MANDATORY, null));
+        fields.put(NOTES, buildFieldProperties(false, HIDDEN, null));
+        fields.put(CERTIFICATE, buildFieldProperties(false, MANDATORY, null));
+        when(iamProperties.getRegistration().getFields()).thenReturn(fields);
 
-    result = service.validateRegistrationRequest(request, Optional.empty());
-    assertTrue(result.isOk());
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertTrue(result.isOk());
 
-    fields.get(NOTES).setFieldBehaviour(OPTIONAL);
-    result = service.validateRegistrationRequest(request, Optional.empty());
-    assertTrue(result.isOk());
+        fields.get(NOTES).setFieldBehaviour(OPTIONAL);
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertTrue(result.isOk());
 
-    // Mandatory: expected error
-    fields.get(NOTES).setFieldBehaviour(MANDATORY);
-    result = service.validateRegistrationRequest(request, Optional.empty());
-    assertFalse(result.isOk());
-    assertEquals("Mandatory notes field cannot be null or an empty string",
-        result.getErrorMessage());
+        // Mandatory: expected error
+        fields.get(NOTES).setFieldBehaviour(MANDATORY);
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertFalse(result.isOk());
+        assertEquals("Mandatory notes field cannot be null or an empty string",
+                result.getErrorMessage());
 
-    request.setNotes("");
-    result = service.validateRegistrationRequest(request, Optional.empty());
-    assertFalse(result.isOk());
-    assertEquals("Mandatory notes field cannot be null or an empty string",
-        result.getErrorMessage());
+        request.setNotes("");
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertFalse(result.isOk());
+        assertEquals("Mandatory notes field cannot be null or an empty string",
+                result.getErrorMessage());
 
-    request.setNotes("   ");
-    result = service.validateRegistrationRequest(request, Optional.empty());
-    assertFalse(result.isOk());
-    assertEquals("Mandatory notes field cannot be null or an empty string",
-        result.getErrorMessage());
-  }
+        request.setNotes("   ");
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertFalse(result.isOk());
+        assertEquals("Mandatory notes field cannot be null or an empty string",
+                result.getErrorMessage());
+    }
+
+    @Test
+    void testCertificateWithDifferentBehaviours() {
+
+        RegistrationRequestDto request;
+        RegistrationRequestValidationResult result;
+
+        // Hidden or Optional: null is ignored
+        request = getDefaultFullRegistrationRequest();
+        request.setCertificate(null);
+
+        Map<RegistrationField, RegistrationFieldProperties> fields =
+                new EnumMap<>(RegistrationField.class);
+        fields.put(NAME, buildFieldProperties(false, MANDATORY, null));
+        fields.put(SURNAME, buildFieldProperties(false, MANDATORY, null));
+        fields.put(EMAIL, buildFieldProperties(false, MANDATORY, null));
+        fields.put(USERNAME, buildFieldProperties(false, MANDATORY, null));
+        fields.put(NOTES, buildFieldProperties(false, MANDATORY, null));
+        fields.put(CERTIFICATE, buildFieldProperties(false, HIDDEN, null));
+        when(iamProperties.getRegistration().getFields()).thenReturn(fields);
+
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertTrue(result.isOk());
+
+        fields.get(CERTIFICATE).setFieldBehaviour(OPTIONAL);
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertTrue(result.isOk());
+
+        // Mandatory: expected error
+        fields.get(CERTIFICATE).setFieldBehaviour(MANDATORY);
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertFalse(result.isOk());
+        assertEquals("Mandatory certificate field cannot be null or an empty string",
+                result.getErrorMessage());
+
+        request.setCertificate("");
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertFalse(result.isOk());
+        assertEquals("Mandatory certificate field cannot be null or an empty string",
+                result.getErrorMessage());
+
+        request.setCertificate("   ");
+        result = service.validateRegistrationRequest(request, Optional.empty());
+        assertFalse(result.isOk());
+        assertEquals("Mandatory certificate field cannot be null or an empty string",
+                result.getErrorMessage());
+    }
 
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/RegistrationRequestCertificateOffTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/RegistrationRequestCertificateOffTests.java
@@ -185,7 +185,7 @@ class RegistrationRequestCertificateOffTests {
     request.setEmail(email);
     request.setUsername(USERNAME);
     request.setNotes("Some short notes...");
-    request.setRegisterCertificate("true");
+    request.setCertificate("true");
 
     HttpSession session = httpRequest.getSession();
 
@@ -237,7 +237,7 @@ class RegistrationRequestCertificateOffTests {
     request.setEmail(email);
     request.setUsername(USERNAME);
     request.setNotes("Some short notes...");
-    request.setRegisterCertificate("true");
+    request.setCertificate("true");
 
     HttpSession session = httpRequest.getSession();
 
@@ -309,7 +309,7 @@ class RegistrationRequestCertificateOffTests {
     request1.setEmail(email);
     request1.setUsername(USERNAME);
     request1.setNotes("Some short notes...");
-    request1.setRegisterCertificate("true");
+    request1.setCertificate("true");
 
     MockHttpServletRequest req1 = new MockHttpServletRequest();
     MockHttpSession session1 = new MockHttpSession();
@@ -339,7 +339,7 @@ class RegistrationRequestCertificateOffTests {
     request2.setEmail(email2);
     request2.setUsername(USERNAME_2);
     request2.setNotes("Some short notes...");
-    request2.setRegisterCertificate("true");
+    request2.setCertificate("true");
 
     MockHttpServletRequest req2 = new MockHttpServletRequest();
     MockHttpSession session2 = new MockHttpSession();

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/RegistrationRequestCertificateOptionalTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/RegistrationRequestCertificateOptionalTests.java
@@ -153,7 +153,7 @@ class RegistrationRequestCertificateOptionalTests {
     request.setEmail(email);
     request.setUsername(USERNAME);
     request.setNotes("Some short notes...");
-    request.setRegisterCertificate("true");
+    request.setCertificate("true");
 
     HttpSession session = httpRequest.getSession();
 
@@ -205,7 +205,7 @@ class RegistrationRequestCertificateOptionalTests {
     request.setEmail(email);
     request.setUsername(USERNAME_2);
     request.setNotes("Some short notes...");
-    request.setRegisterCertificate("true");
+    request.setCertificate("true");
 
     HttpSession session = httpRequest.getSession();
 
@@ -258,7 +258,7 @@ class RegistrationRequestCertificateOptionalTests {
     request.setEmail(email);
     request.setUsername(USERNAME_2);
     request.setNotes("Some short notes...");
-    request.setRegisterCertificate("false");
+    request.setCertificate("false");
 
     HttpSession session = httpRequest.getSession();
 
@@ -311,7 +311,7 @@ class RegistrationRequestCertificateOptionalTests {
     request.setEmail(email);
     request.setUsername(USERNAME);
     request.setNotes("Some short notes...");
-    request.setRegisterCertificate("true");
+    request.setCertificate("true");
 
     HttpSession session = httpRequest.getSession();
 
@@ -336,7 +336,7 @@ class RegistrationRequestCertificateOptionalTests {
     email = USERNAME_2 + "@example.org";
     request.setEmail(email);
     request.setUsername(USERNAME_2);
-    request.setRegisterCertificate("true");
+    request.setCertificate("true");
 
     httpRequest.getSession();
 
@@ -380,7 +380,7 @@ class RegistrationRequestCertificateOptionalTests {
     request1.setEmail(email);
     request1.setUsername(USERNAME);
     request1.setNotes("Some short notes...");
-    request1.setRegisterCertificate("true");
+    request1.setCertificate("true");
 
     MockHttpServletRequest req1 = new MockHttpServletRequest();
     MockHttpSession session1 = new MockHttpSession();
@@ -410,7 +410,7 @@ class RegistrationRequestCertificateOptionalTests {
     request2.setEmail(email2);
     request2.setUsername(USERNAME_2);
     request2.setNotes("Some short notes...");
-    request2.setRegisterCertificate("true");
+    request2.setCertificate("true");
 
     MockHttpServletRequest req2 = new MockHttpServletRequest();
     MockHttpSession session2 = new MockHttpSession();

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/RegistrationRequestCertificateRequiredTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/RegistrationRequestCertificateRequiredTests.java
@@ -152,7 +152,7 @@ class RegistrationRequestCertificateRequiredTests {
     request.setEmail(email);
     request.setUsername(USERNAME);
     request.setNotes("Some short notes...");
-    request.setRegisterCertificate("true");
+    request.setCertificate("true");
 
     HttpSession session = httpRequest.getSession();
 
@@ -202,7 +202,7 @@ class RegistrationRequestCertificateRequiredTests {
     request.setEmail(email);
     request.setUsername(USERNAME_2);
     request.setNotes("Some short notes...");
-    request.setRegisterCertificate("true");
+    request.setCertificate("true");
 
     HttpSession session = httpRequest.getSession();
 
@@ -254,7 +254,7 @@ class RegistrationRequestCertificateRequiredTests {
     request.setEmail(email);
     request.setUsername(USERNAME_2);
     request.setNotes("Some short notes...");
-    request.setRegisterCertificate("false");
+    request.setCertificate("false");
 
     HttpSession session = httpRequest.getSession();
 
@@ -306,7 +306,7 @@ class RegistrationRequestCertificateRequiredTests {
     request1.setEmail(email);
     request1.setUsername(USERNAME);
     request1.setNotes("Some short notes...");
-    request1.setRegisterCertificate("false");
+    request1.setCertificate("false");
 
     MockHttpServletRequest req1 = new MockHttpServletRequest();
     MockHttpSession session1 = new MockHttpSession();
@@ -337,7 +337,7 @@ class RegistrationRequestCertificateRequiredTests {
     request2.setEmail(email2);
     request2.setUsername(USERNAME_2);
     request2.setNotes("Some short notes...");
-    request2.setRegisterCertificate("false");
+    request2.setCertificate("false");
 
     MockHttpServletRequest req2 = new MockHttpServletRequest();
     MockHttpSession session2 = new MockHttpSession();
@@ -401,7 +401,7 @@ class RegistrationRequestCertificateRequiredTests {
     request.setEmail(email);
     request.setUsername(USERNAME);
     request.setNotes("Some short notes...");
-    request.setRegisterCertificate("true");
+    request.setCertificate("true");
 
     HttpSession session = httpRequest.getSession();
 
@@ -425,7 +425,7 @@ class RegistrationRequestCertificateRequiredTests {
     email = USERNAME_2 + "@example.org";
     request.setEmail(email);
     request.setUsername(USERNAME_2);
-    request.setRegisterCertificate("true");
+    request.setCertificate("true");
 
     httpRequest.getSession();
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/RegistrationRequestCertificateTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/registration/RegistrationRequestCertificateTests.java
@@ -124,7 +124,7 @@ class RegistrationRequestCertificateTests {
     request.setEmail(email);
     request.setUsername(USERNAME);
     request.setNotes("Some short notes...");
-    request.setRegisterCertificate("true");
+    request.setCertificate("true");
 
     HttpSession session = httpRequest.getSession();
 
@@ -173,7 +173,7 @@ class RegistrationRequestCertificateTests {
     request.setEmail(email);
     request.setUsername(USERNAME);
     request.setNotes("Some short notes...");
-    request.setRegisterCertificate("true");
+    request.setCertificate("true");
 
     httpRequest.getSession();
 
@@ -218,7 +218,7 @@ class RegistrationRequestCertificateTests {
     request.setEmail(email);
     request.setUsername(USERNAME);
     request.setNotes("Some short notes...");
-    request.setRegisterCertificate("true");
+    request.setCertificate("true");
 
     HttpSession session = httpRequest.getSession();
 
@@ -244,7 +244,7 @@ class RegistrationRequestCertificateTests {
     email = USERNAME_2 + "@example.org";
     request.setEmail(email);
     request.setUsername(USERNAME_2);
-    request.setRegisterCertificate("true");
+    request.setCertificate("true");
 
     httpRequest.getSession();
 


### PR DESCRIPTION
I changed the name of the field within the front-end to from `registerCertificate` to `certificate`. Thus, being identically within the one defined in the back-end. 