### PR TITLE
Include schac_home_organization claim in access token

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcAccessTokenBuilder.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcAccessTokenBuilder.java
@@ -46,7 +46,8 @@ public class AarcAccessTokenBuilder extends BaseAccessTokenBuilder {
     return Set.of(EMAIL, PREFERRED_USERNAME, ORGANISATION_NAME, ATTR,
         AarcExtraClaimNames.EDUPERSON_ASSURANCE, AarcExtraClaimNames.ENTITLEMENTS,
         AarcExtraClaimNames.EDUPERSON_ENTITLEMENT, AarcExtraClaimNames.EDUPERSON_SCOPED_AFFILIATION,
-        AarcExtraClaimNames.VOPERSON_ID, AarcExtraClaimNames.VOPERSON_EXTERNAL_AFFILIATION);
+        AarcExtraClaimNames.VOPERSON_ID, AarcExtraClaimNames.VOPERSON_EXTERNAL_AFFILIATION,
+        AarcExtraClaimNames.SCHAC_HOME_ORGANIZATION);
   }
 
   @Override


### PR DESCRIPTION
It was missing in the access token, even though it is not mandatory according to [AARC-G056 guideline](https://docs.google.com/document/d/1jO1X7GSXWf_R604j5LXinr37ZUf96YVdIXSvjpS_Vyk/edit?tab=t.0). The claim MUST be present in the userinfo and introspection responses, as it is already implemented.