### PR TITLE
Update voperson_id and eduPersonScopedAffiliation to use config value or the issuer

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcClaimValueHelper.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcClaimValueHelper.java
@@ -78,11 +78,23 @@ public class AarcClaimValueHelper extends IamClaimValueHelper {
         encodedGroupName);
   }
 
+  private String resolveScopeDomain() {
+    if (properties.getAarcProfile() != null) {
+      String configuredScopeDomain = properties.getAarcProfile().getAffiliationScope();
+      if (configuredScopeDomain != null && !configuredScopeDomain.isBlank()) {
+        return configuredScopeDomain;
+      }
+    }
+  
+    return properties.getIssuer();
+  }
+
   @Override
   public Object resolveClaim(String claimName, OAuth2Authentication auth,
       Optional<IamAccount> account) {
 
     final String SCOPED_FORMAT = "%s@%s";
+    String scopeDomain = resolveScopeDomain();
 
     Optional<SavedUserAuthentication> userAuth =
         (auth != null && auth.getUserAuthentication() != null)
@@ -107,17 +119,15 @@ public class AarcClaimValueHelper extends IamClaimValueHelper {
         case AarcExtraClaimNames.EDUPERSON_ENTITLEMENT, AarcExtraClaimNames.ENTITLEMENTS:
           return resolveGroups(account.get().getUserInfo());
         case AarcExtraClaimNames.VOPERSON_ID:
-          return format(SCOPED_FORMAT, account.get().getUserInfo().getSub(),
-              properties.getOrganisation().getName());
+          return format(SCOPED_FORMAT, account.get().getUserInfo().getSub(), scopeDomain);
         case AarcExtraClaimNames.EDUPERSON_SCOPED_AFFILIATION:
-          return format(SCOPED_FORMAT, DEFAULT_AFFILIATION_TYPE,
-              properties.getOrganisation().getName());
+          return format(SCOPED_FORMAT, DEFAULT_AFFILIATION_TYPE, scopeDomain);
         case AarcExtraClaimNames.VOPERSON_EXTERNAL_AFFILIATION:
           if (userAuth.isPresent()) {
             Set<String> scopedAffiliations = new HashSet<>();
             if (account.get().getAffiliation() != null) {
               scopedAffiliations.add(format(SCOPED_FORMAT, account.get().getAffiliation(),
-                  properties.getOrganisation().getName()));
+                  scopeDomain));
             }
             String externalScopedAffiliation = firstOf(userAuth.get().getAdditionalInfo(),
                 Set.of("EPSA", "eduPersonScopedAffiliation", "urn:oid:1.3.6.1.4.1.5923.1.1.1.9"));

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/AarcClaimValueHelperTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/AarcClaimValueHelperTests.java
@@ -20,7 +20,6 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -168,8 +167,8 @@ class AarcClaimValueHelperTests {
     String scopedAffiliation = (String) helper.resolveClaim(
         AarcExtraClaimNames.EDUPERSON_SCOPED_AFFILIATION, null, Optional.of(account));
 
-    assertThat(vopersonId, equalTo("test-subject@https://scope.example"));
-    assertThat(scopedAffiliation, equalTo("member@https://scope.example"));
+    assertEquals(vopersonId, "test-subject@https://scope.example");
+    assertEquals(scopedAffiliation, "member@https://scope.example");
   }
 
   @Test
@@ -188,8 +187,8 @@ class AarcClaimValueHelperTests {
     String scopedAffiliation = (String) helper.resolveClaim(
         AarcExtraClaimNames.EDUPERSON_SCOPED_AFFILIATION, null, Optional.of(account));
 
-    assertThat(vopersonId, equalTo("test-subject@https://issuer.example"));
-    assertThat(scopedAffiliation, equalTo("member@https://issuer.example"));
+    assertEquals(vopersonId, "test-subject@https://issuer.example");
+    assertEquals(scopedAffiliation, "member@https://issuer.example");
   }
 
   @Test

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/AarcClaimValueHelperTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/AarcClaimValueHelperTests.java
@@ -167,8 +167,8 @@ class AarcClaimValueHelperTests {
     String scopedAffiliation = (String) helper.resolveClaim(
         AarcExtraClaimNames.EDUPERSON_SCOPED_AFFILIATION, null, Optional.of(account));
 
-    assertEquals(vopersonId, "test-subject@https://scope.example");
-    assertEquals(scopedAffiliation, "member@https://scope.example");
+    assertEquals("test-subject@https://scope.example", vopersonId);
+    assertEquals("member@https://scope.example", scopedAffiliation);
   }
 
   @Test
@@ -187,8 +187,8 @@ class AarcClaimValueHelperTests {
     String scopedAffiliation = (String) helper.resolveClaim(
         AarcExtraClaimNames.EDUPERSON_SCOPED_AFFILIATION, null, Optional.of(account));
 
-    assertEquals(vopersonId, "test-subject@https://issuer.example");
-    assertEquals(scopedAffiliation, "member@https://issuer.example");
+    assertEquals("test-subject@https://issuer.example", vopersonId);
+    assertEquals("member@https://issuer.example", scopedAffiliation);
   }
 
   @Test

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/AarcClaimValueHelperTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/AarcClaimValueHelperTests.java
@@ -20,6 +20,7 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -167,9 +168,8 @@ class AarcClaimValueHelperTests {
     String scopedAffiliation = (String) helper.resolveClaim(
         AarcExtraClaimNames.EDUPERSON_SCOPED_AFFILIATION, null, Optional.of(account));
 
-    assertThat(vopersonId, org.hamcrest.Matchers.equalTo("test-subject@https://scope.example"));
-    assertThat(scopedAffiliation,
-        org.hamcrest.Matchers.equalTo("member@https://scope.example"));
+    assertThat(vopersonId, equalTo("test-subject@https://scope.example"));
+    assertThat(scopedAffiliation, equalTo("member@https://scope.example"));
   }
 
   @Test
@@ -188,9 +188,8 @@ class AarcClaimValueHelperTests {
     String scopedAffiliation = (String) helper.resolveClaim(
         AarcExtraClaimNames.EDUPERSON_SCOPED_AFFILIATION, null, Optional.of(account));
 
-    assertThat(vopersonId, org.hamcrest.Matchers.equalTo("test-subject@https://issuer.example"));
-    assertThat(scopedAffiliation,
-        org.hamcrest.Matchers.equalTo("member@https://issuer.example"));
+    assertThat(vopersonId, equalTo("test-subject@https://issuer.example"));
+    assertThat(scopedAffiliation, equalTo("member@https://issuer.example"));
   }
 
   @Test
@@ -217,7 +216,7 @@ class AarcClaimValueHelperTests {
       .resolveClaim(AarcExtraClaimNames.VOPERSON_EXTERNAL_AFFILIATION, auth, Optional.of(account));
 
     assertThat(result, hasSize(2));
-    assertThat(result, hasItem("member@" + properties.getOrganisation().getName()));
+    assertThat(result, hasItem("member@" + properties.getAarcProfile().getAffiliationScope()));
     assertThat(result, hasItem("external@test.org"));
   }
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/AarcClaimValueHelperTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/AarcClaimValueHelperTests.java
@@ -152,6 +152,48 @@ class AarcClaimValueHelperTests {
   }
 
   @Test
+  void testResolveScopedClaimsUseConfiguredScopeDomainWhenPresent() {
+    properties.setIssuer("https://issuer.example");
+    properties.getAarcProfile().setAffiliationScope("https://scope.example");
+
+    IamAccount account = mock(IamAccount.class);
+    IamUserInfo accountUserInfo = mock(IamUserInfo.class);
+
+    when(account.getUserInfo()).thenReturn(accountUserInfo);
+    when(accountUserInfo.getSub()).thenReturn("test-subject");
+
+    String vopersonId = (String) helper.resolveClaim(AarcExtraClaimNames.VOPERSON_ID, null,
+        Optional.of(account));
+    String scopedAffiliation = (String) helper.resolveClaim(
+        AarcExtraClaimNames.EDUPERSON_SCOPED_AFFILIATION, null, Optional.of(account));
+
+    assertThat(vopersonId, org.hamcrest.Matchers.equalTo("test-subject@https://scope.example"));
+    assertThat(scopedAffiliation,
+        org.hamcrest.Matchers.equalTo("member@https://scope.example"));
+  }
+
+  @Test
+  void testResolveScopedClaimsUseIssuerWhenScopeDomainMissing() {
+    properties.setIssuer("https://issuer.example");
+    properties.getAarcProfile().setAffiliationScope(null);
+
+    IamAccount account = mock(IamAccount.class);
+    IamUserInfo accountUserInfo = mock(IamUserInfo.class);
+
+    when(account.getUserInfo()).thenReturn(accountUserInfo);
+    when(accountUserInfo.getSub()).thenReturn("test-subject");
+
+    String vopersonId = (String) helper.resolveClaim(AarcExtraClaimNames.VOPERSON_ID, null,
+        Optional.of(account));
+    String scopedAffiliation = (String) helper.resolveClaim(
+        AarcExtraClaimNames.EDUPERSON_SCOPED_AFFILIATION, null, Optional.of(account));
+
+    assertThat(vopersonId, org.hamcrest.Matchers.equalTo("test-subject@https://issuer.example"));
+    assertThat(scopedAffiliation,
+        org.hamcrest.Matchers.equalTo("member@https://issuer.example"));
+  }
+
+  @Test
   void testResolveScopedAffiliations() {
     OAuth2Authentication auth = mock(OAuth2Authentication.class);
 

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/AarcProfileIntegrationTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/AarcProfileIntegrationTests.java
@@ -80,7 +80,7 @@ class AarcProfileIntegrationTests extends EndpointsTestUtils {
   private static final String ASSURANCE = "https://refeds.org/assurance";
   private static final String ASSURANCE_VALUE = "https://refeds.org/assurance/IAP/low";
 
-  private static final String EDUPERSON_SCOPED_VALUE = "member@indigo-dc";
+  private static final String EDUPERSON_SCOPED_VALUE = "member@iam.example";
 
   @Autowired
   private MockOAuth2Filter oauth2Filter;
@@ -189,7 +189,7 @@ class AarcProfileIntegrationTests extends EndpointsTestUtils {
 
     assertThat(claims.getClaim("sub"), equalTo(TEST_UUID));
     // required by default
-    assertThat(claims.getClaim("voperson_id"), equalTo(TEST_UUID + "@" + ORGANISATION_NAME));
+    assertThat(claims.getClaim("voperson_id"), equalTo(TEST_UUID + "@" + AFFILIATION_SCOPE));
     assertThat(claims.getClaim("eduperson_assurance"), instanceOf(ArrayList.class));
     assertThat((ArrayList<String>) claims.getClaim("eduperson_assurance"),
         containsInAnyOrder(ASSURANCE, ASSURANCE_VALUE));
@@ -223,7 +223,7 @@ class AarcProfileIntegrationTests extends EndpointsTestUtils {
       .andExpect(jsonPath("$.entitlements", containsInAnyOrder(URN_GROUP_ANALYSIS, URN_GROUP_OPTIONAL, URN_GROUP_PRODUCTION)))
       .andExpect(jsonPath("$.eduperson_assurance", hasSize(equalTo(2))))
       .andExpect(jsonPath("$.eduperson_assurance", containsInAnyOrder(ASSURANCE, ASSURANCE_VALUE)))
-      .andExpect(jsonPath("$.voperson_id", equalTo(TEST_UUID + "@" + ORGANISATION_NAME)));
+      .andExpect(jsonPath("$.voperson_id", equalTo(TEST_UUID + "@" + AFFILIATION_SCOPE)));
     // @formatter:on
 
   }
@@ -310,7 +310,7 @@ class AarcProfileIntegrationTests extends EndpointsTestUtils {
       .andExpect(jsonPath("$.entitlements", containsInAnyOrder(URN_GROUP_ANALYSIS, URN_GROUP_OPTIONAL, URN_GROUP_PRODUCTION)))
       .andExpect(jsonPath("$.eduperson_assurance", hasSize(equalTo(2))))
       .andExpect(jsonPath("$.eduperson_assurance", containsInAnyOrder(ASSURANCE, ASSURANCE_VALUE)))
-      .andExpect(jsonPath("$.voperson_id", equalTo(TEST_UUID + "@" + ORGANISATION_NAME)));
+      .andExpect(jsonPath("$.voperson_id", equalTo(TEST_UUID + "@" + AFFILIATION_SCOPE)));
     // @formatter:on
   }
 
@@ -352,7 +352,7 @@ class AarcProfileIntegrationTests extends EndpointsTestUtils {
       .andExpect(jsonPath("$.organisation_name").doesNotExist())
       .andExpect(jsonPath("$.groups").doesNotExist())
       .andExpect(jsonPath("$.voperson_id").isNotEmpty())
-      .andExpect(jsonPath("$.voperson_id", equalTo(TEST_UUID + "@" + ORGANISATION_NAME)))
+      .andExpect(jsonPath("$.voperson_id", equalTo(TEST_UUID + "@" + AFFILIATION_SCOPE)))
       .andExpect(jsonPath("$.eduperson_scoped_affiliation", equalTo(EDUPERSON_SCOPED_VALUE)))
       .andExpect(jsonPath("$.entitlements", hasSize(equalTo(3))))
       .andExpect(jsonPath("$.entitlements", containsInAnyOrder(URN_GROUP_ANALYSIS, URN_GROUP_OPTIONAL, URN_GROUP_PRODUCTION)))
@@ -402,7 +402,7 @@ class AarcProfileIntegrationTests extends EndpointsTestUtils {
     assertNotNull(claims.getClaim("aud"));
     assertThat(claims.getClaim("aud"), is(List.of(PASSWORD_CLIENT_ID)));
     assertNotNull(claims.getClaim("voperson_id"));
-    assertThat(claims.getClaim("voperson_id"), is(TEST_UUID + "@" + ORGANISATION_NAME));
+    assertThat(claims.getClaim("voperson_id"), is(TEST_UUID + "@" + AFFILIATION_SCOPE));
     assertNotNull(claims.getClaim("entitlements"));
     assertThat(claims.getClaim("entitlements"), instanceOf(ArrayList.class));
     assertThat((ArrayList<String>) claims.getClaim("entitlements"),

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/scope/StructuredScopeTestSupportConstants.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/scope/StructuredScopeTestSupportConstants.java
@@ -109,6 +109,8 @@ public interface StructuredScopeTestSupportConstants {
 
   static final String EMPTY_SCOPES = "";
 
+  static final String AFFILIATION_SCOPE = "iam.example";    
+
   static final String ORGANISATION_NAME = "indigo-dc";
 
   static final String TOKEN_EXCHANGE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange";


### PR DESCRIPTION
 Currently indigio iam is using the `iam_organisation_name` as the affiliation scope for voperson_id and eduPersonScopedAffiliation. This pull request introduces a new feature to set:
  ```json
aarc-profile:
    affiliation-scope: ${IAM_AARC_PROFILE_AFFILIATION_SCOPE:iam_example}
```
Which will change the behavior of  `voperson_id` to be `sub@affiliation_scope` and `eduPersonScopedAffiliation`  to be `affiliation@affiliation_scope`

If `affiliation_scope` is not set and empty, the issuer will instead be used on the right side of the "@", such as sub@issuer and affiliation@issuer to make sure these values are globally unique
