### PR TITLE
Add grantType parameter for token events

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/tokens/AccessTokenIssuedEvent.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/tokens/AccessTokenIssuedEvent.java
@@ -31,8 +31,8 @@ public class AccessTokenIssuedEvent extends SignedTokenEvent {
 
   private String refreshTokenJti;
 
-  public AccessTokenIssuedEvent(Object source, OAuth2AccessTokenEntity token) {
-    super(source, token.getJwt(), token.getAuthenticationHolder(), "Issue access token");
+  public AccessTokenIssuedEvent(Object source, OAuth2AccessTokenEntity token, String grantType) {
+    super(source, token.getJwt(), token.getAuthenticationHolder(), grantType, "Issue access token");
 
     if (token.getRefreshToken() != null) {
       try {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/tokens/IdTokenIssuedEvent.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/tokens/IdTokenIssuedEvent.java
@@ -27,8 +27,8 @@ public class IdTokenIssuedEvent extends SignedTokenEvent {
   private static final long serialVersionUID = 1L;
 
   public IdTokenIssuedEvent(Object source, JWT token,
-      AuthenticationHolderEntity authenticationHolder) {
-    super(source, token, authenticationHolder, "Issue id token");
+      AuthenticationHolderEntity authenticationHolder, String grantType) {
+    super(source, token, authenticationHolder, grantType, "Issue id token");
   }
 
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/tokens/RefreshTokenIssuedEvent.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/tokens/RefreshTokenIssuedEvent.java
@@ -22,8 +22,8 @@ public class RefreshTokenIssuedEvent extends TokenEvent {
 
   private static final long serialVersionUID = 7801697305119146714L;
 
-  public RefreshTokenIssuedEvent(Object source, OAuth2RefreshTokenEntity token) {
-    super(source, token.getJwt(), token.getAuthenticationHolder(), "Issue refresh token");
+  public RefreshTokenIssuedEvent(Object source, OAuth2RefreshTokenEntity token, String grantType) {
+    super(source, token.getJwt(), token.getAuthenticationHolder(), grantType, "Issue refresh token");
   }
 
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/tokens/RegistrationTokenIssuedEvent.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/tokens/RegistrationTokenIssuedEvent.java
@@ -21,8 +21,8 @@ public class RegistrationTokenIssuedEvent extends SignedTokenEvent {
 
   private static final long serialVersionUID = 1L;
 
-  public RegistrationTokenIssuedEvent(Object source, OAuth2AccessTokenEntity registrationToken) {
-    super(source, registrationToken.getJwt(), registrationToken.getAuthenticationHolder(), "Issue registration token");
+  public RegistrationTokenIssuedEvent(Object source, OAuth2AccessTokenEntity registrationToken, String grantType) {
+    super(source, registrationToken.getJwt(), registrationToken.getAuthenticationHolder(), grantType, "Issue registration token");
   }
 
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/tokens/ResourceTokenIssuedEvent.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/tokens/ResourceTokenIssuedEvent.java
@@ -21,9 +21,9 @@ public class ResourceTokenIssuedEvent extends SignedTokenEvent {
 
   private static final long serialVersionUID = 1L;
 
-  public ResourceTokenIssuedEvent(Object source, OAuth2AccessTokenEntity registrationToken) {
+  public ResourceTokenIssuedEvent(Object source, OAuth2AccessTokenEntity registrationToken, String grantType) {
     super(source, registrationToken.getJwt(), registrationToken.getAuthenticationHolder(),
-        "Issue registration token");
+        grantType, "Issue registration token");
   }
 
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/tokens/SignedTokenEvent.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/tokens/SignedTokenEvent.java
@@ -27,8 +27,8 @@ public abstract class SignedTokenEvent extends TokenEvent {
   private final HeaderDTO header = new HeaderDTO();
 
   protected SignedTokenEvent(Object source, JWT token, AuthenticationHolderEntity authenticationHolder,
-      String message) {
-    super(source, token, authenticationHolder, message);
+      String grantType, String message) {
+    super(source, token, authenticationHolder, grantType, message);
 
     this.header.setAlg(token.getHeader().getAlgorithm().getName());
     this.header.setKid(String.valueOf(((JWSHeader) token.getHeader()).getKeyID()));

--- a/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/tokens/TokenEvent.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/tokens/TokenEvent.java
@@ -41,7 +41,7 @@ public abstract class TokenEvent extends IamAuditApplicationEvent {
   private final String grantType;
   private transient Map<String, Object> payload;
 
-  public TokenEvent(Object source, JWT token, AuthenticationHolderEntity authenticationHolder, String grantType, String message) {
+  protected TokenEvent(Object source, JWT token, AuthenticationHolderEntity authenticationHolder, String grantType, String message) {
     super(IamEventCategory.TOKEN, source, message);
 
     // subject will contains user-name or client name

--- a/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/tokens/TokenEvent.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/audit/events/tokens/TokenEvent.java
@@ -41,13 +41,13 @@ public abstract class TokenEvent extends IamAuditApplicationEvent {
   private final String grantType;
   private transient Map<String, Object> payload;
 
-  protected TokenEvent(Object source, JWT token, AuthenticationHolderEntity authenticationHolder, String message) {
+  public TokenEvent(Object source, JWT token, AuthenticationHolderEntity authenticationHolder, String grantType, String message) {
     super(IamEventCategory.TOKEN, source, message);
 
     // subject will contains user-name or client name
     this.subject = authenticationHolder.getAuthentication().getName();
     this.scopes = authenticationHolder.getScope();
-    this.grantType = authenticationHolder.getAuthentication().getOAuth2Request().getGrantType();
+    this.grantType = grantType;
 
     try {
       this.payload = token.getJWTClaimsSet().getClaims();

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/IamProperties.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/IamProperties.java
@@ -19,6 +19,8 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.validation.constraints.Pattern;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
@@ -709,6 +711,10 @@ public class IamProperties {
 
   private String host;
 
+  @Pattern(
+      regexp = ".*/",
+      message = "issuer must end with '/'"
+  )
   private String issuer;
 
   private String baseUrl;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/config/IamProperties.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/config/IamProperties.java
@@ -19,8 +19,6 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.validation.constraints.Pattern;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
@@ -711,10 +709,6 @@ public class IamProperties {
 
   private String host;
 
-  @Pattern(
-      regexp = ".*/",
-      message = "issuer must end with '/'"
-  )
   private String issuer;
 
   private String baseUrl;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/as/IamAuthorizationServerTokenServices.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/as/IamAuthorizationServerTokenServices.java
@@ -423,6 +423,8 @@ public class IamAuthorizationServerTokenServices implements AuthorizationServerT
     
     OAuth2Authentication newOAuth2Authentication =
         new OAuth2Authentication(newOAuth2Request, authHolder.getUserAuth());
+    
+    AuthenticationHolderEntity newAuthHolder = createAuthenticationHolder(newOAuth2Authentication);    
 
     JWTProfile profile = profileResolver.resolveProfile(client.getScope());
 
@@ -476,7 +478,7 @@ public class IamAuthorizationServerTokenServices implements AuthorizationServerT
       revocationService.revokeRefreshToken(refreshToken);
     }
 
-    token.setAuthenticationHolder(authHolder);
+    token.setAuthenticationHolder(newAuthHolder);
 
 
     JWTClaimsSet atClaims = profile.getAccessTokenBuilder()

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/as/IamAuthorizationServerTokenServices.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/as/IamAuthorizationServerTokenServices.java
@@ -204,7 +204,7 @@ public class IamAuthorizationServerTokenServices implements AuthorizationServerT
     if (client.isAllowRefresh()
         && isRefreshTokenRequested(request.getGrantType(), accessToken.getScope())) {
 
-      accessToken.setRefreshToken(createRefreshToken(client, authHolder));
+      accessToken.setRefreshToken(createRefreshToken(client, authHolder, request.getGrantType()));
     }
 
     JWTProfile profile = profileResolver.resolveProfile(client.getScope());
@@ -219,7 +219,7 @@ public class IamAuthorizationServerTokenServices implements AuthorizationServerT
 
       JWT idToken =
           createIdToken(client, request, Date.from(iat), account.get().getUuid(), accessToken);
-      eventPublisher.publishEvent(new IdTokenIssuedEvent(this, idToken, authHolder));
+      eventPublisher.publishEvent(new IdTokenIssuedEvent(this, idToken, authHolder, request.getGrantType()));
       accessToken.setIdToken(idToken);
     }
 
@@ -239,7 +239,7 @@ public class IamAuthorizationServerTokenServices implements AuthorizationServerT
   }
 
   private OAuth2RefreshTokenEntity createRefreshToken(ClientDetailsEntity client,
-      AuthenticationHolderEntity authHolder) {
+      AuthenticationHolderEntity authHolder, String grantType) {
 
     String jti = UUID.randomUUID().toString();
     Instant iat = clock.instant();
@@ -265,7 +265,7 @@ public class IamAuthorizationServerTokenServices implements AuthorizationServerT
     refreshToken.setClient(client);
 
     refreshToken = saveRefreshToken(refreshToken);
-    eventPublisher.publishEvent(new RefreshTokenIssuedEvent(this, refreshToken));
+    eventPublisher.publishEvent(new RefreshTokenIssuedEvent(this, refreshToken, grantType));
 
     return refreshToken;
   }
@@ -471,7 +471,7 @@ public class IamAuthorizationServerTokenServices implements AuthorizationServerT
       token.setRefreshToken(refreshToken);
     } else {
       // otherwise, make a new refresh token
-      token.setRefreshToken(createRefreshToken(client, authHolder));
+      token.setRefreshToken(createRefreshToken(client, authHolder, authRequest.getGrantType()));
       // clean up the old refresh token
       revocationService.revokeRefreshToken(refreshToken);
     }
@@ -491,7 +491,7 @@ public class IamAuthorizationServerTokenServices implements AuthorizationServerT
       JWT idToken = createIdToken(client, newOAuth2Request, Date.from(tokenIssueInstant),
           account.get().getUuid(), token);
 
-      eventPublisher.publishEvent(new IdTokenIssuedEvent(this, idToken, authHolder));
+      eventPublisher.publishEvent(new IdTokenIssuedEvent(this, idToken, authHolder, authRequest.getGrantType()));
       token.setIdToken(idToken);
     }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/as/IamAuthorizationServerTokenServices.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/as/IamAuthorizationServerTokenServices.java
@@ -30,6 +30,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -420,8 +421,16 @@ public class IamAuthorizationServerTokenServices implements AuthorizationServerT
 
     OAuth2Request newOAuth2Request =
         authHolder.getAuthentication().getOAuth2Request().refresh(authRequest);
+
+    Map<String, String> params = new HashMap<>(newOAuth2Request.getRequestParameters());
+    params.put("grant_type", authRequest.getGrantType());
+
+    OAuth2Request updatedOAuth2Request = newOAuth2Request.createOAuth2Request(params);
+    
     OAuth2Authentication newOAuth2Authentication =
-        new OAuth2Authentication(newOAuth2Request, authHolder.getUserAuth());
+        new OAuth2Authentication(updatedOAuth2Request, authHolder.getUserAuth());
+    
+    AuthenticationHolderEntity newAuthHolder = createAuthenticationHolder(newOAuth2Authentication);    
 
     JWTProfile profile = profileResolver.resolveProfile(client.getScope());
 
@@ -470,12 +479,12 @@ public class IamAuthorizationServerTokenServices implements AuthorizationServerT
       token.setRefreshToken(refreshToken);
     } else {
       // otherwise, make a new refresh token
-      token.setRefreshToken(createRefreshToken(client, authHolder));
+      token.setRefreshToken(createRefreshToken(client, newAuthHolder));
       // clean up the old refresh token
       revocationService.revokeRefreshToken(refreshToken);
     }
 
-    token.setAuthenticationHolder(authHolder);
+    token.setAuthenticationHolder(newAuthHolder);
 
 
     JWTClaimsSet atClaims = profile.getAccessTokenBuilder()

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/as/IamAuthorizationServerTokenServices.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/as/IamAuthorizationServerTokenServices.java
@@ -423,8 +423,6 @@ public class IamAuthorizationServerTokenServices implements AuthorizationServerT
     
     OAuth2Authentication newOAuth2Authentication =
         new OAuth2Authentication(newOAuth2Request, authHolder.getUserAuth());
-    
-    AuthenticationHolderEntity newAuthHolder = createAuthenticationHolder(newOAuth2Authentication);    
 
     JWTProfile profile = profileResolver.resolveProfile(client.getScope());
 
@@ -478,7 +476,7 @@ public class IamAuthorizationServerTokenServices implements AuthorizationServerT
       revocationService.revokeRefreshToken(refreshToken);
     }
 
-    token.setAuthenticationHolder(newAuthHolder);
+    token.setAuthenticationHolder(authHolder);
 
 
     JWTClaimsSet atClaims = profile.getAccessTokenBuilder()

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/as/IamAuthorizationServerTokenServices.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/as/IamAuthorizationServerTokenServices.java
@@ -30,7 +30,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -229,7 +228,7 @@ public class IamAuthorizationServerTokenServices implements AuthorizationServerT
     }
 
     OAuth2AccessTokenEntity savedAccessToken = saveAccessToken(accessToken);
-    eventPublisher.publishEvent(new AccessTokenIssuedEvent(this, savedAccessToken));
+    eventPublisher.publishEvent(new AccessTokenIssuedEvent(this, savedAccessToken, authentication.getOAuth2Request().getGrantType()));
     return savedAccessToken;
   }
 
@@ -421,16 +420,9 @@ public class IamAuthorizationServerTokenServices implements AuthorizationServerT
 
     OAuth2Request newOAuth2Request =
         authHolder.getAuthentication().getOAuth2Request().refresh(authRequest);
-
-    Map<String, String> params = new HashMap<>(newOAuth2Request.getRequestParameters());
-    params.put("grant_type", authRequest.getGrantType());
-
-    OAuth2Request updatedOAuth2Request = newOAuth2Request.createOAuth2Request(params);
     
     OAuth2Authentication newOAuth2Authentication =
-        new OAuth2Authentication(updatedOAuth2Request, authHolder.getUserAuth());
-    
-    AuthenticationHolderEntity newAuthHolder = createAuthenticationHolder(newOAuth2Authentication);    
+        new OAuth2Authentication(newOAuth2Request, authHolder.getUserAuth());
 
     JWTProfile profile = profileResolver.resolveProfile(client.getScope());
 
@@ -479,12 +471,12 @@ public class IamAuthorizationServerTokenServices implements AuthorizationServerT
       token.setRefreshToken(refreshToken);
     } else {
       // otherwise, make a new refresh token
-      token.setRefreshToken(createRefreshToken(client, newAuthHolder));
+      token.setRefreshToken(createRefreshToken(client, authHolder));
       // clean up the old refresh token
       revocationService.revokeRefreshToken(refreshToken);
     }
 
-    token.setAuthenticationHolder(newAuthHolder);
+    token.setAuthenticationHolder(authHolder);
 
 
     JWTClaimsSet atClaims = profile.getAccessTokenBuilder()
@@ -508,7 +500,7 @@ public class IamAuthorizationServerTokenServices implements AuthorizationServerT
     }
     token = saveAccessToken(token);
 
-    eventPublisher.publishEvent(new AccessTokenIssuedEvent(this, token));
+    eventPublisher.publishEvent(new AccessTokenIssuedEvent(this, token, authRequest.getGrantType()));
     return token;
   }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/as/IamAuthorizationServerTokenServices.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/as/IamAuthorizationServerTokenServices.java
@@ -228,7 +228,7 @@ public class IamAuthorizationServerTokenServices implements AuthorizationServerT
     }
 
     OAuth2AccessTokenEntity savedAccessToken = saveAccessToken(accessToken);
-    eventPublisher.publishEvent(new AccessTokenIssuedEvent(this, savedAccessToken, authentication.getOAuth2Request().getGrantType()));
+    eventPublisher.publishEvent(new AccessTokenIssuedEvent(this, savedAccessToken, request.getGrantType()));
     return savedAccessToken;
   }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/IamRegistrationTokenService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/IamRegistrationTokenService.java
@@ -87,7 +87,8 @@ public class IamRegistrationTokenService implements RegistrationTokenService {
 
     OAuth2AccessTokenEntity registrationToken = saveRegistrationToken(
         buildRegistrationAccessToken(client, SystemScopeService.REGISTRATION_TOKEN_SCOPE));
-    eventPublisher.publishEvent(new RegistrationTokenIssuedEvent(this, registrationToken));
+    String grantType = registrationToken.getAuthenticationHolder().getAuthentication().getOAuth2Request().getGrantType();
+    eventPublisher.publishEvent(new RegistrationTokenIssuedEvent(this, registrationToken, grantType));
     return registrationToken;
   }
 
@@ -96,7 +97,8 @@ public class IamRegistrationTokenService implements RegistrationTokenService {
 
     OAuth2AccessTokenEntity resourceToken = saveRegistrationToken(
         buildRegistrationAccessToken(client, SystemScopeService.RESOURCE_TOKEN_SCOPE));
-    eventPublisher.publishEvent(new ResourceTokenIssuedEvent(this, resourceToken));
+    String grantType = resourceToken.getAuthenticationHolder().getAuthentication().getOAuth2Request().getGrantType();    
+    eventPublisher.publishEvent(new ResourceTokenIssuedEvent(this, resourceToken, grantType));
     return resourceToken;
   }
 


### PR DESCRIPTION
After the change:

`{"@type":"AccessTokenIssuedEvent","timestamp":1782483755375,"category":"TOKEN","principal":"password-grant","message":"Issue access token","scopes":["storage.read:/","openid","offline_access"],"subject":"test","grantType":"refresh_token","header":{"kid":"rsa1","alg":"RS256"},"payload":{"sub":"80e5fb8d-b7c8-451a-89ba-346ae278a66f","iss":"http://localhost:8080/","iat":1782483738755,"exp":1782487338755,"jti":"d6182dbe-ecb1-4e91-9794-64c5579cc2dd","client_id":"password-grant"},"refreshTokenJti":"de8806ad-8c63-450c-99f2-a110c507e4d6","source":"IamTokenService"}
`