### PR TITLE
Upgrade voms-api-java from 3.3.6 to 3.3.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@
     <mitreid.version>1.3.7.cnaf-20260213</mitreid.version>
     <spring-security-oauth2.version>2.5.2.RELEASE</spring-security-oauth2.version>
 
-    <voms.version>3.3.6</voms.version>
-    <bc.version>1.81</bc.version>
+    <voms.version>3.3.8</voms.version>
+    <bc.version>1.84</bc.version>
 
     <spring-security-saml.version>1.0.10.RELEASE</spring-security-saml.version>
 


### PR DESCRIPTION
That means BouncyCastle version from 1.81 to 1.84