### PR TITLE
Fix token exchange requested token type handling

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/granters/TokenExchangeTokenGranter.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/granters/TokenExchangeTokenGranter.java
@@ -19,12 +19,17 @@ import static it.infn.mw.iam.core.oauth.exchange.TokenExchangePdpResult.Decision
 import static it.infn.mw.iam.core.oauth.exchange.TokenExchangePdpResult.Decision.PERMIT;
 import static java.lang.String.format;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.oauth2.client.resource.OAuth2AccessDeniedException;
+import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
+import org.springframework.security.oauth2.common.ExpiringOAuth2RefreshToken;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.OAuth2RefreshToken;
 import org.springframework.security.oauth2.common.exceptions.InvalidGrantException;
 import org.springframework.security.oauth2.common.exceptions.InvalidRequestException;
 import org.springframework.security.oauth2.common.exceptions.InvalidScopeException;
@@ -52,10 +57,18 @@ public class TokenExchangeTokenGranter extends AbstractTokenGranter {
 
   public static final Logger LOG = LoggerFactory.getLogger(TokenExchangeTokenGranter.class);
 
+  private static final String REQUESTED_TOKEN_TYPE = "requested_token_type";
+  private static final String ISSUED_TOKEN_TYPE = "issued_token_type";
+
+  private static final String ACCESS_TOKEN_TYPE =
+      "urn:ietf:params:oauth:token-type:access_token";
+  private static final String REFRESH_TOKEN_TYPE =
+      "urn:ietf:params:oauth:token-type:refresh_token";
+
+  private static final String TOKEN_TYPE_NA = "N_A";
+
   public static final String TOKEN_EXCHANGE_GRANT_TYPE =
       "urn:ietf:params:oauth:grant-type:token-exchange";
-
-  private static final String TOKEN_TYPE = "urn:ietf:params:oauth:token-type:jwt";
 
   private static final String AUDIENCE_FIELD = "audience";
   private static final String OFFLINE_ACCESS_SCOPE = "offline_access";
@@ -110,13 +123,70 @@ public class TokenExchangeTokenGranter extends AbstractTokenGranter {
   @Override
   protected OAuth2AccessToken getAccessToken(ClientDetails client, TokenRequest tokenRequest) {
 
-    OAuth2Authentication auth = getOAuth2Authentication(client, tokenRequest);
+    String requestedTokenType = resolveRequestedTokenType(tokenRequest);
 
-    OAuth2AccessToken token = tokenService.createAccessToken(auth);
+    OAuth2Authentication auth =
+        getOAuth2Authentication(client, tokenRequest);
 
-    token.getAdditionalInformation().put("issued_token_type", TOKEN_TYPE);
+    OAuth2AccessToken token =
+        tokenService.createAccessToken(auth);
+
+    if (REFRESH_TOKEN_TYPE.equals(requestedTokenType)) {
+      return refreshTokenResponse(token);
+    }
+
+    token.getAdditionalInformation().put(
+        ISSUED_TOKEN_TYPE, ACCESS_TOKEN_TYPE);
 
     return token;
+  }
+
+  private String resolveRequestedTokenType(TokenRequest request) {
+
+    String requestedTokenType =
+        request.getRequestParameters().get(REQUESTED_TOKEN_TYPE);
+
+    if (requestedTokenType == null || requestedTokenType.isBlank()) {
+      return ACCESS_TOKEN_TYPE;
+    }
+
+    if (!ACCESS_TOKEN_TYPE.equals(requestedTokenType)
+        && !REFRESH_TOKEN_TYPE.equals(requestedTokenType)) {
+      throw new InvalidRequestException(
+          "Unsupported requested_token_type: " + requestedTokenType);
+    }
+
+    return requestedTokenType;
+  }
+
+  private OAuth2AccessToken refreshTokenResponse(OAuth2AccessToken token) {
+
+    OAuth2RefreshToken refreshToken = token.getRefreshToken();
+
+    if (refreshToken == null) {
+      throw new OAuth2AccessDeniedException(
+          "A refresh token cannot be issued for this token exchange");
+    }
+
+    DefaultOAuth2AccessToken response =
+        new DefaultOAuth2AccessToken(refreshToken.getValue());
+
+    response.setTokenType(TOKEN_TYPE_NA);
+    response.setScope(token.getScope());
+
+    Map<String, Object> additionalInformation =
+        new HashMap<>(token.getAdditionalInformation());
+
+    additionalInformation.put(
+        ISSUED_TOKEN_TYPE, REFRESH_TOKEN_TYPE);
+
+    response.setAdditionalInformation(additionalInformation);
+
+    if (refreshToken instanceof ExpiringOAuth2RefreshToken expiringRefreshToken) {
+      response.setExpiration(expiringRefreshToken.getExpiration());
+    }
+
+    return response;
   }
 
   private SubjectTokenContext resolveSubjectToken(ClientDetailsEntity actor, TokenRequest request) {

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/TokenExchangeTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/TokenExchangeTests.java
@@ -25,6 +25,8 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
@@ -41,10 +43,13 @@ import java.util.Random;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTClaimsSet;
@@ -54,15 +59,24 @@ import it.infn.mw.iam.IamLoginService;
 import it.infn.mw.iam.core.oauth.introspection.model.TokenTypeHint;
 import it.infn.mw.iam.persistence.model.IamAup;
 import it.infn.mw.iam.persistence.repository.IamAupRepository;
-import it.infn.mw.iam.test.util.annotation.IamMockMvcIntegrationTest;
 
 @SuppressWarnings("deprecation")
-@IamMockMvcIntegrationTest
 @SpringBootTest(classes = {IamLoginService.class}, webEnvironment = WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@Transactional
 class TokenExchangeTests extends EndpointsTestUtils {
 
-  private static final String GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange";
-  private static final String TOKEN_TYPE = "urn:ietf:params:oauth:token-type:jwt";
+  private static final String GRANT_TYPE =
+      "urn:ietf:params:oauth:grant-type:token-exchange";
+
+  private static final String JWT_TOKEN_TYPE =
+      "urn:ietf:params:oauth:token-type:jwt";
+
+  private static final String ACCESS_TOKEN_TYPE =
+      "urn:ietf:params:oauth:token-type:access_token";
+
+  private static final String REFRESH_TOKEN_TYPE =
+      "urn:ietf:params:oauth:token-type:refresh_token";
 
   private static final String TEST_USER_USERNAME = "test";
   private static final String TEST_USER_PASSWORD = "password";
@@ -100,11 +114,11 @@ class TokenExchangeTests extends EndpointsTestUtils {
         .param("grant_type", GRANT_TYPE)
         .param("audience", audClientId)
         .param("subject_token", accessToken)
-        .param("subject_token_type", TOKEN_TYPE)
+        .param("subject_token_type", JWT_TOKEN_TYPE)
         .param("scope", "openid"))
       .andExpect(status().isOk())
       .andExpect(jsonPath("$.scope", equalTo("openid")))
-      .andExpect(jsonPath("$.issued_token_type", equalTo(TOKEN_TYPE)))
+      .andExpect(jsonPath("$.issued_token_type", equalTo(ACCESS_TOKEN_TYPE)))
       .andExpect(jsonPath("$.token_type", equalTo("Bearer")))
       .andExpect(jsonPath("$.access_token").exists())
       .andExpect(jsonPath("$.access_token", notNullValue()))
@@ -166,7 +180,7 @@ class TokenExchangeTests extends EndpointsTestUtils {
       .perform(post(TOKEN_ENDPOINT).with(httpBasic(actorClientId, actorClientSecret))
         .param("grant_type", GRANT_TYPE)
         .param("subject_token", accessToken)
-        .param("subject_token_type", TOKEN_TYPE)
+        .param("subject_token_type", JWT_TOKEN_TYPE)
         .param("scope", "openid profile"))
       .andExpect(status().isOk());
 
@@ -186,7 +200,7 @@ class TokenExchangeTests extends EndpointsTestUtils {
       .perform(post(TOKEN_ENDPOINT).with(httpBasic(actorClientId, actorClientSecret))
         .param("grant_type", GRANT_TYPE)
         .param("subject_token", accessToken)
-        .param("subject_token_type", TOKEN_TYPE)
+        .param("subject_token_type", JWT_TOKEN_TYPE)
         .param("scope", "read-tasks openid profile"))
       .andExpect(status().isBadRequest())
       .andExpect(jsonPath("$.error", equalTo("invalid_grant")))
@@ -216,11 +230,11 @@ class TokenExchangeTests extends EndpointsTestUtils {
         .with(httpBasic(actorClientId, actorClientSecret))
         .param("grant_type", GRANT_TYPE)
         .param("subject_token", accessToken)
-        .param("subject_token_type", TOKEN_TYPE)
+        .param("subject_token_type", JWT_TOKEN_TYPE)
         .param("scope", "openid profile"))
       .andExpect(status().isOk())
       .andExpect(jsonPath("$.scope", equalTo("openid profile")))
-      .andExpect(jsonPath("$.issued_token_type", equalTo(TOKEN_TYPE)))
+      .andExpect(jsonPath("$.issued_token_type", equalTo(ACCESS_TOKEN_TYPE)))
       .andExpect(jsonPath("$.token_type", equalTo("Bearer")))
       .andExpect(jsonPath("$.access_token").exists())
       .andExpect(jsonPath("$.access_token", notNullValue()))
@@ -288,7 +302,7 @@ class TokenExchangeTests extends EndpointsTestUtils {
         .param("grant_type", GRANT_TYPE)
         .param("audience", audClientId)
         .param("subject_token", accessToken)
-        .param("subject_token_type", TOKEN_TYPE)
+        .param("subject_token_type", JWT_TOKEN_TYPE)
         .param("scope", "read-tasks"))
       .andExpect(status().isUnauthorized())
       .andExpect(jsonPath("$.error", equalTo("invalid_client")))
@@ -297,7 +311,7 @@ class TokenExchangeTests extends EndpointsTestUtils {
   }
 
   @Test
-  void testTokenExchangeWithRefreshToken() throws Exception {
+  void testTokenExchangeWithOfflineAccess() throws Exception {
 
     String clientId = "token-exchange-subject";
     String clientSecret = "secret";
@@ -321,11 +335,11 @@ class TokenExchangeTests extends EndpointsTestUtils {
         .param("grant_type", GRANT_TYPE)
         .param("audience", audClientId)
         .param("subject_token", accessToken)
-        .param("subject_token_type", TOKEN_TYPE)
+        .param("subject_token_type", JWT_TOKEN_TYPE)
         .param("scope", "openid offline_access"))
       .andExpect(status().isOk())
       .andExpect(jsonPath("$.scope", equalTo("openid offline_access")))
-      .andExpect(jsonPath("$.issued_token_type", equalTo(TOKEN_TYPE)))
+      .andExpect(jsonPath("$.issued_token_type", equalTo(ACCESS_TOKEN_TYPE)))
       .andExpect(jsonPath("$.token_type", equalTo("Bearer")))
       .andExpect(jsonPath("$.id_token", notNullValue()))
       .andExpect(jsonPath("$.access_token", notNullValue()))
@@ -417,9 +431,9 @@ class TokenExchangeTests extends EndpointsTestUtils {
         .param("grant_type", GRANT_TYPE)
         .param("audience", audClientId)
         .param("subject_token", subjectToken)
-        .param("subject_token_type", TOKEN_TYPE)
+        .param("subject_token_type", JWT_TOKEN_TYPE)
         .param("actor_token", actorToken)
-        .param("actor_token_type", TOKEN_TYPE)
+        .param("actor_token_type", JWT_TOKEN_TYPE)
         .param("want_composite", "true")
         .param("scope", "read-tasks"))
       .andExpect(status().isBadRequest())
@@ -441,7 +455,7 @@ class TokenExchangeTests extends EndpointsTestUtils {
         .with(httpBasic(actorClientId, actorClientSecret))
         .param("grant_type", GRANT_TYPE)
         .param("subject_token", accessToken)
-        .param("subject_token_type", TOKEN_TYPE)
+        .param("subject_token_type", JWT_TOKEN_TYPE)
         .param("scope", "read-tasks"))
       .andExpect(status().isBadRequest())
       .andExpect(jsonPath("$.error", equalTo("invalid_grant")));
@@ -464,7 +478,7 @@ class TokenExchangeTests extends EndpointsTestUtils {
       .perform(post(TOKEN_ENDPOINT).with(httpBasic(actorClientId, actorClientSecret))
         .param("grant_type", GRANT_TYPE)
         .param("subject_token", accessToken)
-        .param("subject_token_type", TOKEN_TYPE)
+        .param("subject_token_type", JWT_TOKEN_TYPE)
         .param("scope", "read-tasks offline_access"))
       .andExpect(status().isOk())
       .andExpect(jsonPath("$.access_token").exists())
@@ -514,7 +528,7 @@ class TokenExchangeTests extends EndpointsTestUtils {
     mvc.perform(post(TOKEN_ENDPOINT).with(httpBasic(clientId, clientSecret))
         .param("grant_type", GRANT_TYPE)
         .param("subject_token", accessToken)
-        .param("subject_token_type", TOKEN_TYPE)
+        .param("subject_token_type", JWT_TOKEN_TYPE)
         .param("scope", "openid offline_access"))
       .andExpect(status().isForbidden());
 
@@ -523,7 +537,7 @@ class TokenExchangeTests extends EndpointsTestUtils {
       .perform(post(TOKEN_ENDPOINT).with(httpBasic(clientId, clientSecret))
         .param("grant_type", GRANT_TYPE)
         .param("subject_token", accessToken)
-        .param("subject_token_type", TOKEN_TYPE)
+        .param("subject_token_type", JWT_TOKEN_TYPE)
         .param("scope", "openid"))
       .andExpect(status().isOk())
       .andExpect(jsonPath("$.scope", equalTo("openid")))
@@ -557,11 +571,11 @@ class TokenExchangeTests extends EndpointsTestUtils {
         .param("grant_type", GRANT_TYPE)
         .param("audience", audClientId)
         .param("subject_token", accessToken)
-        .param("subject_token_type", TOKEN_TYPE)
+        .param("subject_token_type", JWT_TOKEN_TYPE)
         .param("scope", "openid offline_access"))
       .andExpect(status().isOk())
       .andExpect(jsonPath("$.scope", equalTo("openid offline_access")))
-      .andExpect(jsonPath("$.issued_token_type", equalTo(TOKEN_TYPE)))
+      .andExpect(jsonPath("$.issued_token_type", equalTo(ACCESS_TOKEN_TYPE)))
       .andExpect(jsonPath("$.token_type", equalTo("Bearer")))
       .andExpect(jsonPath("$.id_token", notNullValue()))
       .andExpect(jsonPath("$.access_token", notNullValue()))
@@ -626,11 +640,11 @@ class TokenExchangeTests extends EndpointsTestUtils {
         .with(httpBasic(secondActorClient, "secret"))
         .param("grant_type", GRANT_TYPE)
         .param("subject_token", refreshedToken.getValue())
-        .param("subject_token_type", TOKEN_TYPE)
+        .param("subject_token_type", JWT_TOKEN_TYPE)
         .param("scope", "openid offline_access"))
       .andExpect(status().isOk())
       .andExpect(jsonPath("$.scope", equalTo("openid offline_access")))
-      .andExpect(jsonPath("$.issued_token_type", equalTo(TOKEN_TYPE)))
+      .andExpect(jsonPath("$.issued_token_type", equalTo(ACCESS_TOKEN_TYPE)))
       .andExpect(jsonPath("$.token_type", equalTo("Bearer")))
       .andExpect(jsonPath("$.id_token", notNullValue()))
       .andExpect(jsonPath("$.access_token", notNullValue()))
@@ -680,11 +694,11 @@ class TokenExchangeTests extends EndpointsTestUtils {
         .param("random_long_string", longString)
         .param("audience", audClientId)
         .param("subject_token", accessToken)
-        .param("subject_token_type", TOKEN_TYPE)
+        .param("subject_token_type", JWT_TOKEN_TYPE)
         .param("scope", "openid"))
       .andExpect(status().isOk())
       .andExpect(jsonPath("$.scope", equalTo("openid")))
-      .andExpect(jsonPath("$.issued_token_type", equalTo(TOKEN_TYPE)))
+      .andExpect(jsonPath("$.issued_token_type", equalTo(ACCESS_TOKEN_TYPE)))
       .andExpect(jsonPath("$.token_type", equalTo("Bearer")))
       .andExpect(jsonPath("$.access_token").exists())
       .andExpect(jsonPath("$.access_token", notNullValue()))
@@ -709,5 +723,181 @@ class TokenExchangeTests extends EndpointsTestUtils {
     }
 
     return stringBuilder.toString();
+  }
+
+  @Test
+  void shouldDefaultRequestedTokenTypeToAccessToken() throws Exception {
+
+    String subjectToken = new AccessTokenGetter().grantType("password")
+      .clientId("token-exchange-subject")
+      .clientSecret("secret")
+      .username(TEST_USER_USERNAME)
+      .password(TEST_USER_PASSWORD)
+      .scope("openid profile")
+      .getAccessTokenValue();
+
+    mvc.perform(post(TOKEN_ENDPOINT)
+        .with(httpBasic("token-exchange-actor", "secret"))
+        .param("grant_type", GRANT_TYPE)
+        .param("subject_token", subjectToken)
+        .param("subject_token_type", JWT_TOKEN_TYPE)
+        .param("scope", "openid"))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.access_token", notNullValue()))
+      .andExpect(jsonPath("$.issued_token_type", equalTo(ACCESS_TOKEN_TYPE)))
+      .andExpect(jsonPath("$.token_type", equalTo("Bearer")));
+  }
+
+  @Test
+  void shouldIssueAccessTokenWhenRequestedTokenTypeIsAccessToken() throws Exception {
+
+    String subjectToken = new AccessTokenGetter().grantType("password")
+      .clientId("token-exchange-subject")
+      .clientSecret("secret")
+      .username(TEST_USER_USERNAME)
+      .password(TEST_USER_PASSWORD)
+      .scope("openid profile")
+      .getAccessTokenValue();
+
+    String response = mvc.perform(post(TOKEN_ENDPOINT)
+        .with(httpBasic("token-exchange-actor", "secret"))
+        .param("grant_type", GRANT_TYPE)
+        .param("subject_token", subjectToken)
+        .param("subject_token_type", JWT_TOKEN_TYPE)
+        .param("requested_token_type", ACCESS_TOKEN_TYPE)
+        .param("scope", "openid"))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.access_token", notNullValue()))
+      .andExpect(jsonPath("$.issued_token_type", equalTo(ACCESS_TOKEN_TYPE)))
+      .andExpect(jsonPath("$.token_type", equalTo("Bearer")))
+      .andReturn()
+      .getResponse()
+      .getContentAsString();
+
+    DefaultOAuth2AccessToken responseToken =
+        mapper.readValue(response, DefaultOAuth2AccessToken.class);
+
+    JWT jwt = JWTParser.parse(responseToken.getValue());
+
+    assertThat(jwt.getJWTClaimsSet().getSubject(), is(TEST_USER_SUB));
+  }
+
+  @Test
+  void shouldIssueRefreshTokenWhenRequestedTokenTypeIsRefreshToken() throws Exception {
+
+    String subjectToken = new AccessTokenGetter().grantType("password")
+      .clientId("token-exchange-subject")
+      .clientSecret("secret")
+      .username(TEST_USER_USERNAME)
+      .password(TEST_USER_PASSWORD)
+      .scope("openid profile offline_access")
+      .getAccessTokenValue();
+
+    String response = mvc.perform(post(TOKEN_ENDPOINT)
+        .with(httpBasic("token-exchange-actor", "secret"))
+        .param("grant_type", GRANT_TYPE)
+        .param("audience", "client")
+        .param("subject_token", subjectToken)
+        .param("subject_token_type", JWT_TOKEN_TYPE)
+        .param("requested_token_type", REFRESH_TOKEN_TYPE)
+        .param("scope", "openid offline_access"))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.access_token", notNullValue()))
+      .andExpect(jsonPath("$.issued_token_type", equalTo(REFRESH_TOKEN_TYPE)))
+      .andExpect(jsonPath("$.token_type", equalTo("N_A")))
+      .andExpect(jsonPath("$.refresh_token").doesNotExist())
+      .andReturn()
+      .getResponse()
+      .getContentAsString();
+
+    JsonNode tokenResponse = mapper.readTree(response);
+
+    String refreshToken = tokenResponse.get("access_token").asText();
+
+    assertNotNull(refreshToken);
+    assertFalse(refreshToken.isEmpty());
+  }
+
+  @Test
+  void issuedRefreshTokenShouldBeUsableWithRefreshTokenGrant() throws Exception {
+
+    String subjectToken = new AccessTokenGetter().grantType("password")
+      .clientId("token-exchange-subject")
+      .clientSecret("secret")
+      .username(TEST_USER_USERNAME)
+      .password(TEST_USER_PASSWORD)
+      .scope("openid profile offline_access")
+      .getAccessTokenValue();
+
+    String exchangeResponse = mvc.perform(post(TOKEN_ENDPOINT)
+        .with(httpBasic("token-exchange-actor", "secret"))
+        .param("grant_type", GRANT_TYPE)
+        .param("subject_token", subjectToken)
+        .param("subject_token_type", JWT_TOKEN_TYPE)
+        .param("requested_token_type", REFRESH_TOKEN_TYPE)
+        .param("scope", "openid offline_access"))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.issued_token_type", equalTo(REFRESH_TOKEN_TYPE)))
+      .andExpect(jsonPath("$.token_type", equalTo("N_A")))
+      .andReturn()
+      .getResponse()
+      .getContentAsString();
+
+    String refreshToken =
+        mapper.readTree(exchangeResponse).get("access_token").asText();
+
+    mvc.perform(post(TOKEN_ENDPOINT)
+        .with(httpBasic("token-exchange-actor", "secret"))
+        .param("grant_type", "refresh_token")
+        .param("refresh_token", refreshToken))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.access_token", notNullValue()))
+      .andExpect(jsonPath("$.token_type", equalTo("Bearer")));
+  }
+
+  @Test
+  void shouldRejectUnsupportedRequestedTokenType() throws Exception {
+
+    String subjectToken = new AccessTokenGetter().grantType("password")
+      .clientId("token-exchange-subject")
+      .clientSecret("secret")
+      .username(TEST_USER_USERNAME)
+      .password(TEST_USER_PASSWORD)
+      .scope("openid")
+      .getAccessTokenValue();
+
+    mvc.perform(post(TOKEN_ENDPOINT)
+        .with(httpBasic("token-exchange-actor", "secret"))
+        .param("grant_type", GRANT_TYPE)
+        .param("subject_token", subjectToken)
+        .param("subject_token_type", JWT_TOKEN_TYPE)
+        .param("requested_token_type",
+            "urn:ietf:params:oauth:token-type:saml2")
+        .param("scope", "openid"))
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.error", equalTo("invalid_request")))
+      .andExpect(jsonPath("$.error_description",
+          containsString("Unsupported requested_token_type")));
+  }
+
+  @Test
+  void shouldFailWhenRefreshTokenIsRequestedButCannotBeIssued() throws Exception {
+
+    String subjectToken = new AccessTokenGetter().grantType("password")
+      .clientId("token-exchange-subject")
+      .clientSecret("secret")
+      .username(TEST_USER_USERNAME)
+      .password(TEST_USER_PASSWORD)
+      .scope("openid")
+      .getAccessTokenValue();
+
+    mvc.perform(post(TOKEN_ENDPOINT)
+        .with(httpBasic("token-exchange-actor", "secret"))
+        .param("grant_type", GRANT_TYPE)
+        .param("subject_token", subjectToken)
+        .param("subject_token_type", JWT_TOKEN_TYPE)
+        .param("requested_token_type", REFRESH_TOKEN_TYPE)
+        .param("scope", "openid"))
+      .andExpect(status().isForbidden());
   }
 }


### PR DESCRIPTION
## Motivation

The INDIGO IAM token exchange implementation currently does not take the `requested_token_type` parameter into account when processing an OAuth 2.0 Token Exchange request.

Regardless of the requested token type, IAM currently issues an OAuth access token and reports:

```json
{
  "access_token": "<access-token>",
  "token_type": "Bearer",
  "issued_token_type": "urn:ietf:params:oauth:token-type:jwt"
}
```

A refresh token may additionally be returned when the requested scopes and client configuration allow one.

This behavior is problematic when a client explicitly requests a different token type, in particular:

```text
requested_token_type=urn:ietf:params:oauth:token-type:refresh_token
```

According to [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693), `requested_token_type` indicates the type of token the client wants the authorization server to issue. The token resulting from the exchange is returned in the `access_token` response parameter, even when the issued token is not actually an OAuth access token.

This somewhat counter-intuitive use of the `access_token` response parameter is explicitly defined by [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693).

## Changes

This change updates the token exchange implementation to honor `requested_token_type`.

The following token types are supported:

* `urn:ietf:params:oauth:token-type:access_token`
* `urn:ietf:params:oauth:token-type:refresh_token`

When `requested_token_type` is omitted, IAM defaults to issuing an OAuth access token, as specified by RFC 8693.

Unsupported requested token types are rejected.

The value of `issued_token_type` is also changed to describe the semantic type of the issued token rather than its JWT representation.

### Access token request

For a request such as:

```text
grant_type=urn:ietf:params:oauth:grant-type:token-exchange
subject_token=<subject-token>
subject_token_type=urn:ietf:params:oauth:token-type:jwt
requested_token_type=urn:ietf:params:oauth:token-type:access_token
```

IAM returns an OAuth access token:

```json
{
  "access_token": "<access-token>",
  "token_type": "Bearer",
  "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
  "expires_in": 3600
}
```

The same behavior applies when `requested_token_type` is omitted.

Previously, IAM reported:

```text
urn:ietf:params:oauth:token-type:jwt
```

as the `issued_token_type`.

The new value:

```text
urn:ietf:params:oauth:token-type:access_token
```

reflects that the issued token is being used as an OAuth access token, regardless of the fact that its concrete representation in IAM is a JWT.

### Refresh token request

For a request explicitly asking for a refresh token:

```text
grant_type=urn:ietf:params:oauth:grant-type:token-exchange
subject_token=<subject-token>
subject_token_type=urn:ietf:params:oauth:token-type:jwt
requested_token_type=urn:ietf:params:oauth:token-type:refresh_token
scope=openid offline_access
```

the refresh token is returned as the value of the `access_token` response parameter:

```json
{
  "access_token": "<refresh-token>",
  "token_type": "N_A",
  "issued_token_type": "urn:ietf:params:oauth:token-type:refresh_token",
  "expires_in": 2592000
}
```

`token_type` is set to `N_A` because the value carried by the `access_token` response parameter is not an OAuth access token and therefore cannot be used as a Bearer token.

The returned token can subsequently be used with the regular refresh token grant:

```text
grant_type=refresh_token
refresh_token=<value-returned-in-access_token>
```

to obtain a usable OAuth access token.

If IAM cannot issue a refresh token for the requested exchange, the request fails instead of silently returning an access token of a different type.

## Interoperability

This change also addresses an interoperability difference observed between INDIGO IAM and CILogon.

For a token exchange request containing:

```text
requested_token_type=urn:ietf:params:oauth:token-type:refresh_token
```

CILogon returns the requested refresh token in the `access_token` response parameter with:

```json
{
  "token_type": "N_A",
  "issued_token_type": "urn:ietf:params:oauth:token-type:refresh_token"
}
```

while INDIGO IAM currently returns a directly usable Bearer access token and, when applicable, a separate refresh token.

Clients consuming token exchange responses must therefore not assume that the `access_token` response parameter always contains a directly usable OAuth access token. They should take `issued_token_type` and `token_type` into account when processing the response.

## Backward compatibility

This introduces a behavioral change for token exchange clients.

Requests that omit `requested_token_type`, or explicitly request:

```text
urn:ietf:params:oauth:token-type:access_token
```

continue to receive a usable OAuth access token.

However, the `issued_token_type` for these responses changes from:

```text
urn:ietf:params:oauth:token-type:jwt
```

to:

```text
urn:ietf:params:oauth:token-type:access_token
```

More importantly, clients explicitly requesting:

```text
urn:ietf:params:oauth:token-type:refresh_token
```

will no longer receive a usable Bearer access token in the `access_token` response parameter. The field will instead contain the requested refresh token and `token_type` will be `N_A`.

Clients that currently request a refresh token but nevertheless consume `access_token` directly as a Bearer token will therefore need to be updated.

## Tests

The token exchange integration tests have been updated and extended to cover:

* default issuance of an access token when `requested_token_type` is omitted;
* explicit requests for an access token;
* explicit requests for a refresh token;
* correct `issued_token_type` values;
* `token_type=Bearer` for OAuth access tokens;
* `token_type=N_A` for issued refresh tokens;
* use of the refresh token returned in the `access_token` response parameter with the refresh token grant;
* rejection of unsupported requested token types;
* failure when a refresh token is requested but cannot be issued;
* existing audience, scope, impersonation and `act` claim behavior.

## References

[RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693) — OAuth 2.0 Token Exchange, in particular sections 2.1 and 2.2.1.
