### PR TITLE
Fix client search view

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/search/SearchClientController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/search/SearchClientController.java
@@ -50,7 +50,7 @@ public class SearchClientController {
     this.service = service;
   }
 
-  @JsonView({ClientViews.ClientManagement.class})
+  @JsonView({ClientViews.NoSecretDynamicRegistration.class})
   @GetMapping
   public ListResponseDTO<RegisteredClientDTO> searchClients(
       ClientSearchForm searchForm) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/client/search/service/DefaultClientSearchService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/client/search/service/DefaultClientSearchService.java
@@ -18,7 +18,6 @@ package it.infn.mw.iam.api.client.search.service;
 import java.util.stream.Collectors;
 
 import org.mitre.oauth2.model.ClientDetailsEntity;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -52,7 +51,6 @@ public class DefaultClientSearchService implements ClientSearchService {
   private final AccountUtils accountUtils;
   private final ClientConverter converter;
 
-  @Autowired
   public DefaultClientSearchService(IamClientRepository clientRepo,
       IamAccountClientRepository accountClientRepo, AccountUtils accountUtils,
       ClientConverter converter) {
@@ -99,17 +97,15 @@ public class DefaultClientSearchService implements ClientSearchService {
   }
 
   @Override
-  public ListResponseDTO<RegisteredClientDTO> findOwnedClients(
-      PaginatedRequestForm form) {
+  public ListResponseDTO<RegisteredClientDTO> findOwnedClients(PaginatedRequestForm form) {
 
     IamAccount account =
         accountUtils.getAuthenticatedUserAccount().orElseThrow(NoAuthenticatedUserError::new);
 
-    Pageable pageable = PagingUtils.buildPageRequest(form.getCount(), form.getStartIndex(),
-        MAX_PAGE_SIZE);
+    Pageable pageable =
+        PagingUtils.buildPageRequest(form.getCount(), form.getStartIndex(), MAX_PAGE_SIZE);
 
-    Page<IamAccountClient> pagedResults = 
-        accountClientRepo.findByAccount(account, pageable);
+    Page<IamAccountClient> pagedResults = accountClientRepo.findByAccount(account, pageable);
 
     ListResponseDTO.Builder<RegisteredClientDTO> resultBuilder = ListResponseDTO.builder();
 
@@ -124,17 +120,16 @@ public class DefaultClientSearchService implements ClientSearchService {
   }
 
   @Override
-  public ListResponseDTO<RegisteredClientDTO> findClientsOwnedByAccount(String accountId, 
+  public ListResponseDTO<RegisteredClientDTO> findClientsOwnedByAccount(String accountId,
       PaginatedRequestForm form) {
 
     IamAccount account =
         accountUtils.getByAccountId(accountId).orElseThrow(NoAuthenticatedUserError::new);
 
-    Pageable pageable = PagingUtils.buildPageRequest(form.getCount(), form.getStartIndex(),
-        MAX_PAGE_SIZE);
+    Pageable pageable =
+        PagingUtils.buildPageRequest(form.getCount(), form.getStartIndex(), MAX_PAGE_SIZE);
 
-    Page<IamAccountClient> pagedResults = 
-        accountClientRepo.findByAccount(account, pageable);
+    Page<IamAccountClient> pagedResults = accountClientRepo.findByAccount(account, pageable);
 
     ListResponseDTO.Builder<RegisteredClientDTO> resultBuilder = ListResponseDTO.builder();
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/client/SearchClientControllerTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/client/SearchClientControllerTests.java
@@ -36,7 +36,7 @@ import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
 
 @ExtendWith(SpringExtension.class)
 @IamMockMvcIntegrationTest
-public class SearchClientControllerTests {
+class SearchClientControllerTests {
 
   @Autowired
   private MockMvc mvc;
@@ -46,7 +46,7 @@ public class SearchClientControllerTests {
 
   @Test
   @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin.read")
-  public void searchForTestClient() throws Exception {
+  void searchForTestClient() throws Exception {
 
     ListResponseDTO<RegisteredClientDTO> response = mapper
       .readValue(mvc.perform(get(ENDPOINT).param("search", "test").param("searchType", "name"))

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/api/client/SearchClientControllerTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/api/client/SearchClientControllerTests.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.api.client;
+
+import static it.infn.mw.iam.api.client.search.SearchClientController.ENDPOINT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import it.infn.mw.iam.api.common.ListResponseDTO;
+import it.infn.mw.iam.api.common.client.RegisteredClientDTO;
+import it.infn.mw.iam.test.util.WithMockOAuthUser;
+import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
+
+@ExtendWith(SpringExtension.class)
+@IamMockMvcIntegrationTest
+public class SearchClientControllerTests {
+
+  @Autowired
+  private MockMvc mvc;
+
+  @Autowired
+  private ObjectMapper mapper;
+
+  @Test
+  @WithMockOAuthUser(user = "admin", authorities = {"ROLE_ADMIN"}, scopes = "iam:admin.read")
+  public void searchForTestClient() throws Exception {
+
+    ListResponseDTO<RegisteredClientDTO> response = mapper
+      .readValue(mvc.perform(get(ENDPOINT).param("search", "test").param("searchType", "name"))
+        .andExpect(status().isOk())
+        .andReturn()
+        .getResponse()
+        .getContentAsString(), new TypeReference<ListResponseDTO<RegisteredClientDTO>>() {});
+    assertThat(response.getTotalResults()).isGreaterThan(0);
+  }
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/service/client/ClientSearchServiceTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/service/client/ClientSearchServiceTests.java
@@ -36,7 +36,7 @@ import it.infn.mw.iam.test.util.annotation.IamNoMvcTest;
 
 @IamNoMvcTest
 @SpringBootTest(classes = {IamLoginService.class, ClientTestConfig.class},
-  webEnvironment = WebEnvironment.NONE)
+    webEnvironment = WebEnvironment.NONE)
 class ClientSearchServiceTests {
 
   @Autowired
@@ -44,7 +44,7 @@ class ClientSearchServiceTests {
 
   @Test
   void testParamValidation() {
-    
+
     assertThrows(ConstraintViolationException.class, () -> {
       ClientSearchForm form = new ClientSearchForm();
       form.setSearch(null);
@@ -63,7 +63,6 @@ class ClientSearchServiceTests {
       form.setSearch("term");
       service.searchClients(form);
     });
-
   }
 
   @Test
@@ -72,12 +71,8 @@ class ClientSearchServiceTests {
     ClientSearchForm form = new ClientSearchForm();
     form.setSearch("scim");
 
-    ListResponseDTO<RegisteredClientDTO> result =
-        service.searchClients(form);
+    ListResponseDTO<RegisteredClientDTO> result = service.searchClients(form);
 
     assertThat(result.getTotalResults(), is(2L));
-
-
   }
-
 }


### PR DESCRIPTION
Searching for clients by any field (e.g. client name, client ID, etc.) no longer worked due to a change in the _View_ for the `ListResponseDTO` with the introduction of [this feature](https://github.com/indigo-iam/iam/pull/1081).
The solution was to replace the new _View_ for the `/iam/api/search/clients` API that does not return the client secret.