### PR TITLE
URL-encode/decode client credentials in Authorization header

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/oidc/DefaultOidcTokenRequestor.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/oidc/DefaultOidcTokenRequestor.java
@@ -17,9 +17,11 @@ package it.infn.mw.iam.authn.oidc;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
+import org.apache.commons.codec.binary.Base64;
 import org.mitre.oauth2.model.ClientDetailsEntity.AuthMethod;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,12 +54,15 @@ public class DefaultOidcTokenRequestor implements OidcTokenRequestor {
 
   private void basicAuthRequest(OidcClient oidcClientConfig, HttpHeaders headers) {
 
-    String auth = oidcClientConfig.clientId() + ":" + oidcClientConfig.clientSecret();
-    byte[] encodedAuth = org.apache.commons.codec.binary.Base64
-      .encodeBase64(auth.getBytes(StandardCharsets.US_ASCII));
-    String authHeader = "Basic " + new String(encodedAuth);
+    String encodedClientId = URLEncoder.encode(oidcClientConfig.clientId(), StandardCharsets.UTF_8);
 
-    headers.set("Authorization", authHeader);
+    String encodedClientSecret =
+        URLEncoder.encode(oidcClientConfig.clientSecret(), StandardCharsets.UTF_8);
+
+    String auth = encodedClientId + ":" + encodedClientSecret;
+    String authHeader = "Basic " + Base64.encodeBase64String(auth.getBytes(StandardCharsets.UTF_8));
+
+    headers.set(HttpHeaders.AUTHORIZATION, authHeader);
   }
 
   protected void formAuthRequest(OidcClient oidcClientConfig,
@@ -65,7 +70,6 @@ public class DefaultOidcTokenRequestor implements OidcTokenRequestor {
 
     requestParams.add("client_id", oidcClientConfig.clientId());
     requestParams.add("client_secret", oidcClientConfig.clientSecret());
-
   }
 
   protected HttpEntity<MultiValueMap<String, String>> prepareTokenRequest(

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/authn/TokenEndpointBasicAuthenticationProvider.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/authn/TokenEndpointBasicAuthenticationProvider.java
@@ -15,11 +15,15 @@
  */
 package it.infn.mw.iam.core.authn;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
 import org.mitre.oauth2.model.ClientDetailsEntity;
 import org.mitre.oauth2.model.ClientDetailsEntity.AuthMethod;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -46,7 +50,8 @@ public class TokenEndpointBasicAuthenticationProvider extends DaoAuthenticationP
   @Override
   public Authentication authenticate(Authentication authentication) throws AuthenticationException {
 
-    String clientId = authentication.getName();
+    String clientId = URLDecoder.decode(authentication.getName(), StandardCharsets.UTF_8);
+
     ClientDetailsEntity client = clientService.findClientByClientId(clientId)
       .orElseThrow(
           () -> new BadCredentialsException("Client with id " + clientId + " was not found"));
@@ -57,6 +62,13 @@ public class TokenEndpointBasicAuthenticationProvider extends DaoAuthenticationP
     }
     if (!supportsBasic(client)) {
       throw new BadCredentialsException("Client does not support basic authentication");
+    }
+
+    if (AuthMethod.SECRET_BASIC.equals(client.getTokenEndpointAuthMethod())) {
+      String clientSecret =
+          URLDecoder.decode(authentication.getCredentials().toString(), StandardCharsets.UTF_8);
+
+      return super.authenticate(new UsernamePasswordAuthenticationToken(clientId, clientSecret));
     }
 
     return super.authenticate(authentication);

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/ClientCredentialsDecodingTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/ClientCredentialsDecodingTests.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.oauth;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jwt.SignedJWT;
+
+import it.infn.mw.iam.IamLoginService;
+import it.infn.mw.iam.test.config.ClockConfig;
+import it.infn.mw.iam.test.core.CoreControllerTestSupport;
+
+@SpringBootTest(
+    classes = {IamLoginService.class, CoreControllerTestSupport.class, ClockConfig.class},
+    webEnvironment = WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@Transactional
+public class ClientCredentialsDecodingTests {
+
+  @Autowired
+  private MockMvc mvc;
+
+  @Test
+  void decodeURLEncodedClientCredentialsAtTokenEndpoint() throws Exception {
+
+    String clientId = "https://federated-client.com";
+    String clientSecret = "secret";
+
+    // URL encode client_id and client_secret
+    String encodedClientId = URLEncoder.encode(clientId, StandardCharsets.UTF_8);
+    String encodedClientSecret = URLEncoder.encode(clientSecret, StandardCharsets.UTF_8);
+
+    String credentials = Base64.getEncoder()
+      .encodeToString(
+          (encodedClientId + ":" + encodedClientSecret).getBytes(StandardCharsets.UTF_8));
+
+    String tokenResponse = mvc
+      .perform(post("/token").param("grant_type", "client_credentials")
+        .header("Authorization", "Basic " + credentials))
+      .andExpect(status().isOk())
+      .andReturn()
+      .getResponse()
+      .getContentAsString();
+
+    JsonNode json = new ObjectMapper().readTree(tokenResponse);
+    String accessToken = json.get("access_token").asText();
+    SignedJWT jwt = SignedJWT.parse(accessToken);
+    assertEquals(clientId, jwt.getJWTClaimsSet().getStringClaim("client_id"));
+  }
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/ClientCredentialsDecodingTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/ClientCredentialsDecodingTests.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,13 +34,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jwt.SignedJWT;
 
-import it.infn.mw.iam.IamLoginService;
-import it.infn.mw.iam.test.config.ClockConfig;
-import it.infn.mw.iam.test.core.CoreControllerTestSupport;
-
-@SpringBootTest(
-    classes = {IamLoginService.class, CoreControllerTestSupport.class, ClockConfig.class},
-    webEnvironment = WebEnvironment.MOCK)
+@SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
 class ClientCredentialsDecodingTests {

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/ClientCredentialsDecodingTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/ClientCredentialsDecodingTests.java
@@ -44,7 +44,7 @@ import it.infn.mw.iam.test.core.CoreControllerTestSupport;
     webEnvironment = WebEnvironment.MOCK)
 @AutoConfigureMockMvc
 @Transactional
-public class ClientCredentialsDecodingTests {
+class ClientCredentialsDecodingTests {
 
   @Autowired
   private MockMvc mvc;

--- a/iam-persistence/src/main/resources/db/migration/test/V100000___test_data.sql
+++ b/iam-persistence/src/main/resources/db/migration/test/V100000___test_data.sql
@@ -33,7 +33,8 @@ INSERT INTO client_details (id, client_id, client_secret, client_name, dynamical
   (23, 'public-client-with-secret', 'secret', 'Public client with secret', false, 3600, 3600, 600, false, 'NONE', false, 600, CURRENT_TIMESTAMP(), 'optional', true),
   (24, 'pkce-s256-client', 'secret', 'Client with PKCE S256', false, 3600, 3600, 600, false, 'SECRET_BASIC', false, 600, CURRENT_TIMESTAMP(), 'S256', true),
   (25, 'pkce-plain-client', 'secret', 'Client with PKCE plain', false, 3600, 3600, 600, false, 'SECRET_BASIC', false, 600, CURRENT_TIMESTAMP(), 'plain', true),
-  (26, 'pkce-none-client', 'secret', 'Client with PKCE none', false, 3600, 3600, 600, false, 'SECRET_BASIC', false, 600, CURRENT_TIMESTAMP(), 'none', true);
+  (26, 'pkce-none-client', 'secret', 'Client with PKCE none', false, 3600, 3600, 600, false, 'SECRET_BASIC', false, 600, CURRENT_TIMESTAMP(), 'none', true),
+  (27, 'https://federated-client.com', 'secret', 'Federated client', false, 86400, 3600, 600, true, 'SECRET_BASIC',false, null, CURRENT_TIMESTAMP(), 'optional', true);
 
 UPDATE client_details SET client_description = 'implicit-flow-client description'
 WHERE id = 13 AND client_id = 'implicit-flow-client';
@@ -193,7 +194,8 @@ INSERT INTO client_scope (owner_id, scope) VALUES
   (25, 'openid'),
   (25, 'profile'),
   (26, 'openid'),
-  (26, 'profile');
+  (26, 'profile'),
+  (27, 'openid');
 
 INSERT INTO client_redirect_uri (owner_id, redirect_uri) VALUES
   (1, 'http://localhost:9090/iam-test-client/openid_connect_login'),
@@ -268,7 +270,8 @@ INSERT INTO client_grant_type (owner_id, grant_type) VALUES
   (23, 'client_credentials'),
   (24, 'authorization_code'),
   (25, 'authorization_code'),
-  (26, 'authorization_code');
+  (26, 'authorization_code'),
+  (27, 'client_credentials');
 
 INSERT INTO client_contact (owner_id, contact) VALUES
   (1, 'admin@example.com'),

--- a/iam-persistence/src/main/resources/db/migration/test/V100000___test_data.sql
+++ b/iam-persistence/src/main/resources/db/migration/test/V100000___test_data.sql
@@ -34,7 +34,7 @@ INSERT INTO client_details (id, client_id, client_secret, client_name, dynamical
   (24, 'pkce-s256-client', 'secret', 'Client with PKCE S256', false, 3600, 3600, 600, false, 'SECRET_BASIC', false, 600, CURRENT_TIMESTAMP(), 'S256', true),
   (25, 'pkce-plain-client', 'secret', 'Client with PKCE plain', false, 3600, 3600, 600, false, 'SECRET_BASIC', false, 600, CURRENT_TIMESTAMP(), 'plain', true),
   (26, 'pkce-none-client', 'secret', 'Client with PKCE none', false, 3600, 3600, 600, false, 'SECRET_BASIC', false, 600, CURRENT_TIMESTAMP(), 'none', true),
-  (27, 'https://federated-client.com', 'secret', 'Federated client', false, 86400, 3600, 600, true, 'SECRET_BASIC',false, null, CURRENT_TIMESTAMP(), 'optional', true);
+  (27, 'https://federated-client.com', 'secret', 'Federated client', false, 86400, 3600, 600, true, 'SECRET_BASIC', false, null, CURRENT_TIMESTAMP(), 'optional', true);
 
 UPDATE client_details SET client_description = 'implicit-flow-client description'
 WHERE id = 13 AND client_id = 'implicit-flow-client';


### PR DESCRIPTION
Following [OAuth2.1](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1#section-2.4.1)