### PR TITLE
Enhance UX for new client/secret

### DIFF
--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/client.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/client.component.js
@@ -24,11 +24,9 @@
         $ctrl.newClient = data.client;
         $ctrl.secret = $ctrl.newClient.client_secret;
         $ctrl.clientId = $ctrl.newClient.client_id;
-        $ctrl.showSecret = false;
         $ctrl.confirmation = true;
-
-        self.clipboardSuccess = clipboardSuccess;
-        self.clipboardError = clipboardError;
+        $ctrl.clientIdCopied = false;
+        $ctrl.clientSecretCopied = false;
 
         $ctrl.ok = function () {
             $uibModalInstance.close($ctrl.selected);
@@ -38,26 +36,32 @@
             $uibModalInstance.dismiss('cancel');
         };
 
-        $ctrl.toggleSecretVisibility = function () {
-            $ctrl.showSecret = !$ctrl.showSecret;
-        };
-
-        function clipboardError(event) {
+        $ctrl.clipboardError = function (event) {
             toaster.pop({
                 type: 'error',
                 body: 'Could not copy secret to clipboard!'
             });
         }
 
-        function clipboardSuccess(event, source) {
+        $ctrl.clipboardSuccess = function (event, source) {
+            var message = "Copied to clipboard.";
+
+            if (source === "clientid") {
+                $ctrl.clientIdCopied = true;
+                message = "Client ID copied to clipboard.";
+            }
+
+            if (source === "secret") {
+                $ctrl.clientSecretCopied = true;
+                message = "Client Secret copied to clipboard.";
+            }
+
             toaster.pop({
                 type: 'success',
-                body: 'Secret copied to clipboard!'
+                body: message
             });
+
             event.clearSelection();
-            if (source === 'secret') {
-                $ctrl.toggleSecretVisibility();
-            }
         }
     };
 
@@ -152,8 +156,8 @@
                         resolve: {
                             data: {
                                 client: res,
-                                title: "New client credential details",
-                                message: "Save this client credential on safe before press Confirm button",
+                                title: "Client details",
+                                message: "Your Client Secret will be no longer shown.",
                                 isNewClient: true,
                             }
                         }

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/client.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/client.component.js
@@ -24,7 +24,6 @@
         $ctrl.newClient = data.client;
         $ctrl.secret = $ctrl.newClient.client_secret;
         $ctrl.clientId = $ctrl.newClient.client_id;
-        $ctrl.confirmation = true;
         $ctrl.clientIdCopied = false;
         $ctrl.clientSecretCopied = false;
 

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/clientsecret/clientsecret.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/clientsecret/clientsecret.component.js
@@ -18,16 +18,13 @@
 
     function ModalClientSecretController($rootScope, $scope, $uibModal, $uibModalInstance, ClientsService, toaster, client) {
         var self = this;
-        self.showSecret = false;
 
-        self.clipboardSuccess = clipboardSuccess;
-        self.clipboardError = clipboardError;
-        self.confirmation = true;
+        self.confirmed = false;
         self.clientId = client.client_id;
         self.clientName = client.client_name;
         self.isNewClient = !!self.clientId;
         self.parent = parent;
-        self.showSecret = false;
+        self.clientSecretCopied = false;
 
         self.closeModal = function() {
             self.isModalOpen = false;
@@ -39,43 +36,38 @@
             $uibModalInstance.close();
         };
 
-        self.toggleSecretVisibility = function() {
-            self.showSecret = !self.showSecret;
-        };
-
         self.confirmRequestNewSecret = function() {
-            self.confirmation = true;
+            self.confirmed = true;
             ClientsService.rotateClientSecret(client.client_id).then(res => {
                 self.newSecret = res.client_secret;
                 toaster.pop({
                     type: 'success',
-                    body: 'Registration access token rotated for client ' + self.clientName
+                    body: 'New secret generated for Client ' + self.clientName
                 });
             }).catch(error => {
                 console.error(error);
                 toaster.pop({
                     type: 'error',
-                    body: 'Could not rotate secret for client ' + self.clientName
+                    body: 'Could not generate new secret for Client ' + self.clientName
                 });
             });
         }
 
-        function clipboardError(event) {
+        self.clipboardError = function (event) {
             toaster.pop({
                 type: 'error',
-                body: 'Could not copy secret to clipboard!'
+                body: 'Could not copy Client Secret to clipboard!'
             });
         }
 
-        function clipboardSuccess(event, source) {
+        self.clipboardSuccess = function (event, source) {
+            self.clientSecretCopied = true;
+
             toaster.pop({
                 type: 'success',
-                body: 'Secret copied to clipboard!'
+                body: 'Client Secret copied to clipboard.'
             });
             event.clearSelection();
-            if (source === 'secret') {
-                self.toggleSecretVisibility();
-            }
         }
         self.confirmRequestNewSecret();
     }

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/clientsecret/clientsecret.dialog.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/clientsecret/clientsecret.dialog.html
@@ -16,34 +16,40 @@
 
 -->
 <div class="modal-header">
-    <h3 class="modal-title">Regenerate Client Secret</h3>
+    <h3 class="modal-title">New Client Secret</h3>
 </div>
 <div class="modal-body">
+
+    <div class="alert alert-danger" role="alert">
+        <strong><i class="fa fa-exclamation-triangle"></i> Important</strong><br/>
+            This is the only time the Client Secret will be displayed.
+            Please <strong>copy and store</strong> it in a secure location before closing this window.
+            Once closed, the secret cannot be retrieved again.
+    </div>
+
     <div class="form-group">
-        <div ng-if="!$ctrl.confirmation">
-            <p>Are you sure you want to change the secret of this client: {{$ctrl.clientName}} ?</p>
+
+        <div ng-if="!$ctrl.confirmed">
+            <p>Are you sure you want to change the secret of Client {{$ctrl.clientName}} ?</p>
         </div>
-        <div class="input-group" ng-if="$ctrl.confirmation">
-            <span class="input-group-btn" ng-if="!$ctrl.showSecret">
-                <button class="btn btn-default" type="button" ng-click="$ctrl.toggleSecretVisibility()">
-                    <i class="fa fa-eye"></i>
-                </button>
-            </span>
-            <span class="input-group-btn" ng-if="$ctrl.showSecret">
+        
+        <div class="input-group" ng-if="$ctrl.confirmed">
+            <input type="text" id="client_secret" ng-model="$ctrl.newSecret" class="form-control" readonly>
+            <span class="input-group-btn">
                 <button class="btn btn-default" type="button" ngclipboard data-clipboard-target="#client_secret"
                     ngclipboard-success="$ctrl.clipboardSuccess(e, 'secret');"
                     ngclipboard-error="$ctrl.clipboardError(e);" alt="Copy secret to clipboard">
-                    <i class="fa fa-clipboard"></i>
+                    <i class="fa" ng-class="{'fa-clipboard': !$ctrl.clientSecretCopied,
+                        'fa-check text-success': $ctrl.clientSecretCopied}">
+                    </i>
                 </button>
             </span>
-            <input type="password" value="******" ng-if="!$ctrl.showSecret" class="form-control" readonly>
-            <input type="text" id="client_secret" ng-model="$ctrl.newSecret" ng-if="$ctrl.showSecret"
-                class="form-control" readonly>
         </div>
+
     </div>
 </div>
 <div class="modal-footer">
-    <button class="btn btn-success" type="button" ng-if="!$ctrl.confirmation"
+    <button class="btn btn-success" type="button" ng-if="!$ctrl.confirmed"
         ng-click="$ctrl.confirmRequestNewSecret()">Confirm</button>
     <button class="btn btn-danger" type="button" id="modal-btn-cancel" ng-click="$ctrl.closeModal()">Close</button>
 </div>

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/newclientsecretshow/clientsecretview.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/newclientsecretshow/clientsecretview.component.js
@@ -23,9 +23,8 @@
         $ctrl.data = data;
         $ctrl.newClient = !!data.client.clientSecret;
         $ctrl.client = data.client
-
-        self.clipboardSuccess = clipboardSuccess;
-        self.clipboardError = clipboardError;
+        $ctrl.clientIdCopied = false;
+        $ctrl.clientSecretCopied = false;
 
         $ctrl.ok = function () {
             $uibModalInstance.close($ctrl.selected);
@@ -35,22 +34,33 @@
             $uibModalInstance.dismiss('cancel');
         };
 
-        function clipboardError(event) {
+        $ctrl.clipboardError = function (event) {
             toaster.pop({
                 type: 'error',
-                body: 'Could not copy secret to clipboard!'
+                body: 'Could not copy Client details to clipboard!'
             });
         }
 
-        function clipboardSuccess(event, source) {
+        $ctrl.clipboardSuccess = function (event, source) {
+
+            var message = "Copied to clipboard.";
+
+            if (source === "clientid") {
+                $ctrl.clientIdCopied = true;
+                message = "Client ID copied to clipboard.";
+            }
+
+            if (source === "secret") {
+                $ctrl.clientSecretCopied = true;
+                message = "Client Secret copied to clipboard.";
+            }
+
             toaster.pop({
                 type: 'success',
-                body: 'Secret copied to clipboard!'
+                body: message
             });
+
             event.clearSelection();
-            if (source === 'secret') {
-                toggleSecretVisibility();
-            }
         }
     };
 

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/newclientsecretshow/newclientsecretshow.component.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/newclientsecretshow/newclientsecretshow.component.html
@@ -19,13 +19,32 @@
     <h3 class="modal-title">{{ $ctrl.data.title }}</h3>
 </div>
 <div class="modal-body">
-    <p>{{ $ctrl.data.message }}</p>
-    <p>client secret</p>
+
+    <div class="alert alert-danger" role="alert">
+        <strong><i class="fa fa-exclamation-triangle"></i> Important</strong><br/>
+            This is the only time the Client Secret will be displayed.
+            Please <strong>copy and store</strong> it in a secure location before closing this window.
+            Once closed, the secret cannot be retrieved again.
+    </div>
+
+    <p>Client ID</p>
+    <div class="input-group">
+        <input type="text" id="client_id" ng-model="$ctrl.clientId" class="form-control" readonly>
+        <span class="input-group-btn">
+            <button class="btn btn-default" type="button" ngclipboard data-clipboard-target="#client_id"
+                ngclipboard-success="$ctrl.clipboardSuccess(e, 'clientid');" ngclipboard-error="$ctrl.clipboardError(e);">
+                <i class="fa" ng-class="{'fa-clipboard': !$ctrl.clientIdCopied,
+                    'fa-check text-success': $ctrl.clientIdCopied}"></i>
+            </button>
+        </span>
+    </div><br/>
+
+    <p>Client Secret</p>
     <div ng-if="$ctrl.client.registration_access_token && !$ctrl.isLimited()">
         <div class="input-group">
             <span class="input-group-btn">
                 <button class="btn btn-default" type="button" ngclipboard data-clipboard-target="#rat"
-                    ngclipboard-success="$ctrl.clipboardSuccess(e);" ngclipboard-error="$ctrl.clipboardError(e);"
+                    ngclipboard-success="$ctrl.clipboardSuccess(e, 'secret');" ngclipboard-error="$ctrl.clipboardError(e);"
                     alt="Copy registration access token to clipboard">
                     <i class="fa fa-clipboard"></i>
                 </button>
@@ -35,28 +54,20 @@
     </div>
 
     <div class="input-group" ng-if="$ctrl.confirmation">
-        <span class="input-group-btn" ng-if="!$ctrl.showSecret">
-            <button class="btn btn-default" type="button" ng-click="$ctrl.toggleSecretVisibility()">
-                <i class="fa fa-eye"></i>
-            </button>
-        </span>
-        <span class="input-group-btn" ng-if="$ctrl.showSecret">
+        <input type="text" id="client_secret" ng-model="$ctrl.secret" class="form-control" readonly>
+        <span class="input-group-btn">
             <button class="btn btn-default" type="button" ngclipboard data-clipboard-target="#client_secret"
                 ngclipboard-success="$ctrl.clipboardSuccess(e, 'secret');" ngclipboard-error="$ctrl.clipboardError(e);"
                 alt="Copy secret to clipboard">
-                <i class="fa fa-clipboard"></i>
+                <i class="fa" ng-class="{'fa-clipboard': !$ctrl.clientSecretCopied,
+                    'fa-check text-success': $ctrl.clientSecretCopied}">
+                </i>
             </button>
         </span>
-        <input type="password" value="******" ng-if="!$ctrl.showSecret" class="form-control" readonly>
-        <input type="text" id="client_secret" ng-model="$ctrl.secret" ng-if="$ctrl.showSecret" class="form-control"
-            readonly>
     </div>
-    </br>
-    <p>client id</p>
-    <div>
-        <input type="text" id="client_id" ng-model="$ctrl.clientId" class="form-control" readonly>
-    </div>
+
     <div class="modal-footer">
         <button class="btn btn-primary" type="button" ng-click="$ctrl.ok()">Confirm</button>
     </div>
+
 </div>

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/newclientsecretshow/newclientsecretshow.component.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/newclientsecretshow/newclientsecretshow.component.html
@@ -53,7 +53,7 @@
         </div>
     </div>
 
-    <div class="input-group" ng-if="$ctrl.confirmation">
+    <div class="input-group" >
         <input type="text" id="client_secret" ng-model="$ctrl.secret" class="form-control" readonly>
         <span class="input-group-btn">
             <button class="btn btn-default" type="button" ngclipboard data-clipboard-target="#client_secret"

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/myclients/myclient/myclient.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/myclients/myclient/myclient.component.js
@@ -23,7 +23,6 @@
         $ctrl.newClient = data.client;
         $ctrl.secret = $ctrl.newClient.client_secret;
         $ctrl.clientId = $ctrl.newClient.client_id;
-        $ctrl.confirmation = true;
         $ctrl.clientIdCopied = false;
         $ctrl.clientSecretCopied = false;
 

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/myclients/myclient/myclient.component.js
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/myclients/myclient/myclient.component.js
@@ -23,11 +23,9 @@
         $ctrl.newClient = data.client;
         $ctrl.secret = $ctrl.newClient.client_secret;
         $ctrl.clientId = $ctrl.newClient.client_id;
-        $ctrl.showSecret = false;
         $ctrl.confirmation = true;
-
-        self.clipboardSuccess = clipboardSuccess;
-        self.clipboardError = clipboardError;
+        $ctrl.clientIdCopied = false;
+        $ctrl.clientSecretCopied = false;
 
         $ctrl.ok = function () {
             $uibModalInstance.close($ctrl.selected);
@@ -37,26 +35,32 @@
             $uibModalInstance.dismiss('cancel');
         };
 
-        $ctrl.toggleSecretVisibility = function () {
-            $ctrl.showSecret = !$ctrl.showSecret;
-        };
-
-        function clipboardError(event) {
+        $ctrl.clipboardError = function (event) {
             toaster.pop({
                 type: 'error',
                 body: 'Could not copy secret to clipboard!'
             });
         }
 
-        function clipboardSuccess(event, source) {
+        $ctrl.clipboardSuccess = function (event, source) {
+            var message = "Copied to clipboard.";
+
+            if (source === "clientid") {
+                $ctrl.clientIdCopied = true;
+                message = "Client ID copied to clipboard.";
+            }
+
+            if (source === "secret") {
+                $ctrl.clientSecretCopied = true;
+                message = "Client Secret copied to clipboard.";
+            }
+
             toaster.pop({
                 type: 'success',
-                body: 'Secret copied to clipboard!'
+                body: message
             });
+
             event.clearSelection();
-            if (source === 'secret') {
-                $ctrl.toggleSecretVisibility();
-            }
         }
     };
 
@@ -151,8 +155,8 @@
                     resolve: {
                         data: {
                             client: res,
-                            title: "New client credential details",
-                            message: "Save this client credential on safe before press Confirm button",
+                            title: "Client details",
+                            message: "Your Client Secret will be no longer shown.",
                             isNewClient: true,
                         }
                     }


### PR DESCRIPTION
When a new client is created, an improve pop-up window allows to save the ClientID and secret as follows

<img width="719" height="546" alt="Screenshot from 2026-07-16 16-16-49" src="https://github.com/user-attachments/assets/440e297b-c9ab-486e-8a4c-23eb458e2495" />

Also, when a new secret is created, a similar pop-up window allows to save the Client secret

<img width="719" height="434" alt="Screenshot from 2026-07-16 16-16-13" src="https://github.com/user-attachments/assets/cc7ee6b7-73b6-4e1f-86df-37803a5b1623" />
