### PR TITLE
Add and fix AARC claims

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcClaimValueHelper.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcClaimValueHelper.java
@@ -125,6 +125,11 @@ public class AarcClaimValueHelper extends IamClaimValueHelper {
             return scopedAffiliations;
           }
           return null;
+        case AarcExtraClaimNames.SCHAC_HOME_ORGANIZATION:
+          if (userAuth.isPresent()) {
+            return userAuth.get().getAdditionalInfo().get("urn:oid:1.3.6.1.4.1.25178.1.2.9");
+          }
+          return null;
         default:
           return super.resolveClaim(claimName, auth, account);
       }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcClaimValueHelper.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcClaimValueHelper.java
@@ -112,7 +112,7 @@ public class AarcClaimValueHelper extends IamClaimValueHelper {
                   properties.getOrganisation().getName()));
             }
             String externalScopedAffiliation = firstOf(userAuth.get().getAdditionalInfo(),
-                Set.of("VPSA", "voPersonScopedAffiliation", "urn:oid:1.3.6.1.4.1.34998.3.3.1.12"));
+                Set.of("EPSA", "eduPersonScopedAffiliation", "urn:oid:1.3.6.1.4.1.5923.1.1.1.9"));
             if (externalScopedAffiliation != null) {
               scopedAffiliations.add(externalScopedAffiliation);
             }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcClaimValueHelper.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcClaimValueHelper.java
@@ -85,7 +85,9 @@ public class AarcClaimValueHelper extends IamClaimValueHelper {
     final String SCOPED_FORMAT = "%s@%s";
 
     Optional<SavedUserAuthentication> userAuth =
-        AuthenticationUtils.getExternalAuthenticationInfo(auth.getUserAuthentication());
+        (auth != null && auth.getUserAuthentication() != null)
+            ? AuthenticationUtils.getExternalAuthenticationInfo(auth.getUserAuthentication())
+            : Optional.empty();
 
     if (account.isPresent()) {
       switch (claimName) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcClaimValueHelper.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcClaimValueHelper.java
@@ -19,7 +19,6 @@ import static java.lang.String.format;
 
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -85,11 +84,23 @@ public class AarcClaimValueHelper extends IamClaimValueHelper {
 
     final String SCOPED_FORMAT = "%s@%s";
 
+    Optional<SavedUserAuthentication> userAuth =
+        AuthenticationUtils.getExternalAuthenticationInfo(auth.getUserAuthentication());
+
     if (account.isPresent()) {
       switch (claimName) {
         case AarcExtraClaimNames.AARC_VER:
           return AARC_VERSION_URI;
         case AarcExtraClaimNames.EDUPERSON_ASSURANCE:
+          if (userAuth.isPresent()) {
+            Set<String> loa = new HashSet<>(DEFAULT_LOA);
+            String remoteLoa = firstOf(userAuth.get().getAdditionalInfo(),
+                Set.of("eduPersonAssurance", "urn:oid:1.3.6.1.4.1.5923.1.1.1.11"));
+            if (remoteLoa != null) {
+              loa.add(remoteLoa);
+            }
+            return loa;
+          }
           return DEFAULT_LOA;
         case AarcExtraClaimNames.EDUPERSON_ENTITLEMENT, AarcExtraClaimNames.ENTITLEMENTS:
           return resolveGroups(account.get().getUserInfo());
@@ -100,11 +111,6 @@ public class AarcClaimValueHelper extends IamClaimValueHelper {
           return format(SCOPED_FORMAT, DEFAULT_AFFILIATION_TYPE,
               properties.getOrganisation().getName());
         case AarcExtraClaimNames.VOPERSON_EXTERNAL_AFFILIATION:
-          if (Objects.isNull(auth)) {
-            return null;
-          }
-          Optional<SavedUserAuthentication> userAuth =
-              AuthenticationUtils.getExternalAuthenticationInfo(auth.getUserAuthentication());
           if (userAuth.isPresent()) {
             Set<String> scopedAffiliations = new HashSet<>();
             if (account.get().getAffiliation() != null) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcExtraClaimNames.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcExtraClaimNames.java
@@ -45,17 +45,19 @@ public interface AarcExtraClaimNames extends BaseExtraClaimNames {
 
   String VOPERSON_EXTERNAL_AFFILIATION = "voperson_external_affiliation";
 
+  String SCHAC_HOME_ORGANIZATION = "schac_home_organization";
+
   public static final Set<String> ACCESS_TOKEN_REQUIRED_CLAIMS =
       Set.of(VOPERSON_ID, EDUPERSON_ASSURANCE, ENTITLEMENTS);
 
   public static final Set<String> ID_TOKEN_REQUIRED_CLAIMS =
       Set.of(VOPERSON_ID, EDUPERSON_ASSURANCE, ENTITLEMENTS);
 
-  public static final Set<String> INTROSPECTION_REQUIRED_CLAIMS =
-      Set.of(AARC_VER, VOPERSON_ID, EDUPERSON_ASSURANCE, ENTITLEMENTS, VOPERSON_EXTERNAL_AFFILIATION);
+  public static final Set<String> INTROSPECTION_REQUIRED_CLAIMS = Set.of(AARC_VER, VOPERSON_ID,
+      EDUPERSON_ASSURANCE, ENTITLEMENTS, VOPERSON_EXTERNAL_AFFILIATION);
 
   public static final Set<String> USERINFO_REQUIRED_CLAIMS =
       Set.of(AARC_VER, VOPERSON_ID, EDUPERSON_ASSURANCE, ENTITLEMENTS, ORGANIZATION_NAME,
-          VOPERSON_EXTERNAL_AFFILIATION, JWTClaimNames.SUBJECT, StandardClaimNames.NAME, StandardClaimNames.GIVEN_NAME,
-          StandardClaimNames.FAMILY_NAME, StandardClaimNames.EMAIL);
+          VOPERSON_EXTERNAL_AFFILIATION, JWTClaimNames.SUBJECT, StandardClaimNames.NAME,
+          StandardClaimNames.GIVEN_NAME, StandardClaimNames.FAMILY_NAME, StandardClaimNames.EMAIL);
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcOidcScopes.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcOidcScopes.java
@@ -35,4 +35,6 @@ public interface AarcOidcScopes extends IamOidcScopes {
 
   String VOPERSON_EXTERNAL_AFFILIATION = AarcExtraClaimNames.VOPERSON_EXTERNAL_AFFILIATION;
 
+  String SCHAC_HOME_ORGANIZATION = AarcExtraClaimNames.SCHAC_HOME_ORGANIZATION;
+
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcScopeClaimTranslationService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcScopeClaimTranslationService.java
@@ -40,6 +40,7 @@ public class AarcScopeClaimTranslationService extends BaseScopeClaimTranslationS
             AarcExtraClaimNames.ENTITLEMENTS,
             AarcExtraClaimNames.ORGANIZATION_NAME,
             AarcExtraClaimNames.VOPERSON_EXTERNAL_AFFILIATION,
+            AarcExtraClaimNames.SCHAC_HOME_ORGANIZATION,
             StandardClaimNames.NAME,
             StandardClaimNames.GIVEN_NAME,
             StandardClaimNames.FAMILY_NAME,
@@ -65,6 +66,10 @@ public class AarcScopeClaimTranslationService extends BaseScopeClaimTranslationS
         return Sets.newHashSet(
             AarcExtraClaimNames.EDUPERSON_ENTITLEMENT,
             AarcExtraClaimNames.ENTITLEMENTS);
+      case AarcOidcScopes.SCHAC_HOME_ORGANIZATION:
+        return Sets.newHashSet(
+            AarcExtraClaimNames.SCHAC_HOME_ORGANIZATION
+            );
       case OidcScopes.PROFILE:
         return merge(scope, Sets.newHashSet(
             AarcExtraClaimNames.AARC_VER,

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/AarcClaimValueHelperTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/AarcClaimValueHelperTests.java
@@ -20,6 +20,7 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -226,5 +227,26 @@ class AarcClaimValueHelperTests {
     assertThat(result, hasItem("https://refeds.org/assurance/IAP/medium"));
     assertThat(result, hasItem("https://refeds.org/assurance/IAP/low"));
     assertThat(result, hasItem("https://refeds.org/assurance"));
+  }
+
+  @Test
+  void testResolveSchacHomeOrganization() {
+    OAuth2Authentication auth = mock(OAuth2Authentication.class);
+
+    Map<String, String> additionalInfo = new HashMap<>();
+    additionalInfo.put("urn:oid:1.3.6.1.4.1.25178.1.2.9", "infn.it");
+
+    SavedUserAuthentication savedAuth = new SavedUserAuthentication();
+    savedAuth.setSourceClass(OidcExternalAuthenticationToken.class.getName());
+    savedAuth.setAdditionalInfo(additionalInfo);
+
+    when(auth.getUserAuthentication()).thenReturn(savedAuth);
+
+    IamAccount account = mock(IamAccount.class);
+
+    String result = (String) helper.resolveClaim(AarcExtraClaimNames.SCHAC_HOME_ORGANIZATION, auth,
+        Optional.of(account));
+
+    assertEquals("infn.it", result);
   }
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/AarcClaimValueHelperTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/AarcClaimValueHelperTests.java
@@ -155,7 +155,7 @@ class AarcClaimValueHelperTests {
     OAuth2Authentication auth = mock(OAuth2Authentication.class);
 
     Map<String, String> additionalInfo = new HashMap<>();
-    additionalInfo.put("VPSA", "external@test.org");
+    additionalInfo.put("EPSA", "external@test.org");
 
     SavedUserAuthentication savedAuth = new SavedUserAuthentication();
     savedAuth.setSourceClass(OidcExternalAuthenticationToken.class.getName());
@@ -183,7 +183,7 @@ class AarcClaimValueHelperTests {
     OAuth2Authentication auth = mock(OAuth2Authentication.class);
 
     Map<String, String> additionalInfo = new HashMap<>();
-    additionalInfo.put("VPSA", "external@test.org");
+    additionalInfo.put("EPSA", "external@test.org");
 
     SavedUserAuthentication savedAuth = new SavedUserAuthentication();
     savedAuth.setSourceClass(OidcExternalAuthenticationToken.class.getName());
@@ -201,5 +201,30 @@ class AarcClaimValueHelperTests {
 
     assertThat(result, hasSize(1));
     assertThat(result, hasItem("external@test.org"));
+  }
+
+  @Test
+  void testResolveAssuranceInfo() {
+    OAuth2Authentication auth = mock(OAuth2Authentication.class);
+
+    Map<String, String> additionalInfo = new HashMap<>();
+    additionalInfo.put("urn:oid:1.3.6.1.4.1.5923.1.1.1.11",
+        "https://refeds.org/assurance/IAP/medium");
+
+    SavedUserAuthentication savedAuth = new SavedUserAuthentication();
+    savedAuth.setSourceClass(OidcExternalAuthenticationToken.class.getName());
+    savedAuth.setAdditionalInfo(additionalInfo);
+
+    when(auth.getUserAuthentication()).thenReturn(savedAuth);
+
+    IamAccount account = mock(IamAccount.class);
+
+    Set<String> result = (Set<String>) helper.resolveClaim(AarcExtraClaimNames.EDUPERSON_ASSURANCE,
+        auth, Optional.of(account));
+
+    assertThat(result, hasSize(3));
+    assertThat(result, hasItem("https://refeds.org/assurance/IAP/medium"));
+    assertThat(result, hasItem("https://refeds.org/assurance/IAP/low"));
+    assertThat(result, hasItem("https://refeds.org/assurance"));
   }
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/AarcProfileIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/AarcProfileIntegrationTests.java
@@ -67,7 +67,7 @@ import it.infn.mw.iam.test.util.oauth.MockOAuth2Filter;
 // @formatter:off
   "iam.host=example.org",
   "iam.jwt-profile.default-profile=aarc",
-  "iam.access-token.include-authn-info=true"
+  "iam.access_token.include_authn_info=true"
 // @formatter:on
 })
 @SuppressWarnings("deprecation")


### PR DESCRIPTION
This PR:
* fixes the `voperson_external_affiliation` attribute by setting its value to the `EPSA` received from the remote IdP
* fixes the `eduperson_assurance` attribute by populating it with the corresponding value received from the remote IdP
* adds the `schac_home_organization` attribute, populating it with the corresponding value received from the remote IdP

Ref: [AARC G056](https://aarc-community.org/guidelines/aarc-g056/)