### PR TITLE
Fix registration request from external IdP

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/IamProperties.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/IamProperties.java
@@ -23,7 +23,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.Lists;
 import com.nimbusds.jose.JWEAlgorithm;
 import com.nimbusds.jose.JWSAlgorithm;
@@ -42,28 +41,27 @@ public class IamProperties {
 
   public enum RegistrationField {
     EMAIL, NAME, SURNAME, USERNAME, AFFILIATION, NOTES, CERTIFICATE;
-
-    @JsonValue
-    public String toJson() {
-      return name().toLowerCase();
-    }
   }
 
   public enum LocalAuthenticationAllowedUsers {
     ALL, VO_ADMINS, NONE
   }
 
+
   public enum LoginPageLayoutOptions {
     LOGIN_FORM, LOGIN_EXTERNAL_AUTHN
   }
+
 
   public enum LocalAuthenticationLoginPageMode {
     VISIBLE, HIDDEN, HIDDEN_WITH_LINK
   }
 
+
   public enum ExternalAuthAttributeSectionBehaviour {
     MANDATORY, OPTIONAL, HIDDEN
   }
+
 
   public static class AccountLinkingProperties {
     boolean enable = true;
@@ -76,6 +74,7 @@ public class IamProperties {
       return enable;
     }
   }
+
 
   public static class ActuatorUserProperties {
 
@@ -99,6 +98,7 @@ public class IamProperties {
     }
 
   }
+
 
   public static class ExternalConnectivityProbeProperties {
 
@@ -132,6 +132,7 @@ public class IamProperties {
     }
   }
 
+
   public static class VersionedStaticResourcesProperties {
     boolean enableVersioning = true;
 
@@ -143,6 +144,7 @@ public class IamProperties {
       this.enableVersioning = enableVersioning;
     }
   }
+
 
   public static class CustomizationProperties {
     boolean includeCustomLoginPageContent = false;
@@ -166,6 +168,7 @@ public class IamProperties {
     }
   }
 
+
   public static class LocalAuthenticationProperties {
 
     LocalAuthenticationLoginPageMode loginPageVisibility;
@@ -188,6 +191,7 @@ public class IamProperties {
     }
   }
 
+
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   public static class UserProfileProperties {
     private List<EditableFields> editableFields = Lists.newArrayList();
@@ -200,6 +204,7 @@ public class IamProperties {
       this.editableFields = editableFields;
     }
   }
+
 
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   public static class RegistrationFieldProperties {
@@ -231,6 +236,7 @@ public class IamProperties {
       this.fieldBehaviour = fieldBehaviour;
     }
   }
+
 
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   public static class RegistrationProperties {
@@ -327,6 +333,7 @@ public class IamProperties {
     }
   }
 
+
   public static class DeviceCodeProperties {
     Boolean allowCompleteVerificationUri = true;
 
@@ -339,6 +346,7 @@ public class IamProperties {
     }
 
   }
+
 
   public static class JWKProperties {
     String keystoreLocation;
@@ -399,6 +407,7 @@ public class IamProperties {
     }
   }
 
+
   public static class JWTProfile {
 
     public enum Profile {
@@ -415,6 +424,7 @@ public class IamProperties {
       this.defaultProfile = defaultProfile;
     }
   }
+
 
   public static class LoginLink {
     String url;
@@ -436,6 +446,7 @@ public class IamProperties {
       this.text = text;
     }
   }
+
 
   public static class LoginPageLayout {
 
@@ -463,6 +474,7 @@ public class IamProperties {
     }
   }
 
+
   public static class RegistractionAccessToken {
     long lifetime = -1;
 
@@ -474,6 +486,7 @@ public class IamProperties {
       this.lifetime = lifetime;
     }
   }
+
 
   public static class AccessToken {
 
@@ -519,6 +532,7 @@ public class IamProperties {
     }
   }
 
+
   public static class Organisation {
     private String name = "indigo-dc";
 
@@ -530,6 +544,7 @@ public class IamProperties {
       this.name = name;
     }
   }
+
 
   public static class Logo {
     private String url = "resources/images/indigo-logo.png";
@@ -571,6 +586,7 @@ public class IamProperties {
 
   }
 
+
   public static class LocalResources {
 
     private boolean enable = false;
@@ -593,6 +609,7 @@ public class IamProperties {
     }
   }
 
+
   public static class ClientProperties {
     private boolean trackLastUsed = false;
 
@@ -604,6 +621,7 @@ public class IamProperties {
       this.trackLastUsed = trackLastUsed;
     }
   }
+
 
   public static class DefaultGroup {
     private String name;
@@ -625,6 +643,7 @@ public class IamProperties {
       this.enrollment = enrollment;
     }
   }
+
 
   public static class AarcProfile {
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/IamProperties.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/IamProperties.java
@@ -23,6 +23,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.Lists;
 import com.nimbusds.jose.JWEAlgorithm;
 import com.nimbusds.jose.JWSAlgorithm;
@@ -40,7 +41,12 @@ public class IamProperties {
   }
 
   public enum RegistrationField {
-    EMAIL, NAME, SURNAME, USERNAME, AFFILIATION, NOTES, CERTIFICATE
+    EMAIL, NAME, SURNAME, USERNAME, AFFILIATION, NOTES, CERTIFICATE;
+
+    @JsonValue
+    public String toJson() {
+      return name().toLowerCase();
+    }
   }
 
   public enum LocalAuthenticationAllowedUsers {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/IamProperties.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/IamProperties.java
@@ -40,28 +40,24 @@ public class IamProperties {
   }
 
   public enum RegistrationField {
-    EMAIL, NAME, SURNAME, USERNAME, AFFILIATION, NOTES, CERTIFICATE;
+    EMAIL, NAME, SURNAME, USERNAME, AFFILIATION, NOTES, CERTIFICATE
   }
 
   public enum LocalAuthenticationAllowedUsers {
     ALL, VO_ADMINS, NONE
   }
 
-
   public enum LoginPageLayoutOptions {
     LOGIN_FORM, LOGIN_EXTERNAL_AUTHN
   }
-
 
   public enum LocalAuthenticationLoginPageMode {
     VISIBLE, HIDDEN, HIDDEN_WITH_LINK
   }
 
-
   public enum ExternalAuthAttributeSectionBehaviour {
     MANDATORY, OPTIONAL, HIDDEN
   }
-
 
   public static class AccountLinkingProperties {
     boolean enable = true;
@@ -74,7 +70,6 @@ public class IamProperties {
       return enable;
     }
   }
-
 
   public static class ActuatorUserProperties {
 
@@ -98,7 +93,6 @@ public class IamProperties {
     }
 
   }
-
 
   public static class ExternalConnectivityProbeProperties {
 
@@ -132,7 +126,6 @@ public class IamProperties {
     }
   }
 
-
   public static class VersionedStaticResourcesProperties {
     boolean enableVersioning = true;
 
@@ -144,7 +137,6 @@ public class IamProperties {
       this.enableVersioning = enableVersioning;
     }
   }
-
 
   public static class CustomizationProperties {
     boolean includeCustomLoginPageContent = false;
@@ -168,7 +160,6 @@ public class IamProperties {
     }
   }
 
-
   public static class LocalAuthenticationProperties {
 
     LocalAuthenticationLoginPageMode loginPageVisibility;
@@ -191,7 +182,6 @@ public class IamProperties {
     }
   }
 
-
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   public static class UserProfileProperties {
     private List<EditableFields> editableFields = Lists.newArrayList();
@@ -204,7 +194,6 @@ public class IamProperties {
       this.editableFields = editableFields;
     }
   }
-
 
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   public static class RegistrationFieldProperties {
@@ -236,7 +225,6 @@ public class IamProperties {
       this.fieldBehaviour = fieldBehaviour;
     }
   }
-
 
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   public static class RegistrationProperties {
@@ -333,7 +321,6 @@ public class IamProperties {
     }
   }
 
-
   public static class DeviceCodeProperties {
     Boolean allowCompleteVerificationUri = true;
 
@@ -346,7 +333,6 @@ public class IamProperties {
     }
 
   }
-
 
   public static class JWKProperties {
     String keystoreLocation;
@@ -407,7 +393,6 @@ public class IamProperties {
     }
   }
 
-
   public static class JWTProfile {
 
     public enum Profile {
@@ -424,7 +409,6 @@ public class IamProperties {
       this.defaultProfile = defaultProfile;
     }
   }
-
 
   public static class LoginLink {
     String url;
@@ -446,7 +430,6 @@ public class IamProperties {
       this.text = text;
     }
   }
-
 
   public static class LoginPageLayout {
 
@@ -474,7 +457,6 @@ public class IamProperties {
     }
   }
 
-
   public static class RegistractionAccessToken {
     long lifetime = -1;
 
@@ -486,7 +468,6 @@ public class IamProperties {
       this.lifetime = lifetime;
     }
   }
-
 
   public static class AccessToken {
 
@@ -532,7 +513,6 @@ public class IamProperties {
     }
   }
 
-
   public static class Organisation {
     private String name = "indigo-dc";
 
@@ -544,7 +524,6 @@ public class IamProperties {
       this.name = name;
     }
   }
-
 
   public static class Logo {
     private String url = "resources/images/indigo-logo.png";
@@ -586,7 +565,6 @@ public class IamProperties {
 
   }
 
-
   public static class LocalResources {
 
     private boolean enable = false;
@@ -609,7 +587,6 @@ public class IamProperties {
     }
   }
 
-
   public static class ClientProperties {
     private boolean trackLastUsed = false;
 
@@ -621,7 +598,6 @@ public class IamProperties {
       this.trackLastUsed = trackLastUsed;
     }
   }
-
 
   public static class DefaultGroup {
     private String name;
@@ -643,7 +619,6 @@ public class IamProperties {
       this.enrollment = enrollment;
     }
   }
-
 
   public static class AarcProfile {
 

--- a/iam-login-service/src/main/webapp/resources/iam/apps/registration/registration.controller.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/registration/registration.controller.js
@@ -255,11 +255,12 @@ function RegistrationController(
 	}
 
 	function populateValue(info, name) {
+		const fieldName = name.toUpperCase();
 		const hasExternalAttributeDefined = Boolean(typeof $scope.config.fields != 'undefined' 
-			&& typeof $scope.config.fields[name] != 'undefined' 
-			&& typeof $scope.config.fields[name].externalAuthAttribute != 'undefined');
+			&& typeof $scope.config.fields[fieldName] != 'undefined'
+			&& typeof $scope.config.fields[fieldName].externalAuthAttribute != 'undefined');
 		if (hasExternalAttributeDefined) {
-			return lookupAuthInfo(info, $scope.config.fields[name].externalAuthAttribute);
+			return lookupAuthInfo(info, $scope.config.fields[fieldName].externalAuthAttribute);
 		}
 	}
 
@@ -353,7 +354,7 @@ function RegistrationController(
 	}
 
 	function fieldReadonly(name) {
-		return $scope.config?.fields?.[name]?.readOnly === true;
+		return $scope.config?.fields?.[name.toUpperCase()]?.readOnly === true;
 	}
 
 	function populateFieldsWithAdminPreference() {
@@ -362,16 +363,16 @@ function RegistrationController(
 				if (
 					$scope.config.fields[field]["fieldBehaviour"] === "MANDATORY"
 				) {
-					$scope.fields[field].showField = true;
-					$scope.fields[field].required = true;
+					$scope.fields[field.toLowerCase()].showField = true;
+					$scope.fields[field.toLowerCase()].required = true;
 				} else if (
 					$scope.config.fields[field]["fieldBehaviour"] === "OPTIONAL"
 				) {
-					$scope.fields[field].showField = true;
-					$scope.fields[field].required = false;
+					$scope.fields[field.toLowerCase()].showField = true;
+					$scope.fields[field.toLowerCase()].required = false;
 				} else {
-					$scope.fields[field].showField = false;
-					$scope.fields[field].required = false;
+					$scope.fields[field.toLowerCase()].showField = false;
+					$scope.fields[field.toLowerCase()].required = false;
 				}
 			}
 		}

--- a/iam-login-service/src/main/webapp/resources/iam/apps/registration/registration.controller.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/registration/registration.controller.js
@@ -130,7 +130,7 @@ function RegistrationController(
 			required: true,
 			showField: true,
 		},
-		registerCertificate: {
+		certificate: {
 			type: "certificate",
 			required: false,
 			showField: true,
@@ -151,7 +151,7 @@ function RegistrationController(
 	vm.populateFieldsWithAdminPreference = populateFieldsWithAdminPreference;
 	vm.getFieldErrorMessage = getFieldErrorMessage;
 	vm.openExpiringCertificateDialog = openExpiringCertificateDialog;
-	vm.registerCertificate = true;
+	vm.certificate = true;
 
 	vm.activate();
 	vm.openExpiringCertificateDialog();
@@ -194,6 +194,17 @@ function RegistrationController(
 	};
 
 	function activate() {
+		AuthnInfo.getInfo()
+			.then(function (res) {
+				if (res != null) {
+					$scope.extAuthInfo = res.data;
+				}
+			})
+			.catch(function (res) {
+				console.error(
+					'Error fetching external authentication info : ' + res.status + ' ' + res.statusText);
+			});
+
 		RegistrationRequestService.getConfig()
 			.then(function (res) {
 				$scope.config = res.data;
@@ -227,16 +238,6 @@ function RegistrationController(
 					res.statusText);
 			});
 
-		AuthnInfo.getInfo()
-			.then(function (res) {
-				if (res != null) {
-					$scope.extAuthInfo = res.data;
-				}
-			})
-			.catch(function (res) {
-				console.error(
-					'Error fetching external authentication info : ' + res.status + ' ' + res.statusText);
-			});
 	}
 
 	function userIsExternallyAuthenticated() {
@@ -271,10 +272,10 @@ function RegistrationController(
 				email: populateValue($scope.extAuthInfo, 'email'),
 				affiliation: populateValue($scope.extAuthInfo, 'affiliation'),
 				notes: '',
-				registerCertificate: true,
+				certificate: true,
 			};
 
-			if (info.type === 'OIDC') {
+			if ($scope.extAuthInfo.type === 'OIDC') {
 				$scope.extAuthProviderName = 'an OIDC identity provider';
 			} else {
 				$scope.extAuthProviderName = 'a SAML identity provider';
@@ -326,7 +327,7 @@ function RegistrationController(
 			username: '',
 			email: '',
 			notes: '',
-			registerCertificate: true,
+			certificate: true,
 			affiliation: '',
 		};
 	}
@@ -359,18 +360,18 @@ function RegistrationController(
 		if ($scope.config.fields) {
 			for (let field in $scope.config.fields) {
 				if (
-					field.fieldBehaviour.toLowerCase() == "mandatory"
+					$scope.config.fields[field]["fieldBehaviour"] === "MANDATORY"
 				) {
-					field.showField = true;
-					field.required = true;
+					$scope.fields[field].showField = true;
+					$scope.fields[field].required = true;
 				} else if (
-					field.fieldBehaviour.toLowerCase() === "optional"
+					$scope.config.fields[field]["fieldBehaviour"] === "OPTIONAL"
 				) {
-					field.showField = true;
-					field.required = false;
+					$scope.fields[field].showField = true;
+					$scope.fields[field].required = false;
 				} else {
-					field.showField = false;
-					field.required = false;
+					$scope.fields[field].showField = false;
+					$scope.fields[field].required = false;
 				}
 			}
 		}

--- a/iam-login-service/src/main/webapp/resources/iam/apps/registration/registration.controller.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/registration/registration.controller.js
@@ -57,6 +57,8 @@ function RegistrationController(
 
 	$scope.config = undefined;
 
+	$scope.extAuthInfo = undefined;
+
 	// Form `fields` with necessary properties and validations.
 	$scope.fields = {
 		name: {
@@ -224,6 +226,17 @@ function RegistrationController(
 					'Error fetching privacy policy: ' + res.status + ' ' +
 					res.statusText);
 			});
+
+		AuthnInfo.getInfo()
+			.then(function (res) {
+				if (res != null) {
+					$scope.extAuthInfo = res.data;
+				}
+			})
+			.catch(function (res) {
+				console.error(
+					'Error fetching external authentication info : ' + res.status + ' ' + res.statusText);
+			});
 	}
 
 	function userIsExternallyAuthenticated() {
@@ -241,25 +254,22 @@ function RegistrationController(
 	}
 
 	function populateValue(info, name) {
-		const fieldName = name.toUpperCase();
 		const hasExternalAttributeDefined = Boolean(typeof $scope.config.fields != 'undefined' 
-			&& typeof $scope.config.fields[fieldName] != 'undefined' 
-			&& typeof $scope.config.fields[fieldName].externalAuthAttribute != 'undefined');
+			&& typeof $scope.config.fields[name] != 'undefined' 
+			&& typeof $scope.config.fields[name].externalAuthAttribute != 'undefined');
 		if (hasExternalAttributeDefined) {
-			return lookupAuthInfo(info, $scope.config.fields[fieldName].externalAuthAttribute);
+			return lookupAuthInfo(info, $scope.config.fields[name].externalAuthAttribute);
 		}
 	}
 
 	function populateRequest() {
 		var success = function (res) {
-			var info = res.data;
-			$scope.extAuthInfo = info;
 			$scope.request = {
-				givenname: populateValue(info, 'name'),
-				familyname: populateValue(info, 'surname'),
-				username: populateValue(info, 'username'),
-				email: populateValue(info, 'email'),
-				affiliation: populateValue(info, 'affiliation'),
+				givenname: populateValue($scope.extAuthInfo, 'name'),
+				familyname: populateValue($scope.extAuthInfo, 'surname'),
+				username: populateValue($scope.extAuthInfo, 'username'),
+				email: populateValue($scope.extAuthInfo, 'email'),
+				affiliation: populateValue($scope.extAuthInfo, 'affiliation'),
 				notes: '',
 				registerCertificate: true,
 			};
@@ -349,18 +359,18 @@ function RegistrationController(
 		if ($scope.config.fields) {
 			for (let field in $scope.config.fields) {
 				if (
-					$scope.config.fields[field]["fieldBehaviour"].toLowerCase() == "mandatory"
+					field.fieldBehaviour.toLowerCase() == "mandatory"
 				) {
-					$scope.fields[field.toLowerCase()].showField = true;
-					$scope.fields[field.toLowerCase()].required = true;
+					field.showField = true;
+					field.required = true;
 				} else if (
-					$scope.config.fields[field]["fieldBehaviour"].toLowerCase() === "optional"
+					field.fieldBehaviour.toLowerCase() === "optional"
 				) {
-					$scope.fields[field.toLowerCase()].showField = true;
-					$scope.fields[field.toLowerCase()].required = false;
+					field.showField = true;
+					field.required = false;
 				} else {
-					$scope.fields[field.toLowerCase()].showField = false;
-					$scope.fields[field.toLowerCase()].required = false;
+					field.showField = false;
+					field.required = false;
 				}
 			}
 		}

--- a/iam-login-service/src/main/webapp/resources/iam/apps/registration/registration.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/registration/registration.html
@@ -134,40 +134,40 @@
 
 					<chekbox ng-if="field.type === 'certificate'">
 						<div id="checkbox"
-							ng-attr-title="{{(request.registerCertificate) ? 'Un-check to not link your certificate to the account' : 'Check to link your certificate to the account'}}"
+							ng-attr-title="{{(request.certificate) ? 'Un-check to not link your certificate to the account' : 'Check to link your certificate to the account'}}"
 							ng-if="iamX509Required === 'OPTIONAL'">
 
 							<label for="register-certificate"
-								ng-style="(request.registerCertificate && (iamX509SuspendedAccount || iamX509CanLogin)) ? {'color' : 'red'} : {}">
+								ng-style="(request.certificate && (iamX509SuspendedAccount || iamX509CanLogin)) ? {'color' : 'red'} : {}">
 								Register certificate
 							</label><br>
 
 							<input type="checkbox" id="register-certificate" name="register-certificate"
-								ng-model="request.registerCertificate">
+								ng-model="request.certificate">
 
 							<!-- Certificate is already linked -->
 							<span
-								ng-if="(iamX509Required === 'OPTIONAL') && iamX509CanLogin && request.registerCertificate"
+								ng-if="(iamX509Required === 'OPTIONAL') && iamX509CanLogin && request.certificate"
 								style="color: red;">
 								Certificate is already linked to an account. It can not be linked
 							</span>
 
 							<!-- Certificate is linked to a blocked account -->
 							<span
-								ng-if="(iamX509Required === 'OPTIONAL') && iamX509SuspendedAccount && request.registerCertificate"
+								ng-if="(iamX509Required === 'OPTIONAL') && iamX509SuspendedAccount && request.certificate"
 								style="color: red;">
 								Certificate is linked to an suspended account. It can not be linked
 							</span>
 
 							<!-- Certificate is not present in the browser -->
-							<span ng-if="(iamX509Required === 'OPTIONAL') &&!iamX509Cred && request.registerCertificate"
+							<span ng-if="(iamX509Required === 'OPTIONAL') &&!iamX509Cred && request.certificate"
 								style="color: red;">
 								No certificate present to link. Not possible to link certificate
 							</span>
 
 							<!-- No errors or the box is not checked -->
 							<span
-								ng-if="(iamX509Required === 'OPTIONAL') && ((!iamX509SuspendedAccount && !iamX509CanLogin && iamX509Cred && request.registerCertificate) || !request.registerCertificate)">
+								ng-if="(iamX509Required === 'OPTIONAL') && ((!iamX509SuspendedAccount && !iamX509CanLogin && iamX509Cred && request.certificate) || !request.certificate)">
 								Link your certificate to the account
 							</span>
 
@@ -221,7 +221,7 @@
 			<div class="form-group"
 				ng-if="!(iamX509Required === 'MANDATORY') || (iamX509Cred && !iamX509CanLogin && !iamX509SuspendedAccount)">
 				<button class="btn btn-primary" type="submit" id="register-submit-btn" name="register"
-					ng-disabled="!registrationForm.$valid || busy || (iamX509Required === 'OPTIONAL' && request.registerCertificate && (iamX509CanLogin || iamX509SuspendedAccount || !iamX509Cred))"
+					ng-disabled="!registrationForm.$valid || busy || (iamX509Required === 'OPTIONAL' && request.certificate && (iamX509CanLogin || iamX509SuspendedAccount || !iamX509Cred))"
 					ng-click="rc.submit()">Register</button>
 				<button class="btn btn-warning" type="button" id="register-reset-btn" name="reset" ng-click="rc.reset()"
 					ng-disabled="registrationForm.$pristine">Reset Form</button>
@@ -229,7 +229,7 @@
 			</div>
 			<div id="x509-authn-info"
 				ng-if="iamX509Cred && (iamX509Required === 'OPTIONAL' || (iamX509Required === 'MANDATORY' && !iamX509CanLogin && !iamX509SuspendedAccount))">
-				You have been succesfully authenticated as, {{registerCertificate}}<br>
+				You have been succesfully authenticated as, {{certificate}}<br>
 				<strong>{{iamX509Subject}}</strong>
 
 				<p ng-if="!iamX509CanLogin && !iamX509SuspendedAccount">


### PR DESCRIPTION
Here we fix the registration request when the user was authenticated with an external provider.

In the next example I have logged-into IAM with iam-dev, and the "Given Name" field is read-only

<img width="642" height="638" alt="image" src="https://github.com/user-attachments/assets/f93e8b4d-79fa-455f-a051-2766cc625ed2" />

Previously, the fields were not populated at all.