### PR TITLE
Fix registration request from external IdP with read-only fields

### DIFF
--- a/iam-login-service/src/main/webapp/resources/iam/apps/registration/registration.controller.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/registration/registration.controller.js
@@ -342,7 +342,7 @@ function RegistrationController(
 	}
 
 	function fieldReadonly(name) {
-		return $scope.config?.fields?.[name]?.readOnly === true;
+		return $scope.config?.fields?.[name?.toUpperCase()]?.readOnly === true;
 	}
 
 	function populateFieldsWithAdminPreference() {


### PR DESCRIPTION
When the IAM configuration  requires to fill a registration request with attributes coming from an external IdP in read-only mode, the front-end was showing the fields as editable, even if the back-end validates them correctly.

With this PR read-only fields in the registration request now appear not editable.