### PR TITLE
Add iam-voms-aa RPM (and refactor RPM build)

### DIFF
--- a/.github/workflows/build-rpm.yaml
+++ b/.github/workflows/build-rpm.yaml
@@ -108,4 +108,9 @@ jobs:
       - name: Upload release to repo
         if: env.REPO != ''
         run: |
-          curl --fail --user "${{ vars.NEXUS_USERNAME }}:${{ secrets.NEXUS_PASSWORD }}" --upload-file rpmbuild/RPMS/noarch/*.rpm https://repo.cloud.cnaf.infn.it/repository/indigo-iam-rpm-${{ env.REPO }}/almalinux${{ matrix.version }}/
+          for f in rpmbuild/RPMS/noarch/*.rpm; do
+            curl --fail \
+              --user "${{ vars.NEXUS_USERNAME }}:${{ secrets.NEXUS_PASSWORD }}" \
+              --upload-file "$f" \
+              "https://repo.cloud.cnaf.infn.it/repository/indigo-iam-rpm-${{ env.REPO }}/almalinux${{ matrix.version }}/"
+          done

--- a/rpm/SOURCES/iam-login-service@.service
+++ b/rpm/SOURCES/iam-login-service@.service
@@ -1,14 +1,14 @@
 [Unit]
-Description=INDIGO IAM Service
+Description=INDIGO IAM Service for %I
 After=syslog.target network.target
 
 [Service]
-EnvironmentFile=/etc/sysconfig/iam-login-service
+EnvironmentFile=/etc/sysconfig/iam-login-service.%i
 WorkingDirectory=/etc/iam-login-service
 ExecStart=/usr/bin/java $IAM_JAVA_OPTS -jar /usr/share/indigo-iam/iam-login-service.war
 KillMode=process
 User=iam
-SyslogIdentifier=iam-login-service
+SyslogIdentifier=iam-login-service.%i
 
 [Install]
 WantedBy=multi-user.target

--- a/rpm/SOURCES/iam-voms-aa
+++ b/rpm/SOURCES/iam-voms-aa
@@ -1,0 +1,26 @@
+# Java VM arguments
+IAM_JAVA_OPTS=-Dspring.profiles.active=mysql,voms
+
+# Generic options
+#VOMS_AA_BINDING_ADDRESS=0.0.0.0
+#VOMS_AA_PORT=8080
+#VOMS_AA_FORWARD_HEADERS_STRATEGY=none
+VOMS_AA_TLS_CERTIFICATE_PATH=/etc/grid-security/hostcert.pem
+VOMS_AA_TLS_PRIVATE_KEY_PATH=/etc/grid-security/hostkey.pem
+VOMS_AA_TLS_TRUST_ANCHORS_DIR=/etc/grid-security/certificates
+#VOMS_AA_TLS_TRUST_ANCHORS_REFRESH_INTERVAL_SECS=14400
+#VOMS_AA_VONAME=test
+#VOMS_AA_OPTIONAL_GROUP_LABEL=wlcg.optional-group
+#VOMS_AA_VOMS_ROLE_LABEL=voms.role
+#VOMS_AA_USE_LEGACY_FQAN_ENCODING=false
+
+# Database connection settings
+#IAM_DB_HOST=localhost
+#IAM_DB_PORT=3306
+#IAM_DB_NAME=iam
+#IAM_DB_URL_PARAMS=?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
+#IAM_DB_USERNAME=iam
+#IAM_DB_PASSWORD=pwd
+#IAM_DB_MAX_ACTIVE=50
+#IAM_DB_MIN_IDLE=8
+#IAM_DB_VALIDATION_QUERY=SELECT 1

--- a/rpm/SOURCES/iam-voms-aa.service
+++ b/rpm/SOURCES/iam-voms-aa.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=INDIGO IAM VOMS AA Service
+After=syslog.target network.target
+
+[Service]
+EnvironmentFile=/etc/sysconfig/iam-voms-aa
+WorkingDirectory=/etc/iam-voms-aa
+ExecStart=/usr/bin/java $IAM_JAVA_OPTS -jar /usr/share/indigo-iam/iam-voms-aa.jar
+KillMode=process
+User=iam
+SyslogIdentifier=iam-voms-aa
+
+[Install]
+WantedBy=multi-user.target

--- a/rpm/SOURCES/iam-voms-aa@.service
+++ b/rpm/SOURCES/iam-voms-aa@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=INDIGO IAM VOMS AA Service for %I
+After=syslog.target network.target
+
+[Service]
+EnvironmentFile=/etc/sysconfig/iam-voms-aa.%i
+WorkingDirectory=/etc/iam-voms-aa
+ExecStart=/usr/bin/java $IAM_JAVA_OPTS -jar /usr/share/indigo-iam/iam-voms-aa.jar
+KillMode=process
+User=iam
+SyslogIdentifier=iam-voms-aa.%i
+
+[Install]
+WantedBy=multi-user.target

--- a/rpm/indigo-iam.spec
+++ b/rpm/indigo-iam.spec
@@ -1,11 +1,13 @@
 %define user  iam
 %define jdk_version  17
 %define mvn_version  3.8.0
+%define login_svc iam-login-service
+%define voms_svc  iam-voms-aa
 
 %{!?_unitdir: %global _unitdir %{_prefix}/lib/systemd/system}
 %{!?base_version: %global base_version 0.0.0}
 
-Name:      iam-login-service
+Name:      indigo-iam
 Version:   %{base_version}
 Release:   1%{?dist}
 BuildRoot: %{_tmppath}/%{name}-%{version}-build
@@ -21,51 +23,118 @@ BuildRequires: maven >= %{mvn_version}
 
 Requires:      java-%{jdk_version}-openjdk
 
+%{?systemd_requires}
+Requires(pre):     /usr/sbin/useradd
+
+
 %description
 The INDIGO IAM (Identity and Access Management service) provides 
 user identity and policy information to services so that consistent 
 authorization decisions can be enforced across distributed services.
+
+%package login-service
+Summary:   INDIGO Identity and Access Management Login Service
+Requires: %{name} = %{version}
+Obsoletes: iam-login-service <= 1.14.1
+
+%description login-service
+This package provides the main Indigo IAM login service.
+
+%package voms-aa
+Summary:   INDIGO Identity and Access Management VOMS-AA Service
+Requires: %{name} = %{version}
+
+%description voms-aa
+This package provides the optional VOMS Attribute Authority service.
 
 %prep
 
 %build
 mvn -U -B -DskipTests clean package
 
+%check
+#mvn -B test
+
 %install
-install -d %{buildroot}/var/lib/indigo/%{name}
-install -d %{buildroot}%{_sysconfdir}/%{name}/config
 install -d %{buildroot}%{_sysconfdir}/sysconfig
-install -d %{buildroot}/%{_unitdir}
+install -d %{buildroot}%{_unitdir}
+install -d %{buildroot}%{_datadir}/%{name}
 
-install -m 644 "%{name}/target/%{name}.war" %{buildroot}/var/lib/indigo/%{name}/
-install -m 644 "rpm/SOURCES/%{name}.service" %{buildroot}%{_unitdir}/
-install -m 644 "rpm/SOURCES/%{name}" %{buildroot}%{_sysconfdir}/sysconfig/%{name}
+# iam-login-service
+install -d %{buildroot}%{_sysconfdir}/%{login_svc}/config
+install -m 644 "%{login_svc}/target/%{login_svc}.war" %{buildroot}%{_datadir}/%{name}/%{login_svc}.war
+install -m 644 "rpm/SOURCES/%{login_svc}.service" %{buildroot}%{_unitdir}/%{login_svc}.service
+install -m 644 "rpm/SOURCES/%{login_svc}@.service" %{buildroot}%{_unitdir}/%{login_svc}@.service
+install -m 644 "rpm/SOURCES/%{login_svc}" %{buildroot}%{_sysconfdir}/sysconfig/%{login_svc}
+# iam-voms-aa
+install -d %{buildroot}%{_sysconfdir}/%{voms_svc}/config
+install -m 644 "%{voms_svc}/target/%{voms_svc}.jar" %{buildroot}%{_datadir}/%{name}/%{voms_svc}.jar
+install -m 644 "rpm/SOURCES/%{voms_svc}.service" %{buildroot}%{_unitdir}/%{voms_svc}.service
+install -m 644 "rpm/SOURCES/%{voms_svc}@.service" %{buildroot}%{_unitdir}/%{voms_svc}@.service
+install -m 644 "rpm/SOURCES/%{voms_svc}" %{buildroot}%{_sysconfdir}/sysconfig/%{voms_svc}
 
-%post
-# Create service user if not exists
-if ! getent passwd %{user} > /dev/null; then
-    useradd --comment "INDIGO IAM" --system --user-group --home-dir /var/lib/indigo/%{name} --no-create-home --shell /sbin/nologin %{user}
-fi
+%pre
+getent group %{user} &>/dev/null || groupadd -r %{user}
+getent passwd %{user} &>/dev/null || \
+    /usr/sbin/useradd -r -g %{user} -s /sbin/nologin -c "INDIGO IAM" \
+        -m -d /var/lib/indigo/%{name} %{user}
+exit 0
 
-chown -R %{user}:%{user} /var/lib/indigo/%{name}
-%systemd_post %{name}.service
+%post login-service
+for srv in %{login_svc}.service `systemctl | awk '/%{login_svc}@.*\.service/{print $1}'`;
+do
+  %systemd_post $srv
+done
 
-%preun
-%systemd_preun %{name}.service
+%preun login-service
+for srv in %{login_svc}.service `systemctl | awk '/%{login_svc}@.*\.service/{print $1}'`;
+do
+  %systemd_preun $srv
+done
 
-%postun
-%systemd_postun_with_restart %{name}.service
+%postun login-service
+for srv in %{login_svc}.service `systemctl | awk '/%{login_svc}@.*\.service/{print $1}'`;
+do
+  %systemd_postun_with_restart $srv
+done
+
+%post voms-aa
+for srv in %{voms_svc}.service `systemctl | awk '/%{voms_svc}@.*\.service/{print $1}'`;
+do
+  %systemd_post $srv
+done
+
+%preun voms-aa
+for srv in %{voms_svc}.service `systemctl | awk '/%{voms_svc}@.*\.service/{print $1}'`;
+do
+  %systemd_preun $srv
+done
+
+%postun voms-aa
+for srv in %{voms_svc}.service `systemctl | awk '/%{voms_svc}@.*\.service/{print $1}'`;
+do
+  %systemd_postun_with_restart $srv
+done
 
 
 %files
-%config(noreplace) %{_sysconfdir}/sysconfig/%{name}
-%dir %{_sysconfdir}/sysconfig
-%dir %{_sysconfdir}/%{name}
-%dir %{_sysconfdir}/%{name}/config
-%dir /var/lib/indigo
-%dir /var/lib/indigo/%{name}
-/var/lib/indigo/%{name}/%{name}.war
-%{_unitdir}/%{name}.service
+%dir %{_datadir}/%{name}
+
+%files login-service
+%config(noreplace) %attr(0600,iam,iam) %{_sysconfdir}/sysconfig/%{login_svc}
+%dir %{_sysconfdir}/%{login_svc}/config
+%{_datadir}/%{name}/%{login_svc}.war
+%{_unitdir}/%{login_svc}.service
+%{_unitdir}/%{login_svc}@.service
+
+%files voms-aa
+%config(noreplace) %attr(0600,iam,iam) %{_sysconfdir}/sysconfig/%{voms_svc}
+%dir %{_sysconfdir}/%{voms_svc}
+%dir %{_sysconfdir}/%{voms_svc}/config
+%{_datadir}/%{name}/%{voms_svc}.jar
+%{_unitdir}/%{voms_svc}.service
+%{_unitdir}/%{voms_svc}@.service
+
 
 %changelog
 * Mon Jan 26 2026 Enrico Vianello <enrico.vianello@cnaf.infn.it> 1.13.4


### PR DESCRIPTION
Hi,

Here is our proposal for adding the iam-voms-aa RPM: I've done quite a large amount of refactoring of the other RPM packages so that a single spec file now builds an indigo-iam-login-service, indigo-iam-voms-aa and a top level package that owns the container directory and "iam" user (indigo-iam). I've also moved some of the files around and changed the permissions to match up with the standard Redhat packaging guidelines. For the unit files, I've added some "generic" ones that can take a paramter: this allows multiple instances of these services to be run on a single host (`systemctl start iam-voms-aa@myvo.service`) just like the VOMS packages used to do.

Finally, I've updated the workflow script so that it uploads the full set of RPMs rather than just the one: I hope that's OK, I can't test that bit: I can remove it again if needed.

Please let me and @marianne013 know what you think!

Closes #1291.

Regards,
Simon
