### PR TITLE
Do not send multiple aup reminder emails

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/notification/NotificationDeliveryTask.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/notification/NotificationDeliveryTask.java
@@ -15,7 +15,6 @@
  */
 package it.infn.mw.iam.notification;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,8 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationDeliveryTask implements Runnable {
 
   final NotificationDelivery delivery;
-  
-  @Autowired
+
   public NotificationDeliveryTask(NotificationDelivery nd) {
     this.delivery = nd;
   }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/notification/service/JavaMailNotificationDelivery.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/notification/service/JavaMailNotificationDelivery.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.mail.MailException;
 import org.springframework.mail.SimpleMailMessage;
@@ -50,7 +49,6 @@ public class JavaMailNotificationDelivery implements NotificationDelivery {
   final NotificationProperties properties;
   final TimeProvider timeProvider;
 
-  @Autowired
   public JavaMailNotificationDelivery(JavaMailSender mailSender,
       IamEmailNotificationRepository repo, NotificationProperties properties,
       TimeProvider timeProvider) {
@@ -66,13 +64,13 @@ public class JavaMailNotificationDelivery implements NotificationDelivery {
     message.setFrom(properties.getMailFrom());
     message.setSubject(notification.getSubject());
     message.setText(notification.getBody());
-    
+
     List<String> emailAddresses = Lists.newArrayList();
-    
-    for (IamNotificationReceiver r: notification.getReceivers()) {
+
+    for (IamNotificationReceiver r : notification.getReceivers()) {
       emailAddresses.add(r.getEmailAddress());
     }
-    
+
     message.setTo(emailAddresses.stream().toArray(String[]::new));
     return message;
   }
@@ -97,8 +95,7 @@ public class JavaMailNotificationDelivery implements NotificationDelivery {
         e.setDeliveryStatus(IamDeliveryStatus.DELIVERED);
 
         LOG.info(
-            "Email message delivered. "
-                + "message_id:{} message_type:{} rcpt_to:{} subject:{}",
+            "Email message delivered. " + "message_id:{} message_type:{} rcpt_to:{} subject:{}",
             e.getUuid(), e.getType(), message.getTo(), message.getSubject());
 
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/aup/AupReminderTaskTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/aup/AupReminderTaskTests.java
@@ -16,12 +16,16 @@
 package it.infn.mw.iam.test.api.aup;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Date;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterEach;
@@ -33,9 +37,12 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.TestPropertySource;
 
 import it.infn.mw.iam.IamLoginService;
+import it.infn.mw.iam.core.IamDeliveryStatus;
+import it.infn.mw.iam.core.IamNotificationType;
 import it.infn.mw.iam.core.web.aup.AupReminderTask;
 import it.infn.mw.iam.persistence.model.IamAccount;
 import it.infn.mw.iam.persistence.model.IamAup;
+import it.infn.mw.iam.persistence.model.IamEmailNotification;
 import it.infn.mw.iam.persistence.repository.IamAccountRepository;
 import it.infn.mw.iam.persistence.repository.IamAupRepository;
 import it.infn.mw.iam.persistence.repository.IamAupSignatureRepository;
@@ -50,7 +57,7 @@ import it.infn.mw.iam.test.util.notification.MockNotificationDelivery;
 
 @IamMockMvcIntegrationTest
 @SpringBootTest(classes = {IamLoginService.class, CoreControllerTestSupport.class,
-  NotificationTestConfig.class}, webEnvironment = WebEnvironment.MOCK)
+    NotificationTestConfig.class}, webEnvironment = WebEnvironment.MOCK)
 @WithAnonymousUser
 @TestPropertySource(properties = {"notification.disable=false"})
 class AupReminderTaskTests extends AupTestSupport {
@@ -119,7 +126,6 @@ class AupReminderTaskTests extends AupTestSupport {
     notificationDelivery.sendPendingNotifications();
     assertThat(notificationRepo.countAupRemindersPerAccount(testAccount.getUserInfo().getEmail(),
         tomorrowDate), equalTo(1));
-
   }
 
   @Test
@@ -157,7 +163,6 @@ class AupReminderTaskTests extends AupTestSupport {
     assertThat(
         notificationRepo.countAupExpirationMessPerAccount(testAccount.getUserInfo().getEmail()),
         equalTo(1));
-
   }
 
   @Test
@@ -192,7 +197,6 @@ class AupReminderTaskTests extends AupTestSupport {
     assertThat(
         notificationRepo.countAupExpirationMessPerAccount(testAccount.getUserInfo().getEmail()),
         equalTo(0));
-
   }
 
   @Test
@@ -219,7 +223,6 @@ class AupReminderTaskTests extends AupTestSupport {
     assertThat(
         notificationRepo.countAupExpirationMessPerAccount(testAccount.getUserInfo().getEmail()),
         equalTo(0));
-
   }
 
   @Test
@@ -241,7 +244,7 @@ class AupReminderTaskTests extends AupTestSupport {
 
     signatureRepo.createSignatureForAccount(aup, testAccount, date);
 
-    testAccount.setServiceAccount(true);  
+    testAccount.setServiceAccount(true);
     accountRepo.save(testAccount);
 
     assertThat(
@@ -253,7 +256,6 @@ class AupReminderTaskTests extends AupTestSupport {
     assertThat(
         notificationRepo.countAupExpirationMessPerAccount(testAccount.getUserInfo().getEmail()),
         equalTo(0));
-
   }
 
   @Test
@@ -281,7 +283,7 @@ class AupReminderTaskTests extends AupTestSupport {
 
     assertThat(service.needsAupSignature(testAccount), is(false));
 
-    testAccount.setServiceAccount(true);  
+    testAccount.setServiceAccount(true);
     accountRepo.save(testAccount);
 
     mockTimeProvider.setTime(now.getTime() + TimeUnit.MINUTES.toMillis(10));
@@ -293,6 +295,47 @@ class AupReminderTaskTests extends AupTestSupport {
     notificationDelivery.sendPendingNotifications();
     assertThat(notificationRepo.countAupRemindersPerAccount(testAccount.getUserInfo().getEmail(),
         tomorrowDate), equalTo(0));
+  }
 
+  @Test
+  @WithMockUser(username = "admin", roles = {"ADMIN", "USER"})
+  void aupReminderIsCreatedMultipleTimesBeforeDelivery() {
+    IamAup aup = buildDefaultAup();
+    aup.setSignatureValidityInDays(30L);
+    aupRepo.save(aup);
+
+    Date now = new Date();
+    mockTimeProvider.setTime(now.getTime());
+
+    LocalDate today = LocalDate.now();
+    LocalDate tomorrow = today.plusDays(1);
+    Date tomorrowDate = Date.from(tomorrow.atStartOfDay(ZoneId.systemDefault()).toInstant());
+
+    IamAccount testAccount = accountRepo.findByUsername("test").orElseThrow();
+
+    signatureRepo.createSignatureForAccount(aup, testAccount,
+        new Date(mockTimeProvider.currentTimeMillis()));
+
+    assertEquals(0L, notificationRepo.count());
+
+    // WHEN: reminder task runs multiple times
+    aupReminderTask.sendAupReminders();
+    aupReminderTask.sendAupReminders();
+    aupReminderTask.sendAupReminders();
+
+    // THEN: multiple PENDING reminders exist
+    List<IamEmailNotification> reminders =
+        notificationRepo.findByNotificationType(IamNotificationType.AUP_REMINDER);
+
+    assertThat(reminders.size(), greaterThan(1));
+
+    reminders.forEach(n -> {
+      assertThat(n.getDeliveryStatus(), is(IamDeliveryStatus.PENDING));
+      assertThat(n.getLastUpdate(), is(nullValue()));
+    });
+
+    // AND: the count query still returns 0
+    assertThat(notificationRepo.countAupRemindersPerAccount(testAccount.getUserInfo().getEmail(),
+        tomorrowDate), equalTo(0));
   }
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/aup/AupReminderTaskTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/aup/AupReminderTaskTests.java
@@ -17,9 +17,7 @@ package it.infn.mw.iam.test.api.aup;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.LocalDate;
@@ -37,7 +35,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.TestPropertySource;
 
 import it.infn.mw.iam.IamLoginService;
-import it.infn.mw.iam.core.IamDeliveryStatus;
 import it.infn.mw.iam.core.IamNotificationType;
 import it.infn.mw.iam.core.web.aup.AupReminderTask;
 import it.infn.mw.iam.persistence.model.IamAccount;
@@ -298,8 +295,7 @@ class AupReminderTaskTests extends AupTestSupport {
   }
 
   @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN", "USER"})
-  void aupReminderIsCreatedMultipleTimesBeforeDelivery() {
+  void aupReminderIsCreatedOnlyOncePerDay() {
     IamAup aup = buildDefaultAup();
     aup.setSignatureValidityInDays(30L);
     aupRepo.save(aup);
@@ -307,35 +303,19 @@ class AupReminderTaskTests extends AupTestSupport {
     Date now = new Date();
     mockTimeProvider.setTime(now.getTime());
 
-    LocalDate today = LocalDate.now();
-    LocalDate tomorrow = today.plusDays(1);
-    Date tomorrowDate = Date.from(tomorrow.atStartOfDay(ZoneId.systemDefault()).toInstant());
-
     IamAccount testAccount = accountRepo.findByUsername("test").orElseThrow();
 
     signatureRepo.createSignatureForAccount(aup, testAccount,
         new Date(mockTimeProvider.currentTimeMillis()));
 
     assertEquals(0L, notificationRepo.count());
-
-    // WHEN: reminder task runs multiple times
     aupReminderTask.sendAupReminders();
     aupReminderTask.sendAupReminders();
     aupReminderTask.sendAupReminders();
 
-    // THEN: multiple PENDING reminders exist
     List<IamEmailNotification> reminders =
         notificationRepo.findByNotificationType(IamNotificationType.AUP_REMINDER);
 
-    assertThat(reminders.size(), greaterThan(1));
-
-    reminders.forEach(n -> {
-      assertThat(n.getDeliveryStatus(), is(IamDeliveryStatus.PENDING));
-      assertThat(n.getLastUpdate(), is(nullValue()));
-    });
-
-    // AND: the count query still returns 0
-    assertThat(notificationRepo.countAupRemindersPerAccount(testAccount.getUserInfo().getEmail(),
-        tomorrowDate), equalTo(0));
+    assertThat(reminders.size(), equalTo(1));
   }
 }

--- a/iam-persistence/src/main/java/it/infn/mw/iam/persistence/repository/IamEmailNotificationRepository.java
+++ b/iam-persistence/src/main/java/it/infn/mw/iam/persistence/repository/IamEmailNotificationRepository.java
@@ -48,7 +48,7 @@ public interface IamEmailNotificationRepository
   List<IamEmailNotification> findByNotificationType(IamNotificationType notificationType);
 
   @Query("select count(n) from IamEmailNotification n join n.receivers r where n.notificationType = it.infn.mw.iam.core.IamNotificationType.AUP_REMINDER"
-      + " and CURRENT_DATE <= n.lastUpdate and n.lastUpdate < :tomorrow"
+      + " and CURRENT_DATE <= n.creationTime and n.creationTime < :tomorrow"
       + " and n.deliveryStatus <> it.infn.mw.iam.core.IamDeliveryStatus.DELIVERY_ERROR"
       + " and r.emailAddress = :email_address")
   Integer countAupRemindersPerAccount(@Param("email_address") String emailAddress,


### PR DESCRIPTION
## Problem

The problem comes from the [query](https://github.com/indigo-iam/iam/blob/develop/iam-persistence/src/main/java/it/infn/mw/iam/persistence/repository/IamEmailNotificationRepository.java#L54) used to check whether an AUP_REMINDER notification has already been created for a given account.

The query filters notifications based on the `lastUpdate` field, which is only set when the notification delivery task runs. As a result, notifications that are still in PENDING state are not counted.

Since the AUP reminder task runs multiple times per day, each execution does not see the previously created PENDING notifications and creates new ones, leading to multiple reminder emails being sent on the same day.


## Proposed solution

By checking notification existence using `creationTime` instead of `lastUpdate`, the reminder task becomes idempotent. In an HA deployment, only one instance creates the notification, while all others correctly detect its existence and skip creation. The delivery task then sends a single email.




