### PR TITLE
Restore default value for enc-dec mfa key

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/mfa/IamTotpMfaKeyRotationRunner.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/mfa/IamTotpMfaKeyRotationRunner.java
@@ -22,11 +22,6 @@ import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
-/**
- * Runs at application startup (when the "mfa" profile is active) and ensures the configured MFA
- * admin key is recorded; if the key changed, it re-encrypts all stored TOTP secrets using the old
- * key -> And, encrypts it using new key.
- */
 @Component
 @Profile("mfa")
 public class IamTotpMfaKeyRotationRunner implements ApplicationRunner {
@@ -44,7 +39,7 @@ public class IamTotpMfaKeyRotationRunner implements ApplicationRunner {
   public void run(ApplicationArguments args) {
 
     if (!iamTotpSecretRotationService.shouldRotateSecrets()) {
-      LOG.info("TOTP MFA: No changes detected on totp encryption key");
+      LOG.debug("TOTP MFA: No changes detected on totp encryption key");
       return;
     }
     LOG.info("TOTP MFA: Admin key changed. Starting TOTP secret re-encryption.");

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/mfa/IamTotpSecretRotationService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/mfa/IamTotpSecretRotationService.java
@@ -103,7 +103,7 @@ public class IamTotpSecretRotationService {
         encryptSecret(rawSecret, mfaProperties.getPasswordToEncryptAndDecrypt());
     totp.setSecret(encrypted);
     totpRepository.save(totp);
-    LOG.info("TOTP MFA: Re-encrypted secret for id={}", totp.getId());
+    LOG.debug("TOTP MFA: Re-encrypted secret for user {}", totp.getAccount().getUsername());
   }
 
   private IamTotpAdminKey getCurrentKey() {

--- a/iam-login-service/src/main/resources/application-mfa.yml
+++ b/iam-login-service/src/main/resources/application-mfa.yml
@@ -17,7 +17,7 @@
 mfa:
   multi-factor-settings-btn-enabled: ${IAM_TOTP_MFA_ENABLE_MFA_SETTINGS_BUTTON:true}
   # Please store this KEY securly & safetly
-  password-to-encrypt-and-decrypt: ${IAM_TOTP_MFA_PASSWORD_TO_ENCRYPT_AND_DECRYPT:}
+  password-to-encrypt-and-decrypt: ${IAM_TOTP_MFA_PASSWORD_TO_ENCRYPT_AND_DECRYPT:define_me_please}
   # ONLY provide the previous KEY if you are rotating to a new KEY above.
   # Leave this blank if no KEY rotation is happening.
   old-password-to-decrypt: ${IAM_TOTP_MFA_OLD_PASSWORD_TO_DECRYPT:}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/core/mfa/IamTotpMfaKeyRotationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/core/mfa/IamTotpMfaKeyRotationTests.java
@@ -34,6 +34,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import it.infn.mw.iam.config.mfa.IamTotpMfaProperties;
 import it.infn.mw.iam.core.mfa.IamTotpSecretRotationService;
+import it.infn.mw.iam.persistence.model.IamAccount;
 import it.infn.mw.iam.persistence.model.IamTotpAdminKey;
 import it.infn.mw.iam.persistence.model.IamTotpMfa;
 import it.infn.mw.iam.persistence.repository.IamTotpAdminKeyRepository;
@@ -45,16 +46,19 @@ import it.infn.mw.iam.util.mfa.IamTotpMfaInvalidArgumentError;
 class IamTotpMfaKeyRotationTests {
 
   @Mock
-  private IamTotpMfaProperties mfaProperties;
+  IamTotpMfaProperties mfaProperties;
 
   @Mock
-  private IamTotpMfaRepository totpRepository;
+  IamTotpMfaRepository totpRepository;
 
   @Mock
-  private IamTotpAdminKeyRepository adminKeyRepository;
+  IamTotpAdminKeyRepository adminKeyRepository;
 
   @Mock
-  private PasswordEncoder passwordEncoder;
+  PasswordEncoder passwordEncoder;
+
+  @Mock
+  IamAccount account;
 
   final String currentKey = "define-new-key";
   final String oldKey = "define-old-key";
@@ -106,9 +110,12 @@ class IamTotpMfaKeyRotationTests {
     String encryptedWithOld =
         IamTotpMfaEncryptionAndDecryptionUtil.encryptSecret(rawSecret, oldPassword);
 
+    when(account.getUsername()).thenReturn("test-user");
+
     IamTotpMfa totp = new IamTotpMfa();
     totp.setId(1L);
     totp.setSecret(encryptedWithOld);
+    totp.setAccount(account);
 
     when(mfaProperties.getOldPasswordToDecrypt()).thenReturn(oldPassword);
     when(mfaProperties.getPasswordToEncryptAndDecrypt()).thenReturn(newPassword);


### PR DESCRIPTION
Otherwise the service won't start in case you were using the default key.
Logging level for the usual "no changes detected" moved to debug