### PR TITLE
Handle error on iam account clients endpoint

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/search/service/DefaultClientSearchService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/search/service/DefaultClientSearchService.java
@@ -98,18 +98,12 @@ public class DefaultClientSearchService implements ClientSearchService {
       .build();
   }
 
-  @Override
-  public ListResponseDTO<RegisteredClientDTO> findOwnedClients(
+  private ListResponseDTO<RegisteredClientDTO> findClientsByAccount(IamAccount account,
       PaginatedRequestForm form) {
+    Pageable pageable =
+        PagingUtils.buildPageRequest(form.getCount(), form.getStartIndex(), MAX_PAGE_SIZE);
 
-    IamAccount account =
-        accountUtils.getAuthenticatedUserAccount().orElseThrow(NoAuthenticatedUserError::new);
-
-    Pageable pageable = PagingUtils.buildPageRequest(form.getCount(), form.getStartIndex(),
-        MAX_PAGE_SIZE);
-
-    Page<IamAccountClient> pagedResults = 
-        accountClientRepo.findByAccount(account, pageable);
+    Page<IamAccountClient> pagedResults = accountClientRepo.findByAccount(account, pageable);
 
     ListResponseDTO.Builder<RegisteredClientDTO> resultBuilder = ListResponseDTO.builder();
 
@@ -124,27 +118,23 @@ public class DefaultClientSearchService implements ClientSearchService {
   }
 
   @Override
-  public ListResponseDTO<RegisteredClientDTO> findClientsOwnedByAccount(String accountId, 
+  public ListResponseDTO<RegisteredClientDTO> findOwnedClients(PaginatedRequestForm form) {
+
+    IamAccount account = accountUtils //
+      .getAuthenticatedUserAccount()
+      .orElseThrow(NoAuthenticatedUserError::new);
+
+    return findClientsByAccount(account, form);
+  }
+
+  @Override
+  public ListResponseDTO<RegisteredClientDTO> findClientsOwnedByAccount(String accountId,
       PaginatedRequestForm form) {
 
-    IamAccount account =
-        accountUtils.getByAccountId(accountId).orElseThrow(NoAuthenticatedUserError::new);
+    IamAccount account = accountUtils //
+      .getByAccountId(accountId)
+      .orElseThrow(NoAuthenticatedUserError::new);
 
-    Pageable pageable = PagingUtils.buildPageRequest(form.getCount(), form.getStartIndex(),
-        MAX_PAGE_SIZE);
-
-    Page<IamAccountClient> pagedResults = 
-        accountClientRepo.findByAccount(account, pageable);
-
-    ListResponseDTO.Builder<RegisteredClientDTO> resultBuilder = ListResponseDTO.builder();
-
-    return resultBuilder
-      .resources(pagedResults.getContent()
-        .stream()
-        .map(IamAccountClient::getClient)
-        .map(converter::registeredClientDtoFromEntity)
-        .toList())
-      .fromPage(pagedResults, pageable)
-      .build();
+    return findClientsByAccount(account, form);
   }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/common/error/NoAuthenticatedUserError.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/common/error/NoAuthenticatedUserError.java
@@ -16,7 +16,7 @@
 package it.infn.mw.iam.api.common.error;
 
 public class NoAuthenticatedUserError extends RuntimeException {
-  public static final String MSG = "No authenticated user found";
+  public static final String MSG = "User not found";
   private static final long serialVersionUID = 1L;
 
   public NoAuthenticatedUserError() {

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/client/AccountClientEndpointTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/account/client/AccountClientEndpointTests.java
@@ -49,8 +49,8 @@ import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 
 @IamMockMvcIntegrationTest
 @SpringBootTest(
-  classes = {IamLoginService.class, CoreControllerTestSupport.class, ScimRestUtilsMvc.class},
-  webEnvironment = WebEnvironment.MOCK)
+    classes = {IamLoginService.class, CoreControllerTestSupport.class, ScimRestUtilsMvc.class},
+    webEnvironment = WebEnvironment.MOCK)
 class AccountClientEndpointTests {
 
   @Autowired
@@ -131,9 +131,7 @@ class AccountClientEndpointTests {
 
   @Test
   void anonymousAccessToMyClientsEndpointFailsTest() throws Exception {
-    mvc.perform(get("/iam/account/me/clients"))
-      .andDo(print())
-      .andExpect(status().isUnauthorized());
+    mvc.perform(get("/iam/account/me/clients")).andDo(print()).andExpect(status().isUnauthorized());
   }
 
   @Test
@@ -155,10 +153,10 @@ class AccountClientEndpointTests {
 
     try {
       mvc.perform(get("/iam/account/{id}/clients", testAccount.getUuid()))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$.totalResults", is(1)))
-          .andExpect(jsonPath("$.Resources", not(empty())))
-          .andExpect(jsonPath("$.Resources[0].client_id", is("client-test")));
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.totalResults", is(1)))
+        .andExpect(jsonPath("$.Resources", not(empty())))
+        .andExpect(jsonPath("$.Resources[0].client_id", is("client-test")));
     } finally {
       accountClientRepo.delete(accountClient);
       clientRepo.delete(testClient);
@@ -193,5 +191,14 @@ class AccountClientEndpointTests {
     mvc.perform(get("/iam/account/{id}/clients", testAccount.getUuid()))
       .andDo(print())
       .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser(username = "admin", roles = {"ADMIN", "USER"})
+  void searchClientsOfNotExistingUser() throws Exception {
+    mvc.perform(get("/iam/account/fakeUuid/clients"))
+      .andDo(print())
+      .andExpect(status().isNotFound())
+      .andExpect(jsonPath("$.error", is("User not found")));
   }
 }


### PR DESCRIPTION
GET to `/iam/account/{id}/clients` now returns `404` with message "User not found", instead of `500`.