### PR TITLE
Preserve external authn info after MFA

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/authn/multi_factor_authentication/MultiFactorTotpCheckProvider.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/authn/multi_factor_authentication/MultiFactorTotpCheckProvider.java
@@ -97,17 +97,20 @@ public class MultiFactorTotpCheckProvider implements AuthenticationProvider {
     Object principal;
     Object credentials;
     Set<GrantedAuthority> authorities;
+    AbstractExternalAuthenticationToken<?> externalAuthentication = null;
 
     if (authentication instanceof ExtendedAuthenticationToken token) {
       refs = token.getAuthenticationMethodReferences();
       principal = token.getPrincipal();
       credentials = token.getCredentials();
       authorities = token.getFullyAuthenticatedAuthorities();
+      externalAuthentication = token.getExternalAuthentication();
     } else if (authentication instanceof AbstractExternalAuthenticationToken<?> token) {
       refs = token.getAuthenticationMethodReferences();
       principal = token.getPrincipal();
       credentials = token.getCredentials();
       authorities = token.getFullyAuthenticatedAuthorities();
+      externalAuthentication = token;
     } else {
       throw new IllegalArgumentException(
           "Unsupported authentication type: " + authentication.getClass());
@@ -119,6 +122,7 @@ public class MultiFactorTotpCheckProvider implements AuthenticationProvider {
         new ExtendedAuthenticationToken(principal, credentials, authorities);
     newToken.setAuthenticationMethodReferences(refs);
     newToken.setAuthenticated(true);
+    newToken.setExternalAuthentication(externalAuthentication);
 
     return newToken;
   }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/ExtendedAuthenticationToken.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/ExtendedAuthenticationToken.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 
+import it.infn.mw.iam.authn.AbstractExternalAuthenticationToken;
 import it.infn.mw.iam.authn.multi_factor_authentication.IamAuthenticationMethodReference;
 
 /**
@@ -53,6 +54,7 @@ public class ExtendedAuthenticationToken extends AbstractAuthenticationToken {
   private String totp;
   private Set<GrantedAuthority> fullyAuthenticatedAuthorities;
   private boolean preAuthenticated;
+  private AbstractExternalAuthenticationToken<?> externalAuthentication;
 
   public ExtendedAuthenticationToken(Object principal, Object credentials) {
     super(null);
@@ -109,6 +111,15 @@ public class ExtendedAuthenticationToken extends AbstractAuthenticationToken {
 
   public void setPreAuthenticated(boolean preAuthenticated) {
     this.preAuthenticated = preAuthenticated;
+  }
+
+  public AbstractExternalAuthenticationToken<?> getExternalAuthentication() {
+    return externalAuthentication;
+  }
+
+  public void setExternalAuthentication(
+      AbstractExternalAuthenticationToken<?> externalAuthentication) {
+    this.externalAuthentication = externalAuthentication;
   }
 
   @Override

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/IamAuthenticationHolderService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/IamAuthenticationHolderService.java
@@ -49,8 +49,17 @@ public class IamAuthenticationHolderService {
     Authentication userAuthentication = authn.getUserAuthentication();
     if (userAuthentication != null) {
       SavedUserAuthentication userAuth = new SavedUserAuthentication(userAuthentication);
+      AbstractExternalAuthenticationToken<?> externalToken = null;
+
       if (userAuthentication instanceof AbstractExternalAuthenticationToken<?> token) {
-        Map<String, String> info = token.buildAuthnInfoMap(mapBuilder);
+        externalToken = token;
+      } else if (userAuthentication instanceof ExtendedAuthenticationToken token) {
+        externalToken = token.getExternalAuthentication();
+      }
+      if (externalToken != null) {
+        userAuth.setSourceClass(externalToken.getClass().getName());
+
+        Map<String, String> info = externalToken.buildAuthnInfoMap(mapBuilder);
         userAuth.getAdditionalInfo().putAll(info);
       }
       holder.setUserAuth(userAuth);
@@ -62,7 +71,8 @@ public class IamAuthenticationHolderService {
     return repo.save(authHolder);
   }
 
-  public AuthenticationHolderEntity createAndSave(OAuth2Authentication authn, ClientDetailsEntity client) {
+  public AuthenticationHolderEntity createAndSave(OAuth2Authentication authn,
+      ClientDetailsEntity client) {
     return save(create(authn, client));
   }
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/core/IamAuthenticationHolderServiceTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/core/IamAuthenticationHolderServiceTests.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Request;
+
+import it.infn.mw.iam.authn.ExternalAuthenticationInfoBuilder;
+import it.infn.mw.iam.authn.oidc.OIDCAuthenticationToken;
+import it.infn.mw.iam.authn.oidc.OidcExternalAuthenticationToken;
+import it.infn.mw.iam.core.ExtendedAuthenticationToken;
+import it.infn.mw.iam.core.IamAuthenticationHolderService;
+import it.infn.mw.iam.persistence.model.AuthenticationHolderEntity;
+import it.infn.mw.iam.persistence.model.ClientDetailsEntity;
+import it.infn.mw.iam.persistence.model.SavedUserAuthentication;
+import it.infn.mw.iam.persistence.repository.IamAuthenticationHolderRepository;
+
+@SuppressWarnings("deprecation")
+@ExtendWith(MockitoExtension.class)
+public class IamAuthenticationHolderServiceTests {
+
+  @InjectMocks
+  private IamAuthenticationHolderService authnHolderService;
+
+  @Mock
+  private ExternalAuthenticationInfoBuilder mapBuilder;
+
+  @Mock
+  private ClientDetailsEntity client;
+
+  @Mock
+  private IamAuthenticationHolderRepository repo;
+
+  @Test
+  void shouldPreserveExternalAuthenticationAndAarcInfoAfterMfa() {
+    String username = "test-user";
+    String homeOrganization = "example.org";
+    String externalAffiliation = "researcher@example.org";
+
+    Map<String, String> aarcInfo =
+        Map.of("urn:oid:1.3.6.1.4.1.25178.1.2.9", homeOrganization, "EPSA", externalAffiliation);
+
+    OIDCAuthenticationToken oidcToken = mock(OIDCAuthenticationToken.class);
+
+    OidcExternalAuthenticationToken externalToken =
+        new OidcExternalAuthenticationToken(oidcToken, username, "credentials");
+
+    when(externalToken.buildAuthnInfoMap(mapBuilder)).thenReturn(aarcInfo);
+
+    // Authentication returned after MFA
+    ExtendedAuthenticationToken mfaToken = new ExtendedAuthenticationToken(username, "credentials",
+        Set.of(new SimpleGrantedAuthority("ROLE_USER")));
+
+    mfaToken.setAuthenticated(true);
+    mfaToken.setExternalAuthentication(externalToken);
+
+    OAuth2Request o2Request = mock(OAuth2Request.class);
+    when(o2Request.getAuthorities()).thenReturn(Collections.emptySet());
+
+    OAuth2Authentication oauth2Authentication = new OAuth2Authentication(o2Request, mfaToken);
+
+    AuthenticationHolderEntity holder = authnHolderService.create(oauth2Authentication, client);
+
+    SavedUserAuthentication saved = holder.getUserAuth();
+
+    assertThat(saved).isNotNull();
+    assertThat(saved.getSourceClass()).isEqualTo(OidcExternalAuthenticationToken.class.getName());
+    assertThat(saved.getAdditionalInfo()).containsEntry("urn:oid:1.3.6.1.4.1.25178.1.2.9",
+        homeOrganization);
+    assertThat(saved.getAdditionalInfo()).containsEntry("EPSA", externalAffiliation);
+  }
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/core/IamAuthenticationHolderServiceTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/core/IamAuthenticationHolderServiceTests.java
@@ -44,7 +44,7 @@ import it.infn.mw.iam.persistence.repository.IamAuthenticationHolderRepository;
 
 @SuppressWarnings("deprecation")
 @ExtendWith(MockitoExtension.class)
-public class IamAuthenticationHolderServiceTests {
+class IamAuthenticationHolderServiceTests {
 
   @InjectMocks
   private IamAuthenticationHolderService authnHolderService;

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/multi_factor_authentication/MultiFactorTotpCheckProviderTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/multi_factor_authentication/MultiFactorTotpCheckProviderTests.java
@@ -15,14 +15,18 @@
  */
 package it.infn.mw.iam.test.multi_factor_authentication;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.time.Clock;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,8 +35,12 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import it.infn.mw.iam.api.account.multi_factor_authentication.IamTotpMfaService;
+import it.infn.mw.iam.authn.multi_factor_authentication.IamAuthenticationMethodReference;
 import it.infn.mw.iam.authn.multi_factor_authentication.MultiFactorTotpCheckProvider;
 import it.infn.mw.iam.authn.oidc.OidcExternalAuthenticationToken;
 import it.infn.mw.iam.authn.saml.SamlExternalAuthenticationToken;
@@ -143,5 +151,51 @@ class MultiFactorTotpCheckProviderTests extends IamTotpMfaServiceTestSupport {
     when(totpMfaService.verifyTotp(account, "123456")).thenReturn(true);
 
     assertNotNull(multiFactorTotpCheckProvider.authenticate(samlToken));
+  }
+
+  @Test
+  void preserveExternalAuthnAfterMfa() {
+    OidcExternalAuthenticationToken externalToken = mock(OidcExternalAuthenticationToken.class);
+
+    Set<IamAuthenticationMethodReference> refs = new HashSet<>();
+    Set<GrantedAuthority> authorities = Set.of(new SimpleGrantedAuthority("ROLE_USER"));
+
+    when(externalToken.getTotp()).thenReturn("123456");
+    when(externalToken.getAuthenticationMethodReferences()).thenReturn(refs);
+    when(externalToken.getFullyAuthenticatedAuthorities()).thenReturn(new HashSet<>(authorities));
+    when(externalToken.getName()).thenReturn("test-user");
+    when(externalToken.getPrincipal()).thenReturn("test-user");
+    when(externalToken.getCredentials()).thenReturn("credentials");
+
+    IamAccount account = getAccount(clock.instant());
+    when(accountRepo.findByUsername("test-user")).thenReturn(Optional.of(account));
+    when(totpMfaService.verifyTotp(account, "123456")).thenReturn(true);
+
+    Authentication result = multiFactorTotpCheckProvider.authenticate(externalToken);
+    assertThat(result).isInstanceOf(ExtendedAuthenticationToken.class);
+
+    ExtendedAuthenticationToken extended = (ExtendedAuthenticationToken) result;
+    assertThat(extended.getExternalAuthentication()).isSameAs(externalToken);
+  }
+
+  @Test
+  void externalAuthnIsNullWhenLocalUserWithMfa() {
+    Set<GrantedAuthority> authorities = Set.of(new SimpleGrantedAuthority("ROLE_USER"));
+
+    ExtendedAuthenticationToken authentication =
+        new ExtendedAuthenticationToken("test-user", "credentials", authorities);
+
+    authentication.setTotp("123456");
+    authentication.setFullyAuthenticatedAuthorities(authorities);
+
+    IamAccount account = getAccount(clock.instant());
+    when(accountRepo.findByUsername("test-user")).thenReturn(Optional.of(account));
+    when(totpMfaService.verifyTotp(account, "123456")).thenReturn(true);
+
+    Authentication result = multiFactorTotpCheckProvider.authenticate(authentication);
+    assertThat(result).isInstanceOf(ExtendedAuthenticationToken.class);
+
+    ExtendedAuthenticationToken extended = (ExtendedAuthenticationToken) result;
+    assertThat(extended.getExternalAuthentication()).isNull();
   }
 }


### PR DESCRIPTION
## Description

When an external OIDC/SAML authentication is followed by MFA, the resulting `ExtendedAuthenticationToken` was losing the original external authentication information.

As a consequence, when the authentication was persisted in `saved_user_auth`, the external authentication source was no longer available and AARC claims such as `SCHAC_HOME_ORGANIZATION` and `VOPERSON_EXTERNAL_AFFILIATION` could not be resolved.

## Changes

- Preserve the original external authentication in `ExtendedAuthenticationToken`
- Propagate the external authentication when completing MFA
- Use the preserved external authentication when creating `SavedUserAuthentication`, including its source class and authentication information
- Add tests