### PR TITLE
Evaluate scope policies also based on clientId

### DIFF
--- a/compose/opa-integration/README.md
+++ b/compose/opa-integration/README.md
@@ -54,7 +54,7 @@ $ docker compose up -d nginx
 
 (restart `nginx` in case the `iam-be` health check takes long).
 
-Now, if you login trough iam-test-client at https://iam.local.io/iam_test_client with the Admin user you should see that the `offline_access` scope is filtered by OPA, while if you login with the Test user you will have the `email` scope filtered. Cross-check also the `iam-be` and `opa` logs to properly understand which scope is filtered.
+Now, if you login trough iam-test-client at https://iam.local.io/iam_test_client with the Admin user you should see that the `offline_access` and `phone` scopes are filtered by OPA; if you login with the Test user you will have the `email` and `phone` scopes filtered; if you login with the Test-100 user (test_100/password) only the `phone` scope is filtered, due to a DENY policy applied to iam-test-client. Cross-check also the `iam-be` and `opa` logs to properly understand which scope is filtered.
 
 ### Using an IDE (debug)
 
@@ -66,7 +66,7 @@ Run the docker compose which enables OPA running on http://localhost:8181 with
 $ docker compose up -d opa-dev
 ```
 
-Now, if you login trough iam-test-client with the Admin user you should see that the `offline_access` scope is filtered by OPA, while if you login with the Test user you will have the `email` scope filtered.
+Now, if you login trough iam-test-client at https://iam.local.io/iam_test_client with the Admin user you should see that the `offline_access` and `phone` scopes are filtered by OPA; if you login with the Test user you will have the `email` and `phone` scopes filtered; if you login with the Test-100 user (test_100/password) only the `phone` scope is filtered, due to a DENY policy applied to iam-test-client.
 
 Here you can also test that if the OPA server is not available, a fallback to the IAM Scope policy engine is applied. Please shut down the docker compose
 

--- a/compose/opa-integration/docker-compose.yml
+++ b/compose/opa-integration/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       IAM_CLIENT_FORWARD_HEADERS_STRATEGY: native
       IAM_CLIENT_TLS_USE_GRID_TRUST_ANCHORS: "true"
       IAM_CLIENT_ISSUER: https://iam.local.io/
-      IAM_CLIENT_SCOPES: openid profile email offline_access
+      IAM_CLIENT_SCOPES: openid profile email offline_access phone
       IAM_CLIENT_HIDE_TOKENS: false
 
     volumes:

--- a/compose/opa-integration/opa/policies/data.json
+++ b/compose/opa-integration/opa/policies/data.json
@@ -16,14 +16,27 @@
         {
             "actor": {
                 "id": "80e5fb8d-b7c8-451a-89ba-346ae278a66f",
-                "name": "Test Client",
+                "name": "Test User",
                 "type": "account"
             },
-            "description": "Deny email scope to Test Usert",
+            "description": "Deny email scope to Test User",
             "matchingPolicy": "EQ",
             "rule": "DENY",
             "scopes": [
                 "email"
+            ]
+        },
+        {
+            "actor": {
+                "id": "client",
+                "name": "Test Client",
+                "type": "client"
+            },
+            "description": "Deny phone scope to Test Client",
+            "matchingPolicy": "EQ",
+            "rule": "DENY",
+            "scopes": [
+                "phone"
             ]
         }
     ]

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/TokenUtils.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/TokenUtils.java
@@ -112,7 +112,7 @@ public class TokenUtils {
       .stream()
       .map(a -> new SimpleGrantedAuthority(a.getAuthority()))
       .collect(Collectors.toSet());
-    Set<String> scopes = scopeFilter.filterScopes(token.scopes(), account);
+    Set<String> scopes = scopeFilter.filterScopes(token.scopes(), account, token.clientId() );
     Authentication userAuthentication = buildAuthenticateUser(account, authorities);
     return getUserAuthentication(token.clientId(), scopes, authorities, token.audiences(),
         userAuthentication);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/as/IamAuthorizationServerTokenServices.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/as/IamAuthorizationServerTokenServices.java
@@ -577,7 +577,8 @@ public class IamAuthorizationServerTokenServices implements AuthorizationServerT
     }
 
     if (account.isPresent()) {
-      return scopeFilter.filterScopes(scopesToFilter, account.get());
+      return scopeFilter.filterScopes(scopesToFilter, account.get(),
+          authHolder.getClient().getClientId());
     }
     return scopeFilter.filterScopes(authHolder).getScope();
   }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/AuthorizationRequestBuilder.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/AuthorizationRequestBuilder.java
@@ -63,7 +63,8 @@ public class AuthorizationRequestBuilder {
     this.requestObjectProcessor = requestObjectProcessor;
   }
 
-  void filterRequestedScopes(Map<String, String> inputParams, Authentication authn) {
+  void filterRequestedScopes(Map<String, String> inputParams, Authentication authn,
+      AuthorizationRequest authzRequest) {
     if (authn == null || authn instanceof AnonymousAuthenticationToken) {
       return;
     }
@@ -73,7 +74,7 @@ public class AuthorizationRequestBuilder {
 
     // scopes are filtered also here to avoid authorizing them on the consent page
     inputParams.put(OAuth2Utils.SCOPE,
-        joiner.join(scopeFilter.filterScopes(requestedScopes, authn)));
+        joiner.join(scopeFilter.filterScopes(requestedScopes, authn, authzRequest.getClientId())));
   }
 
   AuthorizationRequest build(Map<String, String> inputParams) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/AuthorizationRequestBuilder.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/AuthorizationRequestBuilder.java
@@ -64,7 +64,7 @@ public class AuthorizationRequestBuilder {
   }
 
   void filterRequestedScopes(Map<String, String> inputParams, Authentication authn,
-      AuthorizationRequest authzRequest) {
+      String clientId) {
     if (authn == null || authn instanceof AnonymousAuthenticationToken) {
       return;
     }
@@ -74,7 +74,7 @@ public class AuthorizationRequestBuilder {
 
     // scopes are filtered also here to avoid authorizing them on the consent page
     inputParams.put(OAuth2Utils.SCOPE,
-        joiner.join(scopeFilter.filterScopes(requestedScopes, authn, authzRequest.getClientId())));
+        joiner.join(scopeFilter.filterScopes(requestedScopes, authn, clientId)));
   }
 
   AuthorizationRequest build(Map<String, String> inputParams) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/IamDeviceEndpointController.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/IamDeviceEndpointController.java
@@ -195,8 +195,8 @@ public class IamDeviceEndpointController {
 
     model.put("client", client);
 
-    Set<String> sortedAndFilteredScopes = userApprovalUtils.sortScopes(
-        scopeService.fromStrings(scopeFilter.filterScopes(authorizationRequest.getScope(), authn)));
+    Set<String> sortedAndFilteredScopes = userApprovalUtils.sortScopes(scopeService.fromStrings(
+        scopeFilter.filterScopes(authorizationRequest.getScope(), authn, client.getClientId())));
     dc.get().setScope(sortedAndFilteredScopes);
     deviceCodeRepository.save(dc.get());
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/IamOAuth2RequestFactory.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/IamOAuth2RequestFactory.java
@@ -88,11 +88,10 @@ public class IamOAuth2RequestFactory extends DefaultOAuth2RequestFactory {
   public AuthorizationRequest createAuthorizationRequest(Map<String, String> inputParams) {
 
     Authentication authn = SecurityContextHolder.getContext().getAuthentication();
-
-    authorizationRequestBuilder.filterRequestedScopes(inputParams, authn);
-    audienceRequestValidator.validateAndUpdateAudienceRequest(inputParams);
-
     AuthorizationRequest authzRequest = authorizationRequestBuilder.build(inputParams);
+
+    authorizationRequestBuilder.filterRequestedScopes(inputParams, authn, authzRequest);
+    audienceRequestValidator.validateAndUpdateAudienceRequest(inputParams);
 
     authorizationRequestBuilder.addExtensions(inputParams, authzRequest);
     authorizationRequestBuilder.applyClientDefaults(authzRequest);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/IamOAuth2RequestFactory.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/IamOAuth2RequestFactory.java
@@ -88,10 +88,12 @@ public class IamOAuth2RequestFactory extends DefaultOAuth2RequestFactory {
   public AuthorizationRequest createAuthorizationRequest(Map<String, String> inputParams) {
 
     Authentication authn = SecurityContextHolder.getContext().getAuthentication();
-    AuthorizationRequest authzRequest = authorizationRequestBuilder.build(inputParams);
 
-    authorizationRequestBuilder.filterRequestedScopes(inputParams, authn, authzRequest);
+    authorizationRequestBuilder.filterRequestedScopes(inputParams, authn,
+        inputParams.get(OAuth2Utils.CLIENT_ID));
     audienceRequestValidator.validateAndUpdateAudienceRequest(inputParams);
+
+    AuthorizationRequest authzRequest = authorizationRequestBuilder.build(inputParams);
 
     authorizationRequestBuilder.addExtensions(inputParams, authzRequest);
     authorizationRequestBuilder.applyClientDefaults(authzRequest);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/common/BaseAccessTokenBuilder.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/common/BaseAccessTokenBuilder.java
@@ -163,7 +163,8 @@ public abstract class BaseAccessTokenBuilder implements AccessTokenBuilder {
 
     /* update token scopes filtering the requested ones */
     Set<String> requestedScopes = getRequestedScopes(token, authentication);
-    token.setScope(scopeFilter.filterScopes(requestedScopes, authentication));
+    token.setScope(
+        scopeFilter.filterScopes(requestedScopes, authentication, token.getClient().getClientId()));
 
     /* include scope claim if configured */
     if (isIncludeScope() && !token.getScope().isEmpty()) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/pdp/DefaultScopeFilter.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/pdp/DefaultScopeFilter.java
@@ -50,22 +50,24 @@ public class DefaultScopeFilter implements ScopeFilter {
   }
 
   @Override
-  public Set<String> filterScopes(Set<String> requestedScopes, Authentication authn) {
+  public Set<String> filterScopes(Set<String> requestedScopes, Authentication authn,
+      String clientId) {
     Optional<IamAccount> account = accountUtils.getAuthenticatedUserAccount(authn);
     if (account.isEmpty()) {
       return requestedScopes;
     }
-    return filterScopes(requestedScopes, account.get());
+    return filterScopes(requestedScopes, account.get(), clientId);
   }
 
   @Override
-  public Set<String> filterScopes(Set<String> requestedScopes, IamAccount account) {
+  public Set<String> filterScopes(Set<String> requestedScopes, IamAccount account,
+      String clientId) {
     Set<String> filteredScopes = new HashSet<>();
     filteredScopes.addAll(requestedScopes);
 
     filteredScopes.retainAll(adminPolicies(requestedScopes, account));
     if (config.isEnableScopeAuthz()) {
-      filteredScopes.retainAll(policyEngine.apply(filteredScopes, account));
+      filteredScopes.retainAll(policyEngine.apply(filteredScopes, account, clientId));
     }
     filteredScopes.addAll(excludedScopes(requestedScopes));
     return filteredScopes;
@@ -88,7 +90,8 @@ public class DefaultScopeFilter implements ScopeFilter {
   }
 
   public AuthenticationHolderEntity filterScopes(AuthenticationHolderEntity authHolder) {
-    authHolder.setScope(filterScopes(authHolder.getScope(), authHolder.getAuthentication()));
+    authHolder.setScope(filterScopes(authHolder.getScope(), authHolder.getAuthentication(),
+        authHolder.getClient().getClientId()));
     return authHolder;
   }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/pdp/DefaultScopePolicyEngine.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/pdp/DefaultScopePolicyEngine.java
@@ -33,7 +33,8 @@ import it.infn.mw.iam.persistence.repository.IamScopePolicyRepository;
 
 public class DefaultScopePolicyEngine implements ScopePolicyEngine {
   public static final Logger LOG = LoggerFactory.getLogger(DefaultScopePolicyEngine.class);
-  private Cache<String, ScopeMatcher> matchersCache = CacheBuilder.newBuilder().maximumSize(30).build();
+  private Cache<String, ScopeMatcher> matchersCache =
+      CacheBuilder.newBuilder().maximumSize(30).build();
   private final IamScopePolicyRepository policyRepo;
 
   public DefaultScopePolicyEngine(IamScopePolicyRepository policyRepo) {
@@ -41,7 +42,11 @@ public class DefaultScopePolicyEngine implements ScopePolicyEngine {
   }
 
   @Override
-  public Set<String> apply(Set<String> requestedScopes, IamAccount account) {
+  public Set<String> apply(Set<String> requestedScopes, IamAccount account, String clientId) {
+    return apply(requestedScopes, account);
+  }
+
+  private Set<String> apply(Set<String> requestedScopes, IamAccount account) {
     DecisionContext dc = new DecisionContext(matchersCache, requestedScopes);
 
     for (IamScopePolicy p : account.getScopePolicies()) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/pdp/DefaultScopePolicyEngine.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/pdp/DefaultScopePolicyEngine.java
@@ -44,7 +44,6 @@ public class DefaultScopePolicyEngine implements ScopePolicyEngine {
   public Set<String> apply(Set<String> requestedScopes, IamAccount account) {
     DecisionContext dc = new DecisionContext(matchersCache, requestedScopes);
 
-    // Apply user policies
     for (IamScopePolicy p : account.getScopePolicies()) {
       dc.applyPolicy(p, account);
     }
@@ -60,7 +59,6 @@ public class DefaultScopePolicyEngine implements ScopePolicyEngine {
     // Apply group policies only on unprocessed scopes
     dc.forgetProcessedEntries();
 
-    // Group policies are naturally composed with the deny overrides behavior
     for (IamScopePolicy p : groupPolicies) {
       dc.applyPolicy(p, account);
     }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/pdp/OpaRequest.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/pdp/OpaRequest.java
@@ -17,7 +17,15 @@ package it.infn.mw.iam.core.oauth.scope.pdp;
 
 import java.util.Set;
 
-public record OpaRequest(User user, Set<String> scopes) {
-  public record User(String id, Set<String> groups) {}
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+public record OpaRequest(User user, @JsonInclude(JsonInclude.Include.NON_NULL) Client client,
+    Set<String> scopes) {
+
+  public record User(String id, Set<String> groups) {
+  }
+
+  public record Client(String id) {
+  }
 
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/pdp/OpaRequest.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/pdp/OpaRequest.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 public record OpaRequest(User user, @JsonInclude(JsonInclude.Include.NON_NULL) Client client,
     Set<String> scopes) {
 
-  public record User(String id, Set<String> groups) {
+  public record User(String id, @JsonInclude(JsonInclude.Include.NON_EMPTY) Set<String> groups) {
   }
 
   public record Client(String id) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/pdp/OpaScopePolicyEngine.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/pdp/OpaScopePolicyEngine.java
@@ -29,6 +29,7 @@ import org.springframework.web.client.RestTemplate;
 
 import it.infn.mw.iam.authn.oidc.RestTemplateFactory;
 import it.infn.mw.iam.config.IamProperties.OpaProperties;
+import it.infn.mw.iam.core.oauth.scope.pdp.OpaRequest.Client;
 import it.infn.mw.iam.core.oauth.scope.pdp.OpaRequest.User;
 import it.infn.mw.iam.persistence.model.IamAccount;
 import it.infn.mw.iam.persistence.repository.IamScopePolicyRepository;
@@ -47,18 +48,19 @@ public class OpaScopePolicyEngine extends DefaultScopePolicyEngine {
   }
 
   @Override
-  public Set<String> apply(Set<String> requestedScopes, IamAccount account) {
+  public Set<String> apply(Set<String> requestedScopes, IamAccount account, String clientId) {
 
     Set<String> userGroups =
         account.getGroups().stream().map(ag -> ag.getGroup().getName()).collect(Collectors.toSet());
     OpaRequest request =
-        new OpaRequest(new User(account.getUuid(), userGroups), requestedScopes);
+        new OpaRequest(new User(account.getUuid(), userGroups),
+            new Client(clientId), requestedScopes);
 
     Optional<OpaResponse> response = evaluatePolicy(request);
     if (response.isPresent()) {
       return response.get().filtered_scopes();
     } else {
-      return super.apply(requestedScopes, account);
+      return super.apply(requestedScopes, account, clientId);
     }
   }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/pdp/OpaScopePolicyEngine.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/pdp/OpaScopePolicyEngine.java
@@ -29,6 +29,7 @@ import org.springframework.web.client.RestTemplate;
 
 import it.infn.mw.iam.authn.oidc.RestTemplateFactory;
 import it.infn.mw.iam.config.IamProperties.OpaProperties;
+import it.infn.mw.iam.core.oauth.scope.pdp.OpaRequest.User;
 import it.infn.mw.iam.persistence.model.IamAccount;
 import it.infn.mw.iam.persistence.repository.IamScopePolicyRepository;
 
@@ -50,8 +51,8 @@ public class OpaScopePolicyEngine extends DefaultScopePolicyEngine {
 
     Set<String> userGroups =
         account.getGroups().stream().map(ag -> ag.getGroup().getName()).collect(Collectors.toSet());
-    OpaRequest.User user = new OpaRequest.User(account.getUuid(), userGroups);
-    OpaRequest request = new OpaRequest(user, requestedScopes);
+    OpaRequest request =
+        new OpaRequest(new User(account.getUuid(), userGroups), requestedScopes);
 
     Optional<OpaResponse> response = evaluatePolicy(request);
     if (response.isPresent()) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/pdp/ScopeFilter.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/pdp/ScopeFilter.java
@@ -25,9 +25,9 @@ import it.infn.mw.iam.persistence.model.IamAccount;
 @SuppressWarnings("deprecation")
 public interface ScopeFilter {
 
-  public Set<String> filterScopes(Set<String> scopes, Authentication authn);
+  public Set<String> filterScopes(Set<String> scopes, Authentication authn, String clientId);
 
-  public Set<String> filterScopes(Set<String> scopes, IamAccount account);
+  public Set<String> filterScopes(Set<String> scopes, IamAccount account, String clientId);
 
   public AuthenticationHolderEntity filterScopes(AuthenticationHolderEntity authHolder);
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/pdp/ScopeFilter.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/pdp/ScopeFilter.java
@@ -18,7 +18,6 @@ package it.infn.mw.iam.core.oauth.scope.pdp;
 import java.util.Set;
 
 import org.springframework.security.core.Authentication;
-import org.springframework.security.oauth2.provider.OAuth2Authentication;
 
 import it.infn.mw.iam.persistence.model.AuthenticationHolderEntity;
 import it.infn.mw.iam.persistence.model.IamAccount;

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/pdp/ScopePolicyEngine.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/scope/pdp/ScopePolicyEngine.java
@@ -20,5 +20,5 @@ import java.util.Set;
 import it.infn.mw.iam.persistence.model.IamAccount;
 
 public interface ScopePolicyEngine {
-    public Set<String> apply(Set<String> requestedScopes, IamAccount account);
+  public Set<String> apply(Set<String> requestedScopes, IamAccount account, String clientId);
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/scope/pdp/OPAScopePolicyEngineTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/scope/pdp/OPAScopePolicyEngineTests.java
@@ -38,6 +38,8 @@ import org.springframework.web.client.RestTemplate;
 import it.infn.mw.iam.authn.oidc.RestTemplateFactory;
 import it.infn.mw.iam.config.IamProperties.OpaProperties;
 import it.infn.mw.iam.core.oauth.scope.pdp.OpaRequest;
+import it.infn.mw.iam.core.oauth.scope.pdp.OpaRequest.Client;
+import it.infn.mw.iam.core.oauth.scope.pdp.OpaRequest.User;
 import it.infn.mw.iam.core.oauth.scope.pdp.OpaResponse;
 import it.infn.mw.iam.core.oauth.scope.pdp.OpaScopePolicyEngine;
 import it.infn.mw.iam.persistence.model.IamAccount;
@@ -82,7 +84,7 @@ class OPAScopePolicyEngineTests extends ScopePolicyTestUtils {
     when(restTemplateFactory.newRestTemplate()).thenReturn(restTemplate);
 
     engine = new OpaScopePolicyEngine(policyRepo, restTemplateFactory, opaProperties);
-    request = new OpaRequest(new OpaRequest.User("1234", Set.of("Analysis")),
+    request = new OpaRequest(new User("1234", Set.of("Analysis")), new Client(null),
         Set.of("openid", "profile", "email"));
   }
 
@@ -151,7 +153,7 @@ class OPAScopePolicyEngineTests extends ScopePolicyTestUtils {
     Set<String> requestedScopes = new HashSet<>(filteredScopes);
     requestedScopes.addAll(deniedScopes);
 
-    assertEquals(filteredScopes, engine.apply(requestedScopes, account));
+    assertEquals(filteredScopes, engine.apply(requestedScopes, account, CLIENT_ID));
   }
 
   @Test
@@ -168,7 +170,7 @@ class OPAScopePolicyEngineTests extends ScopePolicyTestUtils {
     up.getScopes().add(PROFILE);
     when(account.getScopePolicies()).thenReturn(Set.of(up));
 
-    assertEquals(Set.of(), engine.apply(Set.of("openid", "profile"), account));
+    assertEquals(Set.of(), engine.apply(Set.of("openid", "profile"), account, CLIENT_ID));
   }
 
   private void setupAccountGroupMembership(IamAccount account, IamGroup group,

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/scope/pdp/ScopePolicyPdpTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/scope/pdp/ScopePolicyPdpTests.java
@@ -83,13 +83,13 @@ class ScopePolicyPdpTests extends ScopePolicyTestUtils {
 
     IamAccount testAccount = findTestAccount();
     Set<String> filteredScopes =
-        pdp.filterScopes(Sets.newHashSet("openid", "profile", "scim:read"), testAccount);
+        pdp.filterScopes(Sets.newHashSet("openid", "profile", "scim:read"), testAccount, CLIENT_ID);
 
     assertThat(filteredScopes, hasSize(2));
     assertThat(filteredScopes, hasItems("openid", "profile"));
 
-    filteredScopes =
-        pdp.filterScopes(Sets.newHashSet("openid", "profile", "scim:write"), testAccount);
+    filteredScopes = pdp.filterScopes(Sets.newHashSet("openid", "profile", "scim:write"),
+        testAccount, CLIENT_ID);
 
     assertThat(filteredScopes, hasSize(2));
     assertThat(filteredScopes, hasItems("openid", "profile"));
@@ -105,8 +105,8 @@ class ScopePolicyPdpTests extends ScopePolicyTestUtils {
 
     policyScopeRepo.save(up);
 
-    Set<String> filteredScopes =
-        pdp.filterScopes(Sets.newHashSet("openid", "profile", "scim:write"), testAccount);
+    Set<String> filteredScopes = pdp
+      .filterScopes(Sets.newHashSet("openid", "profile", "scim:write"), testAccount, CLIENT_ID);
     assertThat(filteredScopes, hasSize(1));
     assertThat(filteredScopes, hasItems("openid"));
   }
@@ -124,7 +124,7 @@ class ScopePolicyPdpTests extends ScopePolicyTestUtils {
     policyScopeRepo.save(up);
 
     Set<String> filteredScopes =
-        pdp.filterScopes(Sets.newHashSet(OPENID, PROFILE, SCIM_WRITE), testAccount);
+        pdp.filterScopes(Sets.newHashSet(OPENID, PROFILE, SCIM_WRITE), testAccount, CLIENT_ID);
     assertThat(filteredScopes, hasSize(1));
     assertThat(filteredScopes, hasItem(OPENID));
 
@@ -145,8 +145,8 @@ class ScopePolicyPdpTests extends ScopePolicyTestUtils {
 
     policyScopeRepo.save(up);
 
-    Set<String> filteredScopes =
-        pdp.filterScopes(Sets.newHashSet("openid", "profile", "scim:write"), testAccount);
+    Set<String> filteredScopes = pdp
+      .filterScopes(Sets.newHashSet("openid", "profile", "scim:write"), testAccount, CLIENT_ID);
     assertThat(filteredScopes, hasSize(2));
     assertThat(filteredScopes, hasItems("openid", "profile"));
   }
@@ -168,7 +168,7 @@ class ScopePolicyPdpTests extends ScopePolicyTestUtils {
     policyScopeRepo.save(gp);
 
     Set<String> filteredScopes =
-        pdp.filterScopes(Sets.newHashSet("openid", "profile"), testAccount);
+        pdp.filterScopes(Sets.newHashSet("openid", "profile"), testAccount, CLIENT_ID);
 
     assertThat(filteredScopes, hasSize(2));
     assertThat(filteredScopes, hasItems("openid", "profile"));
@@ -195,8 +195,8 @@ class ScopePolicyPdpTests extends ScopePolicyTestUtils {
 
     policyScopeRepo.save(ap);
 
-    Set<String> filteredScopes = pdp
-      .filterScopes(Sets.newHashSet("openid", "profile", "scim:write", "scim:read"), testAccount);
+    Set<String> filteredScopes = pdp.filterScopes(
+        Sets.newHashSet("openid", "profile", "scim:write", "scim:read"), testAccount, CLIENT_ID);
 
     assertThat(filteredScopes, hasSize(2));
     assertThat(filteredScopes, hasItems("openid", "profile"));
@@ -224,8 +224,8 @@ class ScopePolicyPdpTests extends ScopePolicyTestUtils {
     up.setDescription(secondGroup.getName());
     policyScopeRepo.save(up);
 
-    Set<String> filteredScopes =
-        pdp.filterScopes(Sets.newHashSet("openid", "profile", "scim:write"), testAccount);
+    Set<String> filteredScopes = pdp
+      .filterScopes(Sets.newHashSet("openid", "profile", "scim:write"), testAccount, CLIENT_ID);
     assertThat(filteredScopes, hasSize(2));
     assertThat(filteredScopes, hasItems("openid", "profile"));
   }
@@ -252,8 +252,8 @@ class ScopePolicyPdpTests extends ScopePolicyTestUtils {
     up.setDescription(secondGroup.getName());
     policyScopeRepo.save(up);
 
-    Set<String> filteredScopes =
-        pdp.filterScopes(Sets.newHashSet("openid", "profile", "scim:write"), testAccount);
+    Set<String> filteredScopes = pdp
+      .filterScopes(Sets.newHashSet("openid", "profile", "scim:write"), testAccount, CLIENT_ID);
     assertThat(filteredScopes, hasSize(2));
     assertThat(filteredScopes, hasItems("openid", "profile"));
   }
@@ -271,8 +271,9 @@ class ScopePolicyPdpTests extends ScopePolicyTestUtils {
 
     policyScopeRepo.save(up);
 
-    Set<String> filteredScopes = pdp.filterScopes(
-        Sets.newHashSet("openid", "profile", "read:/", "write", "read:/sub/path"), testAccount);
+    Set<String> filteredScopes =
+        pdp.filterScopes(Sets.newHashSet("openid", "profile", "read:/", "write", "read:/sub/path"),
+            testAccount, CLIENT_ID);
 
     assertThat(filteredScopes, hasSize(3));
     assertThat(filteredScopes, hasItems("openid", "profile", "write"));
@@ -290,8 +291,9 @@ class ScopePolicyPdpTests extends ScopePolicyTestUtils {
 
     policyScopeRepo.save(up);
 
-    Set<String> filteredScopes = pdp.filterScopes(
-        Sets.newHashSet("openid", "profile", "read:/", "write", "read:/sub/path"), testAccount);
+    Set<String> filteredScopes =
+        pdp.filterScopes(Sets.newHashSet("openid", "profile", "read:/", "write", "read:/sub/path"),
+            testAccount, CLIENT_ID);
 
     assertThat(filteredScopes, hasSize(5));
     assertThat(filteredScopes, hasItems("openid", "profile", "write", "read:/", "read:/sub/path"));
@@ -315,8 +317,9 @@ class ScopePolicyPdpTests extends ScopePolicyTestUtils {
 
     policyScopeRepo.save(up);
 
-    Set<String> filteredScopes = pdp.filterScopes(Sets.newHashSet("openid", "profile",
-        "storage.write:/", "storage.write:/path", "storage.write:/path/sub"), testAccount);
+    Set<String> filteredScopes =
+        pdp.filterScopes(Sets.newHashSet("openid", "profile", "storage.write:/",
+            "storage.write:/path", "storage.write:/path/sub"), testAccount, CLIENT_ID);
 
     assertThat(filteredScopes, hasSize(4));
     assertThat(filteredScopes,

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/repository/ScopePolicyTestUtils.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/repository/ScopePolicyTestUtils.java
@@ -32,6 +32,7 @@ public class ScopePolicyTestUtils {
   public static final String OPENID = "openid";
   public static final String PROFILE = "profile";
   public static final String WHATEVER = "whatever";
+  public static final String CLIENT_ID = "1234";
 
   protected ScopePolicyDTO initPermitScopePolicyDTO() {
     ScopePolicyDTO dto = new ScopePolicyDTO();


### PR DESCRIPTION
This is basically supported by OPA, not the internal scope policy engine.

An example of the body sent to OPA (taken from the log) is

```bash
opa-dev-1  |       {
opa-dev-1  |         "client": {
opa-dev-1  |           "id": "6ab5c0ad-484d-4f3e-bcb2-d617cf0cef2e"
opa-dev-1  |         },
opa-dev-1  |         "scopes": [
opa-dev-1  |           "openid",
opa-dev-1  |           "offline_access",
opa-dev-1  |           "profile",
opa-dev-1  |           "email"
opa-dev-1  |         ],
opa-dev-1  |         "user": {
opa-dev-1  |           "groups": [
opa-dev-1  |             "Optional",
opa-dev-1  |             "Analysis",
opa-dev-1  |             "Production"
opa-dev-1  |           ],
opa-dev-1  |           "id": "73f16d93-2441-4a50-88ff-85360d78c6b5"
opa-dev-1  |         }
opa-dev-1  |       }
```