### PR TITLE
Restore non-strict backend compliance for SCIM PATCH operations

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimGroupPatchRequest.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimGroupPatchRequest.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -37,6 +38,7 @@ public class ScimGroupPatchRequest {
   @NotEmpty
   @Valid
   @JsonProperty("Operations")
+  @JsonAlias("operations")
   private List<ScimPatchOperation<List<ScimMemberRef>>> operations;
 
   public ScimGroupPatchRequest() {}

--- a/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimUserPatchRequest.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/api/scim/model/ScimUserPatchRequest.java
@@ -23,8 +23,10 @@ import java.util.Set;
 import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonInclude(Include.NON_EMPTY)
 public class ScimUserPatchRequest {
@@ -35,6 +37,8 @@ public class ScimUserPatchRequest {
 
   @NotEmpty
   @Valid
+  @JsonProperty("Operations")
+  @JsonAlias("operations")
   private List<ScimPatchOperation<ScimUser>> operations;
 
   public ScimUserPatchRequest() {

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/services/scim-factory.service.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/services/scim-factory.service.js
@@ -212,7 +212,7 @@ angular.module('dashboardApp').factory("scimFactory", ['$q', '$http', '$httpPara
 		var data = {
 
 			schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-			operations: [{
+			Operations: [{
 				op: "add",
 				path: "members",
 				value: [{
@@ -239,7 +239,7 @@ angular.module('dashboardApp').factory("scimFactory", ['$q', '$http', '$httpPara
 		};
 		var data = {
 			schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-			operations: [{
+			Operations: [{
 				op: "remove",
 				path: "members",
 				value: [{
@@ -265,7 +265,7 @@ angular.module('dashboardApp').factory("scimFactory", ['$q', '$http', '$httpPara
 		};
 		var data = {
 			schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-			operations: [{
+			Operations: [{
 				op: "remove",
 				value: {
 					groups: [{
@@ -290,7 +290,7 @@ angular.module('dashboardApp').factory("scimFactory", ['$q', '$http', '$httpPara
 		};
 		var data = {
 			schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-			operations: [{
+			Operations: [{
 				op: "remove",
 				path: "members",
 				value: [{
@@ -318,7 +318,7 @@ angular.module('dashboardApp').factory("scimFactory", ['$q', '$http', '$httpPara
 		var data = {
 
 			schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-			operations: [{
+			Operations: [{
 				op: "add",
 				value: {
 					"urn:indigo-dc:scim:schemas:IndigoUser": {
@@ -345,7 +345,7 @@ angular.module('dashboardApp').factory("scimFactory", ['$q', '$http', '$httpPara
 		var data = {
 
 			schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-			operations: [{
+			Operations: [{
 				op: "remove",
 				value: {
 					"urn:indigo-dc:scim:schemas:IndigoUser": {
@@ -367,7 +367,7 @@ angular.module('dashboardApp').factory("scimFactory", ['$q', '$http', '$httpPara
 		};
 		var data = {
 			schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-			operations: [{
+			Operations: [{
 				op: "add",
 				value: {
 					"urn:indigo-dc:scim:schemas:IndigoUser": {
@@ -390,7 +390,7 @@ angular.module('dashboardApp').factory("scimFactory", ['$q', '$http', '$httpPara
 		};
 		var data = {
 			schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-			operations: [{
+			Operations: [{
 				op: "add",
 				value: {
 					"urn:indigo-dc:scim:schemas:IndigoUser": {
@@ -411,7 +411,7 @@ angular.module('dashboardApp').factory("scimFactory", ['$q', '$http', '$httpPara
 		};
 		var data = {
 			schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-			operations: [{
+			Operations: [{
 				op: "remove",
 				value: {
 					"urn:indigo-dc:scim:schemas:IndigoUser": {
@@ -433,7 +433,7 @@ angular.module('dashboardApp').factory("scimFactory", ['$q', '$http', '$httpPara
 		};
 		var data = {
 			schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-			operations: [{
+			Operations: [{
 				op: "remove",
 				value: {
 					"urn:indigo-dc:scim:schemas:IndigoUser": {
@@ -460,7 +460,7 @@ angular.module('dashboardApp').factory("scimFactory", ['$q', '$http', '$httpPara
 
 		var data = {
 			schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-			operations: [{
+			Operations: [{
 				op: "add",
 				value: {
 					"urn:indigo-dc:scim:schemas:IndigoUser": {
@@ -483,7 +483,7 @@ angular.module('dashboardApp').factory("scimFactory", ['$q', '$http', '$httpPara
 
 		var data = {
 			schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-			operations: [{
+			Operations: [{
 				op: "remove",
 				value: {
 					"urn:indigo-dc:scim:schemas:IndigoUser": {
@@ -508,7 +508,7 @@ angular.module('dashboardApp').factory("scimFactory", ['$q', '$http', '$httpPara
 		};
 		var data = {
 			schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-			operations: [{
+			Operations: [{
 				op: "add",
 				value: {
 					"urn:indigo-dc:scim:schemas:IndigoUser": {
@@ -532,7 +532,7 @@ angular.module('dashboardApp').factory("scimFactory", ['$q', '$http', '$httpPara
 		};
 		var data = {
 			schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-			operations: [{
+			Operations: [{
 				op: "remove",
 				value: {
 					"urn:indigo-dc:scim:schemas:IndigoUser": {
@@ -561,7 +561,7 @@ angular.module('dashboardApp').factory("scimFactory", ['$q', '$http', '$httpPara
 		};
 		var data = {
 			schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-			operations: [{
+			Operations: [{
 				op: "replace",
 				value: {
 					active: status
@@ -584,7 +584,7 @@ angular.module('dashboardApp').factory("scimFactory", ['$q', '$http', '$httpPara
 		};
 		var data = {
 			schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-			operations: ops
+			Operations: ops
 		};
 		var url = urlUsers + '/' + userId;
 
@@ -602,7 +602,7 @@ angular.module('dashboardApp').factory("scimFactory", ['$q', '$http', '$httpPara
 		};
 		var data = {
 			schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-			operations: ops
+			Operations: ops
 		};
 
 		return $http.patch(urlMe, data, config);
@@ -619,7 +619,7 @@ angular.module('dashboardApp').factory("scimFactory", ['$q', '$http', '$httpPara
 		};
 		var data = {
 			schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-			operations: [{
+			Operations: [{
 				op: "replace",
 				value: {
 					"urn:indigo-dc:scim:schemas:IndigoUser": {

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/nodb/ScimApiAccessTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/nodb/ScimApiAccessTests.java
@@ -57,6 +57,22 @@ class ScimApiAccessTests extends ScimTestSupport {
   }
 
   @Test
+  void userAddedToGroupLegacy() throws Exception {
+
+    String token = passwordToken("scim:read scim:write", "admin", "password");
+
+    JsonNode user = createScimUser(token, random("member"));
+    JsonNode group = createScimGroup(token, random("group"));
+
+    addUserToGroupLegacy(token, group.get("id").asText(), user.get("id").asText());
+
+    JsonNode updatedUser = getResource(token, SCIM_USERS + "/" + user.get("id").asText());
+
+    String uuidGroup = updatedUser.get("groups").get(0).get("value").asText();
+    assertEquals(uuidGroup, group.get("id").asText());
+  }
+
+  @Test
   void wrongGroupContentOnCreation() throws Exception {
 
     String token = scimRwToken();

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/nodb/ScimTestSupport.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/scim/nodb/ScimTestSupport.java
@@ -84,19 +84,50 @@ public class ScimTestSupport extends OidcMockMvcTestSupport {
     return mapper.readTree(result.getResponse().getContentAsString());
   }
 
+  protected String getLegacyOperationsTemplate() {
+    return """
+        {
+        "operations": [{
+          "op": "add",
+          "path": "members",
+          "value": [{
+            "value": "%s"
+          }]
+        }]
+      }
+      """;
+  }
+
+  protected String getOperationsTemplate() {
+    return """
+        {
+        "Operations": [{
+          "op": "add",
+          "path": "members",
+          "value": [{
+            "value": "%s"
+          }]
+        }]
+      }
+      """;
+  }
+
   protected void addUserToGroup(String token, String groupId, String userId) throws Exception {
 
-    String patch = """
-        {
-          "Operations": [{
-            "op": "add",
-            "path": "members",
-            "value": [{
-              "value": "%s"
-            }]
-          }]
-        }
-        """.formatted(userId);
+    String patch = getOperationsTemplate().formatted(userId);
+
+    var result = mockMvc
+      .perform(patch(SCIM_GROUPS + "/" + groupId).header("Authorization", "Bearer " + token)
+        .contentType("application/scim+json")
+        .content(patch))
+      .andReturn();
+
+    assertEquals(204, result.getResponse().getStatus());
+  }
+
+  protected void addUserToGroupLegacy(String token, String groupId, String userId) throws Exception {
+
+    String patch = getLegacyOperationsTemplate().formatted(userId);
 
     var result = mockMvc
       .perform(patch(SCIM_GROUPS + "/" + groupId).header("Authorization", "Bearer " + token)


### PR DESCRIPTION
- Update SCIM payload to use Operations for strict backend compliance
- Support both "operations" and "Operations" keys

From [SCIM Protocol reference](https://datatracker.ietf.org/doc/html/rfc7644#section-3.5.2):

> The body of an HTTP PATCH request MUST contain the attribute
   "Operations", whose value is an array of one or more PATCH
   operations.

In order to keep a backward compatibility with next 1.14.0 release, we'll continue to support the usage of `operations`