### PR TITLE
Stop redirection to AUP page for pre authenticated user

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/account/AccountUtils.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/account/AccountUtils.java
@@ -66,6 +66,11 @@ public class AccountUtils {
     return account.getAuthorities().contains(ROLE_ADMIN);
   }
 
+  public boolean isPreAuthenticated() {
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    return isPreAuthenticated(auth);
+  }
+
   public boolean isPreAuthenticated(Authentication auth) {
     if (auth == null || auth.getAuthorities().isEmpty()) {
       return false;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/web/aup/EnforceAupFilter.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/web/aup/EnforceAupFilter.java
@@ -86,7 +86,8 @@ public class EnforceAupFilter implements Filter {
 
     String requestURL = req.getRequestURL().toString();
 
-    if (!accountUtils.isAuthenticated() || isNull(session) || requestURL.endsWith(AUP_API_PATH)) {
+    if (!accountUtils.isAuthenticated() || isNull(session) || requestURL.endsWith(AUP_API_PATH)
+        || accountUtils.isPreAuthenticated()) {
       chain.doFilter(request, response);
       return;
     }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/SamlExternalAuthenticationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/SamlExternalAuthenticationTests.java
@@ -157,13 +157,12 @@ class SamlExternalAuthenticationTests extends SamlAuthenticationTestSupport {
     aupRepo.deleteAll();    
   }
 
-  private MockHttpSession performInitialLogin() throws Exception, UnsupportedEncodingException {
-    MockHttpSession session = (MockHttpSession) mvc.perform(get(samlDefaultIdpLoginUrl()))
+  private MockHttpSession performInitialLogin() throws Exception {
+    return (MockHttpSession) mvc.perform(get(samlDefaultIdpLoginUrl()))
         .andExpect(status().isOk())
         .andReturn()
         .getRequest()
         .getSession();
-    return session;
   }
 
   private MockHttpSession postMfaResponseAndExpectRedirect(Response response, AuthnRequest authnRequest,

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/SamlExternalAuthenticationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/SamlExternalAuthenticationTests.java
@@ -30,7 +30,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
-import java.io.UnsupportedEncodingException;
 import java.util.Date;
 import java.util.random.RandomGenerator;
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/SamlExternalAuthenticationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/SamlExternalAuthenticationTests.java
@@ -30,17 +30,21 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
+import java.io.UnsupportedEncodingException;
+import java.util.Date;
+import java.util.random.RandomGenerator;
+
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.opensaml.saml2.core.AuthnRequest;
 import org.opensaml.saml2.core.Response;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-
+import it.infn.mw.iam.persistence.model.IamAup;
+import it.infn.mw.iam.persistence.repository.IamAupRepository;
 import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
 import it.infn.mw.iam.test.util.saml.SamlUtils;
 
@@ -48,14 +52,18 @@ import it.infn.mw.iam.test.util.saml.SamlUtils;
 @IamMockMvcIntegrationTest
 class SamlExternalAuthenticationTests extends SamlAuthenticationTestSupport {
 
+  @Autowired
+  private IamAupRepository aupRepo;
+  
+  private static final String URL_DASHBOARD = "/dashboard";
+  private static final String URL_VERIFY = "/iam/verify";
+  private static final String VIEW_VERIFY_MFA = "iam/verify-mfa";
+
+
   @Test
   void testSuccessfulExternalUnregisteredUserAuthentication() throws Throwable {
 
-    MockHttpSession session = (MockHttpSession) mvc.perform(get(samlDefaultIdpLoginUrl()))
-      .andExpect(status().isOk())
-      .andReturn()
-      .getRequest()
-      .getSession();
+    MockHttpSession session = performInitialLogin();
 
     AuthnRequest authnRequest = getAuthnRequestFromSession(session);
 
@@ -87,12 +95,7 @@ class SamlExternalAuthenticationTests extends SamlAuthenticationTestSupport {
   @Test
   void testExternalAuthenticationFailureRedirectsToLoginPage() throws Throwable {
 
-    MockHttpSession session =
-        (MockHttpSession) mvc.perform(MockMvcRequestBuilders.get(samlDefaultIdpLoginUrl()))
-          .andExpect(MockMvcResultMatchers.status().isOk())
-          .andReturn()
-          .getRequest()
-          .getSession();
+    MockHttpSession session = performInitialLogin();
 
     AuthnRequest authnRequest = getAuthnRequestFromSession(session);
 
@@ -116,52 +119,79 @@ class SamlExternalAuthenticationTests extends SamlAuthenticationTestSupport {
   @Test
   void testRegisteredUserWithMfaGetsRedirectedToMfaVerify() throws Throwable {
 
-    MockHttpSession session = (MockHttpSession) mvc.perform(get(samlDefaultIdpLoginUrl()))
-      .andExpect(status().isOk())
-      .andReturn()
-      .getRequest()
-      .getSession();
+    MockHttpSession session = performInitialLogin();
 
     AuthnRequest authnRequest = getAuthnRequestFromSession(session);
+    Response response = buildMfaTest1Response(authnRequest);
+    session = postMfaResponseAndExpectRedirect(response, authnRequest, session, URL_VERIFY);
 
-    Response r = buildMfaTest1Response(authnRequest);
-
-    session = (MockHttpSession) mvc
-      .perform(post(authnRequest.getAssertionConsumerServiceURL())
-        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-        .param("SAMLResponse", SamlUtils.signAndSerializeToBase64(r))
-        .session(session))
-      .andExpect(redirectedUrl("/iam/verify"))
-      .andReturn()
-      .getRequest()
-      .getSession();
-
-    mvc.perform(get("/iam/verify").session(session))
+    mvc.perform(get(URL_VERIFY).session(session))
       .andExpect(status().isOk())
-      .andExpect(view().name("iam/verify-mfa"));
+      .andExpect(view().name(VIEW_VERIFY_MFA));
   }
 
   @Test
   void testRedirectionToDashboardIfRemoteIdpPerformsMfa() throws Throwable {
 
-    MockHttpSession session = (MockHttpSession) mvc.perform(get(samlDefaultIdpLoginUrl()))
-      .andExpect(status().isOk())
-      .andReturn()
-      .getRequest()
-      .getSession();
+    MockHttpSession session = performInitialLogin();
 
     AuthnRequest authnRequest = getAuthnRequestFromSession(session);
 
-    Response r = buildMfaTest2Response(authnRequest);
+    Response response = buildMfaTest2Response(authnRequest);
+    postMfaResponseAndExpectRedirect(response, authnRequest, session, URL_DASHBOARD);
+  }
 
-    mvc
-      .perform(post(authnRequest.getAssertionConsumerServiceURL())
-        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-        .param("SAMLResponse", SamlUtils.signAndSerializeToBase64(r))
-        .session(session))
-      .andExpect(redirectedUrl("/dashboard"))
-      .andReturn()
-      .getRequest()
-      .getSession();
+  @Test
+  void testRegisteredUserWithMfaGetsRedirectedToMfaVerifyEvenIfAupPending() throws Throwable {
+    createDefaultAup();
+    MockHttpSession session = performInitialLogin();
+
+    AuthnRequest authnRequest = getAuthnRequestFromSession(session);
+    Response response = buildMfaTest1Response(authnRequest);
+    session = postMfaResponseAndExpectRedirect(response, authnRequest, session, URL_VERIFY);
+
+    mvc.perform(get(URL_VERIFY).session(session))
+        .andExpect(status().isOk())
+        .andExpect(view().name(VIEW_VERIFY_MFA));
+    
+    aupRepo.deleteAll();    
+  }
+
+  private MockHttpSession performInitialLogin() throws Exception, UnsupportedEncodingException {
+    MockHttpSession session = (MockHttpSession) mvc.perform(get(samlDefaultIdpLoginUrl()))
+        .andExpect(status().isOk())
+        .andReturn()
+        .getRequest()
+        .getSession();
+    return session;
+  }
+
+  private MockHttpSession postMfaResponseAndExpectRedirect(Response response, AuthnRequest authnRequest,
+      MockHttpSession session, String expectedUrl) throws Throwable {
+    String encodedSaml = SamlUtils.signAndSerializeToBase64(response);
+
+    return (MockHttpSession) mvc.perform(
+        post(authnRequest.getAssertionConsumerServiceURL())
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .param("SAMLResponse", encodedSaml)
+            .session(session))
+        .andExpect(redirectedUrl(expectedUrl))
+        .andReturn()
+        .getRequest()
+        .getSession();
+  }
+
+  private void createDefaultAup() {
+    IamAup aup = new IamAup();
+
+    aup.setCreationTime(new Date());
+    aup.setLastUpdateTime(new Date());
+    aup.setName("default-aup" + RandomGenerator.getDefault().nextInt());
+    aup.setUrl("http://default-aup.org/");
+    aup.setDescription("AUP description");
+    aup.setSignatureValidityInDays(0L);
+    aup.setAupRemindersInDays("30,15,1");
+
+    aupRepo.saveDefaultAup(aup);
   }
 }


### PR DESCRIPTION
- A new condition was added to `EnforceAupFilter` so that, when MFA is active for an SSO user, the filter redirects them to the MFA verification page as the first step, instead of sending them to the AUP signing page.
- Test cases for OIDC and SAML flow
- LocalAuthentication is working fine as `accountUtils.isAuthenticated()` is `false` if TOTP not verified