### PR TITLE
Replace obsolete JaCoCo property for Sonar

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -39,13 +39,11 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_VIANELLO }}
-      run: mvn -B -U verify sonar:sonar
-            -Dsonar.projectKey=indigo-iam_iam 
-            -Dsonar.organization=indigo-iam 
-            -Dsonar.login=$SONAR_TOKEN
-            -Dsonar.pullrequest.key=${{ github.event.number }}
-            -Dsonar.pullrequest.branch=${{ github.HEAD_REF }}
-            -Dsonar.pullrequest.base=${{ github.BASE_REF }}
-            -Dsonar.pullrequest.github.repository=${{ github.repository }}
-            -Dsonar.scm.provider=git
-            -Dsonar.host.url=https://sonarcloud.io
+      run: |
+        mvn -B -U verify sonar:sonar
+          -Dsonar.projectKey=indigo-iam_iam
+          -Dsonar.organization=indigo-iam
+          -Dsonar.login=$SONAR_TOKEN
+          -Dsonar.coverage.jacoco.xmlReportPaths=iam-login-service/target/site/jacoco-aggregate/jacoco.xml \
+          -Dsonar.scm.provider=git
+          -Dsonar.host.url=https://sonarcloud.io

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <code.coverage.overall.data.folder>${basedir}/target/</code.coverage.overall.data.folder>
 
     <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
-    <sonar.jacoco.reportPath>${project.basedir}/../target/jacoco.exec</sonar.jacoco.reportPath>
+    <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/../target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     <sonar.language>java</sonar.language>
     <sonar.coverage.exclusions>
       iam-persistence/**/*,iam-test-client/**/*,iam-common/**</sonar.coverage.exclusions>
@@ -536,7 +536,7 @@
           </execution>
           <execution>
             <id>jacoco-report</id>
-            <phase>test</phase>
+            <phase>verify</phase>
             <goals>
               <goal>report</goal>
             </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -101,8 +101,11 @@
     <code.coverage.project.folder>${basedir}/../</code.coverage.project.folder>
     <code.coverage.overall.data.folder>${basedir}/target/</code.coverage.overall.data.folder>
 
+    <sonar.coverage.jacoco.xmlReportPaths>
+      ${maven.multiModuleProjectDirectory}/iam-login-service/target/site/jacoco-aggregate/jacoco.xml
+    </sonar.coverage.jacoco.xmlReportPaths>
+
     <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
-    <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/../target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     <sonar.language>java</sonar.language>
     <sonar.coverage.exclusions>
       iam-persistence/**/*,iam-test-client/**/*,iam-common/**</sonar.coverage.exclusions>
@@ -532,13 +535,6 @@
             <id>jacoco-initialize</id>
             <goals>
               <goal>prepare-agent</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>jacoco-report</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>report</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
Fix for Sonar warnings in last analysis:

```
Property 'sonar.jacoco.reportPath' is no longer supported. Use JaCoCo's xml report and sonar-jacoco plugin. Some thymeleaf templates are not indexed : you may want to add "src/main/resources" in the scanned files of this project to detect java XSS vulnerabilities
```