### PR TITLE
Fix values available into client's crypto settings

### DIFF
--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/cryptosettings/cryptosettings.component.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/clients/client/cryptosettings/cryptosettings.component.html
@@ -21,9 +21,10 @@
             challenge method</label>
 
         <select id="pkce" class="form-control" ng-model="$ctrl.client.code_challenge_method">
-            <option value="">No code challenge</option>
-            <option value="plain">Plain code challenge</option>
-            <option value="S256">SHA-256 hash algorithm</option>
+            <option ng-value="'optional'">Code challenge is accepted but not required</option>
+            <option ng-value="'none'">No code challenge is allowed</option>
+            <option ng-value="'plain'">Plain code challenge required</option>
+            <option ng-value="'S256'">SHA-256 hash algorithm required</option>
         </select>
     </div>
 </div>

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/persistence/PKCEAlgorithmStringConverterTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/persistence/PKCEAlgorithmStringConverterTests.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mitre.oauth2.model.PKCEAlgorithm;
+import org.mitre.oauth2.model.convert.PKCEAlgorithmStringConverter;
+
+class PKCEAlgorithmStringConverterTests {
+
+  private PKCEAlgorithmStringConverter converter = new PKCEAlgorithmStringConverter();
+
+  @Test
+  void shouldConvertAlgorithmToDatabaseColumn() {
+    assertThat(converter.convertToDatabaseColumn(PKCEAlgorithm.S256)).isEqualTo("S256");
+  }
+
+  @Test
+  void shouldConvertNullAlgorithmToNullDatabaseColumn() {
+    assertThat(converter.convertToDatabaseColumn(null)).isNull();
+  }
+
+  @Test
+  void shouldConvertDatabaseValueToAlgorithm() {
+    assertThat(converter.convertToEntityAttribute("S256")).isEqualTo(PKCEAlgorithm.S256);
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {" ", "   ", "\t", "\n"})
+  void shouldUseOptionalForMissingDatabaseValue(String dbData) {
+    assertThat(converter.convertToEntityAttribute(dbData)).isEqualTo(PKCEAlgorithm.optional);
+  }
+
+  @Test
+  void shouldRejectUnknownDatabaseValue() {
+    assertThatThrownBy(() -> converter.convertToEntityAttribute("unknown"))
+      .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 
     <junit.version>5.14.1</junit.version>
 
-    <mitreid.version>2.3.0.cnaf-20260709</mitreid.version>
+    <mitreid.version>2.3.1.cnaf-20260728</mitreid.version>
     <spring-security-oauth2.version>2.5.2.RELEASE</spring-security-oauth2.version>
 
     <voms.version>3.3.8</voms.version>


### PR DESCRIPTION
Used ng-value
Replaced empty string with 'optional' value
Added 'none' option

Related to this commit: https://github.com/indigo-iam/OpenID-Connect-Java-Spring-Server/commit/9282379e64ab7273f1d939810a6059ad1879caa1