### PR TITLE
Update VOMS-AA application.yml to use environment variables

### DIFF
--- a/iam-voms-aa/src/main/resources/application.yml
+++ b/iam-voms-aa/src/main/resources/application.yml
@@ -1,46 +1,41 @@
-#
-# Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 server:
-  address: localhost
-  port: 15000
+  address: 0.0.0.0
+  port: 8080
+  use-forward-headers: true
   max-http-header-size: 16000
-    
-  
+
 spring:
-  flyway:
-    table: schema_version
-  
   main:
-    banner-mode: "off"
-    allow-circular-references: true
+    banner-mode: "off" 
   
   jpa:
-    open-in-view: false
+    open-in-view: true
+
+  datasource:
+    dataSourceClassName: com.mysql.jdbc.jdbc2.optional.MysqlDataSource
+    url: jdbc:mysql://${IAM_DB_HOST}:${IAM_DB_PORT:3306}/${IAM_DB_NAME}?useLegacyDatetimeCode=false&serverTimezone=UTC&useSSL=false
+    username: ${IAM_DB_USERNAME}
+    password: ${IAM_DB_PASSWORD}
+    max-active: ${IAM_DB_MAX_ACTIVE:10}
+    max-idle:  ${IAM_DB_MAX_IDLE:5}
+    initial-size: ${IAM_DB_INITIAL_SIZE:1}
+    test-while-idle: ${IAM_DB_TEST_WHILE_IDLE:true}
+    test-on-borrow: ${IAM_DB_TEST_ON_BORROW:true}
+    validation-query: ${IAM_DB_VALIDATION_QUERY:SELECT 1}
+    time-between-eviction-runs-millis: ${IAM_DB_TIME_BETWEEN_EVICTION_RUNS_MILLIS:5000}
+    min-evictable-idle-time-millis: ${IAM_DB_MIN_EVICTABLE_IDLE_TIME_MILLIS:60000}
   
+  flyway:
+    enabled: false
+      
 voms:
   tls:
-    certificate-path: /etc/grid-security/voms/hostcert.pem
-    private-key-path: /etc/grid-security/voms/hostkey.pem
+    certificate-path: /certs/hostcert.pem
+    private-key-path: /certs/hostkey.pem
     trust-anchors-dir: /etc/grid-security/certificates
     trust-anchors-refresh-interval-secs: 14400
   aa:
-    host: ${server.address}
-    port: ${server.port}
-    vo-name: test
-    optional-group-label: wlcg.optional-group
-    voms-role-label: voms.role
-    use-legacy-fqan-encoding: false
+    host: ${VOMS_AA_HOST:undefined}
+    port: ${VOMS_AA_PORT:undefined}
+    vo-name: ${VOMS_AA_VO:undefined}
+    use-legacy-fqan-encoding: ${VOMS_AA_USE_LEGACY_FQAN_ENCODING:true}

--- a/iam-voms-aa/src/main/resources/application.yml
+++ b/iam-voms-aa/src/main/resources/application.yml
@@ -1,3 +1,19 @@
+#
+# Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 server:
   address: 0.0.0.0
   port: 8080


### PR DESCRIPTION
- Current version cannot be used out of the shelf
- Be consistent with variable already used for the login service
- Add variables VOMS_AA_HOST, VOMS_AA_PORT, VOMS_AA_VO and VOMS_AA_USE_LEGACY_FQAN_ENCODING specific to VOMS AA