### PR TITLE
Document direct SAML login shortcuts

### DIFF
--- a/iam-login-service/src/main/resources/application-saml.yml
+++ b/iam-login-service/src/main/resources/application-saml.yml
@@ -30,6 +30,18 @@ saml:
   
   wayf-login-button:
     text: ${IAM_SAML_LOGIN_BUTTON_TEXT:Your institutional account}
+    # Hide the WAYF button when direct login shortcuts replace IdP discovery.
+    visible: ${IAM_SAML_WAYF_LOGIN_BUTTON_VISIBLE:true}
+
+  # Add direct login buttons for frequently used IdPs. Each shortcut bypasses
+  # the WAYF discovery page and redirects directly to the configured entity ID.
+  # The entity ID must match an IdP in the configured metadata.
+  # login-shortcuts:
+  #   - name: example-idp
+  #     entity-id: https://idp.example.org/idp/shibboleth
+  #     enabled: true
+  #     login-button:
+  #       text: Sign in with Example IdP
     
   idp-entity-id-whilelist: ${IAM_SAML_IDP_ENTITY_ID_WHITELIST}
   

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/WayfLoginButtonTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/WayfLoginButtonTests.java
@@ -33,7 +33,8 @@ import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
 @ExtendWith(SpringExtension.class)
 @IamMockMvcIntegrationTest
 @TestPropertySource(properties = {"saml.wayf-login-button.text=Sign in with EduGAIN",
-  "saml.wayf-login-button.image.url=https://example.org/test.png"})
+  "saml.wayf-login-button.image.url=https://example.org/test.png",
+  "IAM_SAML_WAYF_LOGIN_BUTTON_VISIBLE=false"})
 @WithAnonymousUser
 class WayfLoginButtonTests {
 
@@ -48,7 +49,7 @@ class WayfLoginButtonTests {
       .andExpect(jsonPath("$.text", is("Sign in with EduGAIN")))
       .andExpect(jsonPath("$.image.url", is("https://example.org/test.png")))
       .andExpect(jsonPath("$.image.size", is("SMALL")))
-      .andExpect(jsonPath("$.visible", is(true)));
+      .andExpect(jsonPath("$.visible", is(false)));
   }
 
 }


### PR DESCRIPTION
## Summary

- expose IAM_SAML_WAYF_LOGIN_BUTTON_VISIBLE with the current visible-by-default behavior
- add a commented login-shortcuts example to the bundled SAML configuration
- verify that the environment override hides the WAYF button

This makes the existing direct-IdP login flow discoverable and lets operators retain a login button while bypassing the IdP discovery confirmation page.

Documentation: indigo-iam/iam-website#231

## Validation

- application-saml.yml parsed successfully
- git diff --check passed
- Maven tests were not run because Maven is unavailable in the local environment