### PR TITLE
Revise external_authn claim handling in OIDC tokens and UserInfo

### DIFF
--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcIdTokenCustomizer.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/aarc/AarcIdTokenCustomizer.java
@@ -24,13 +24,13 @@ import com.nimbusds.jwt.JWTClaimsSet.Builder;
 import it.infn.mw.iam.config.IamProperties;
 import it.infn.mw.iam.core.oauth.profile.ClaimValueHelper;
 import it.infn.mw.iam.core.oauth.profile.ScopeClaimTranslationService;
-import it.infn.mw.iam.core.oauth.profile.common.BaseIdTokenCustomizer;
+import it.infn.mw.iam.core.oauth.profile.iam.IamIdTokenCustomizer;
 import it.infn.mw.iam.persistence.model.ClientDetailsEntity;
 import it.infn.mw.iam.persistence.model.IamAccount;
 import it.infn.mw.iam.persistence.model.OAuth2AccessTokenEntity;
 
 @SuppressWarnings("deprecation")
-public class AarcIdTokenCustomizer extends BaseIdTokenCustomizer {
+public class AarcIdTokenCustomizer extends IamIdTokenCustomizer {
 
   public AarcIdTokenCustomizer(IamProperties properties, ClaimValueHelper claimValueHelper,
       ScopeClaimTranslationService scopeClaimTranslationService) {

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/common/BaseAccessTokenBuilder.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/common/BaseAccessTokenBuilder.java
@@ -153,9 +153,7 @@ public abstract class BaseAccessTokenBuilder implements AccessTokenBuilder {
       if (savedAuth.getAdditionalInfo().get(ACR) != null) {
         builder.claim(ACR, savedAuth.getAdditionalInfo().get(ACR));
       }
-      if (savedAuth.getSourceClass() != null && (savedAuth.getSourceClass()
-        .equals(SamlExternalAuthenticationToken.class.getName())
-          || savedAuth.getSourceClass().equals(OidcExternalAuthenticationToken.class.getName()))) {
+      if (isIncludeAuthnInfo() && isExternalAuthn(savedAuth)) {
         builder.claim(EXTERNAL_AUTHN,
             claimValueHelper.resolveClaim(EXTERNAL_AUTHN, authentication, account));
       }
@@ -185,6 +183,13 @@ public abstract class BaseAccessTokenBuilder implements AccessTokenBuilder {
     includeRequiredClaims(builder, authentication, account);
 
     return builder.build();
+  }
+
+  protected boolean isExternalAuthn(SavedUserAuthentication savedAuth) {
+    String sourceClass = savedAuth.getSourceClass();
+    return sourceClass != null
+        && (sourceClass.equals(SamlExternalAuthenticationToken.class.getName())
+            || sourceClass.equals(OidcExternalAuthenticationToken.class.getName()));
   }
 
   protected Set<String> getRequestedScopes(OAuth2AccessTokenEntity token,

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/common/BaseIdTokenCustomizer.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/common/BaseIdTokenCustomizer.java
@@ -61,7 +61,7 @@ public abstract class BaseIdTokenCustomizer implements IDTokenCustomizer {
     this.scopeClaimTranslationService = scopeClaimTranslationService;
   }
 
-  public IamProperties getIamProperties() {
+  public IamProperties getProperties() {
     return properties;
   }
 

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/common/BaseScopeClaimTranslationService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/common/BaseScopeClaimTranslationService.java
@@ -25,7 +25,7 @@ import com.google.common.collect.Sets;
 
 import it.infn.mw.iam.core.oauth.profile.ScopeClaimTranslationService;
 
-public class BaseScopeClaimTranslationService implements ScopeClaimTranslationService {
+public abstract class BaseScopeClaimTranslationService implements ScopeClaimTranslationService {
 
   @Override
   public Set<String> getClaimsForScope(String scope) {
@@ -60,5 +60,4 @@ public class BaseScopeClaimTranslationService implements ScopeClaimTranslationSe
       .flatMap(Set::stream)
       .collect(Collectors.toSet());
   }
-
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/iam/IamIdTokenCustomizer.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/iam/IamIdTokenCustomizer.java
@@ -19,10 +19,13 @@ import static it.infn.mw.iam.config.IamTokenEnhancerProperties.TokenContext.ID_T
 
 import java.util.Optional;
 
+import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.provider.OAuth2Request;
 
 import com.nimbusds.jwt.JWTClaimsSet.Builder;
 
+import it.infn.mw.iam.authn.oidc.OidcExternalAuthenticationToken;
+import it.infn.mw.iam.authn.saml.SamlExternalAuthenticationToken;
 import it.infn.mw.iam.config.IamProperties;
 import it.infn.mw.iam.config.IamTokenEnhancerProperties.IncludeLabelProperties;
 import it.infn.mw.iam.core.oauth.profile.ClaimValueHelper;
@@ -32,6 +35,7 @@ import it.infn.mw.iam.persistence.model.ClientDetailsEntity;
 import it.infn.mw.iam.persistence.model.IamAccount;
 import it.infn.mw.iam.persistence.model.IamLabel;
 import it.infn.mw.iam.persistence.model.OAuth2AccessTokenEntity;
+import it.infn.mw.iam.persistence.model.SavedUserAuthentication;
 
 @SuppressWarnings("deprecation")
 public class IamIdTokenCustomizer extends BaseIdTokenCustomizer {
@@ -43,7 +47,7 @@ public class IamIdTokenCustomizer extends BaseIdTokenCustomizer {
 
   protected final void includeLabelsInIdToken(Builder idClaims, IamAccount account) {
 
-    for (IncludeLabelProperties includeLabel : getIamProperties().getTokenEnhancer()
+    for (IncludeLabelProperties includeLabel : getProperties().getTokenEnhancer()
       .getIncludeLabels()) {
       if (includeLabel.getContext().contains(ID_TOKEN)) {
         Optional<IamLabel> label = account.getLabelByPrefixAndName(
@@ -63,5 +67,30 @@ public class IamIdTokenCustomizer extends BaseIdTokenCustomizer {
     super.customizeIdTokenClaims(idClaims, client, request, sub, accessToken, account);
 
     includeLabelsInIdToken(idClaims, account);
+    includeExternalAuthnInIdToken(idClaims, accessToken, account);
+  }
+
+  protected void includeExternalAuthnInIdToken(Builder idClaims,
+      OAuth2AccessTokenEntity accessToken, IamAccount account) {
+
+    Authentication oauth2auth =
+        accessToken.getAuthenticationHolder().getAuthentication().getUserAuthentication();
+
+    if (isExternalAuthn(oauth2auth)) {
+      idClaims.claim(IamExtraClaimNames.EXTERNAL_AUTHN,
+          getClaimValueHelper().resolveClaim(IamExtraClaimNames.EXTERNAL_AUTHN,
+              accessToken.getAuthenticationHolder().getAuthentication(), Optional.of(account)));
+    }
+  }
+
+  protected boolean isExternalAuthn(Authentication auth) {
+    if (auth instanceof SavedUserAuthentication savedAuth) {
+
+      String sourceClass = savedAuth.getSourceClass();
+      return sourceClass != null
+          && (sourceClass.equals(SamlExternalAuthenticationToken.class.getName())
+              || sourceClass.equals(OidcExternalAuthenticationToken.class.getName()));
+    }
+    return false;
   }
 }

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/iam/IamScopeClaimTranslationService.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/oauth/profile/iam/IamScopeClaimTranslationService.java
@@ -32,7 +32,6 @@ public class IamScopeClaimTranslationService extends BaseScopeClaimTranslationSe
       case OidcScopes.PROFILE:
         Set<String> claims = super.getClaimsForScope(scope);
         claims.add(IamExtraClaimNames.AFFILIATION);
-        claims.add(IamExtraClaimNames.EXTERNAL_AUTHN);
         claims.add(IamExtraClaimNames.GROUPS);
         claims.add(IamExtraClaimNames.LAST_LOGIN_AT);
         claims.add(IamExtraClaimNames.ORGANISATION_NAME);

--- a/iam-login-service/src/main/java/it/infn/mw/iam/core/userinfo/IamUserInfoEndpoint.java
+++ b/iam-login-service/src/main/java/it/infn/mw/iam/core/userinfo/IamUserInfoEndpoint.java
@@ -28,7 +28,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
-import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationDetails;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -36,8 +35,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import it.infn.mw.iam.api.common.ErrorDTO;
 import it.infn.mw.iam.audit.events.tokens.UserInfoEvent;
-import it.infn.mw.iam.core.ParsedAccessToken;
-import it.infn.mw.iam.core.TokenUtils;
 import it.infn.mw.iam.core.oauth.profile.JWTProfile;
 import it.infn.mw.iam.core.oauth.profile.JWTProfileResolver;
 import it.infn.mw.iam.persistence.model.ClientDetailsEntity;
@@ -57,18 +54,15 @@ public class IamUserInfoEndpoint {
   private final OAuth2AuthenticationScopeResolver scopeResolver;
   private final IamAccountRepository accountRepo;
   private final IamClientRepository clientRepo;
-  private final TokenUtils tokenUtils;
   private final ApplicationEventPublisher eventPublisher;
 
   public IamUserInfoEndpoint(JWTProfileResolver profileResolver,
       OAuth2AuthenticationScopeResolver scopeResolver, IamAccountRepository accountRepo,
-      IamClientRepository clientRepo, TokenUtils tokenUtils,
-      ApplicationEventPublisher eventPublisher) {
+      IamClientRepository clientRepo, ApplicationEventPublisher eventPublisher) {
     this.profileResolver = profileResolver;
     this.scopeResolver = scopeResolver;
     this.accountRepo = accountRepo;
     this.clientRepo = clientRepo;
-    this.tokenUtils = tokenUtils;
     this.eventPublisher = eventPublisher;
   }
 
@@ -91,21 +85,9 @@ public class IamUserInfoEndpoint {
     Map<String, Object> claims =
         profile.getUserinfoHelper().resolveScopeClaims(scopes, account, auth);
 
-    addExternalAuthN(auth, claims);
     UserInfoResponse response = new UserInfoResponse(claims);
     eventPublisher.publishEvent(new UserInfoEvent(this, clientId, response));
     return response;
-  }
-
-  private void addExternalAuthN(OAuth2Authentication auth, Map<String, Object> claims) {
-
-    if (auth.getDetails() instanceof OAuth2AuthenticationDetails details
-        && details.getTokenValue() != null) {
-      ParsedAccessToken parsedToken = tokenUtils.parseAccessToken(details.getTokenValue());
-      if (parsedToken.external() != null) {
-        claims.put("external_authn", parsedToken.external());
-      }
-    }
   }
 
   @ResponseStatus(value = HttpStatus.BAD_REQUEST)

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/core/IamCoreControllerTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/core/IamCoreControllerTests.java
@@ -15,7 +15,6 @@
  */
 package it.infn.mw.iam.test.core;
 
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.unauthenticated;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -41,7 +40,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import it.infn.mw.iam.IamLoginService;
-import it.infn.mw.iam.authn.ExternalAuthenticationRegistrationInfo.ExternalAuthenticationType;
 import it.infn.mw.iam.test.scim.ScimRestUtilsMvc;
 import it.infn.mw.iam.test.util.WithMockOAuthUser;
 import it.infn.mw.iam.test.util.WithMockOIDCUser;
@@ -161,19 +159,6 @@ class IamCoreControllerTests {
   void userinfoReturns404ForUserNotFound() throws Exception {
 
     mvc.perform(get("/userinfo")).andDo(print()).andExpect(status().isBadRequest());
-  }
-
-
-  @Test
-  @WithMockOAuthUser(scopes = {"openid", "profile", "email"}, user = "test",
-      authorities = {"ROLE_USER"}, externallyAuthenticated = true,
-      externalAuthenticationType = ExternalAuthenticationType.OIDC)
-  void userInfoReturnsExternalAuthenticationInfo() throws Exception {
-
-    mvc.perform(get("/userinfo"))
-      .andDo(print())
-      .andExpect(status().isOk())
-      .andExpect(jsonPath("$.external_authn.type", equalTo("oidc")));
   }
 
   @Test

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/jit_account_provisioning/SamlJitAccountProvisioningTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/ext_authn/saml/jit_account_provisioning/SamlJitAccountProvisioningTests.java
@@ -273,8 +273,7 @@ public class SamlJitAccountProvisioningTests extends SamlAuthenticationTestSuppo
 
     mvc.perform(get("/userinfo").header("Authorization", format("Bearer %s", accessToken)))
       .andExpect(status().isOk())
-      .andExpect(jsonPath("$.name", equalTo(format("%s %s", JIT1_GIVEN_NAME, JIT1_FAMILY_NAME))))
-      .andExpect(jsonPath("$.external_authn.type", equalTo("saml")));
+      .andExpect(jsonPath("$.name", equalTo(format("%s %s", JIT1_GIVEN_NAME, JIT1_FAMILY_NAME))));
   }
 
   @Test
@@ -370,7 +369,6 @@ public class SamlJitAccountProvisioningTests extends SamlAuthenticationTestSuppo
 
     mvc.perform(get("/userinfo").header("Authorization", format("Bearer %s", accessToken)))
       .andExpect(status().isOk())
-      .andExpect(jsonPath("$.name", equalTo(format("%s %s", JIT1_GIVEN_NAME, JIT1_FAMILY_NAME))))
-      .andExpect(jsonPath("$.external_authn.type", equalTo("saml")));
+      .andExpect(jsonPath("$.name", equalTo(format("%s %s", JIT1_GIVEN_NAME, JIT1_FAMILY_NAME))));
   }
 }

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/IamIdTokenCustomizerTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/profile/IamIdTokenCustomizerTests.java
@@ -1,0 +1,278 @@
+/**
+ * Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.infn.mw.iam.test.oauth.profile;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+
+import com.nimbusds.jwt.JWTClaimsSet.Builder;
+
+import it.infn.mw.iam.authn.oidc.OidcExternalAuthenticationToken;
+import it.infn.mw.iam.authn.saml.SamlExternalAuthenticationToken;
+import it.infn.mw.iam.config.IamProperties;
+import it.infn.mw.iam.config.IamTokenEnhancerProperties;
+import it.infn.mw.iam.config.IamTokenEnhancerProperties.IncludeLabelProperties;
+import it.infn.mw.iam.config.IamTokenEnhancerProperties.TokenContext;
+import it.infn.mw.iam.config.scim.ScimProperties.LabelDescriptor;
+import it.infn.mw.iam.core.oauth.profile.ClaimValueHelper;
+import it.infn.mw.iam.core.oauth.profile.ScopeClaimTranslationService;
+import it.infn.mw.iam.core.oauth.profile.iam.IamExtraClaimNames;
+import it.infn.mw.iam.core.oauth.profile.iam.IamIdTokenCustomizer;
+import it.infn.mw.iam.persistence.model.AuthenticationHolderEntity;
+import it.infn.mw.iam.persistence.model.IamAccount;
+import it.infn.mw.iam.persistence.model.IamLabel;
+import it.infn.mw.iam.persistence.model.OAuth2AccessTokenEntity;
+import it.infn.mw.iam.persistence.model.SavedUserAuthentication;
+
+@SuppressWarnings("deprecation")
+class IamIdTokenCustomizerTests {
+
+  @Mock
+  private IamProperties properties;
+
+  @Mock
+  private ClaimValueHelper claimValueHelper;
+
+  @Mock
+  private ScopeClaimTranslationService scopeClaimTranslationService;
+
+  @Mock
+  private IamAccount account;
+
+  private TestIamIdTokenCustomizer customizer;
+
+  @BeforeEach
+  void setup() {
+    MockitoAnnotations.openMocks(this);
+
+    customizer =
+        new TestIamIdTokenCustomizer(properties, claimValueHelper, scopeClaimTranslationService);
+  }
+
+  @Test
+  void isExternalAuthnReturnsTrueForSamlAuthentication() {
+    SavedUserAuthentication authentication = mock(SavedUserAuthentication.class);
+
+    when(authentication.getSourceClass())
+      .thenReturn(SamlExternalAuthenticationToken.class.getName());
+
+    assertTrue(customizer.testIsExternalAuthn(authentication));
+  }
+
+  @Test
+  void isExternalAuthnReturnsTrueForOidcAuthentication() {
+    SavedUserAuthentication authentication = mock(SavedUserAuthentication.class);
+
+    when(authentication.getSourceClass())
+      .thenReturn(OidcExternalAuthenticationToken.class.getName());
+
+    assertTrue(customizer.testIsExternalAuthn(authentication));
+  }
+
+  @Test
+  void isExternalAuthnReturnsFalseForDifferentSourceClass() {
+    SavedUserAuthentication authentication = mock(SavedUserAuthentication.class);
+
+    when(authentication.getSourceClass())
+      .thenReturn(UsernamePasswordAuthenticationToken.class.getName());
+
+    assertFalse(customizer.testIsExternalAuthn(authentication));
+  }
+
+  @Test
+  void isExternalAuthnReturnsFalseWhenSourceClassIsNull() {
+    SavedUserAuthentication authentication = mock(SavedUserAuthentication.class);
+
+    when(authentication.getSourceClass()).thenReturn(null);
+
+    assertFalse(customizer.testIsExternalAuthn(authentication));
+  }
+
+  @Test
+  void isExternalAuthnReturnsFalseForNonSavedAuthentication() {
+    Authentication authentication = new UsernamePasswordAuthenticationToken("user", "password");
+
+    assertFalse(customizer.testIsExternalAuthn(authentication));
+  }
+
+  @Test
+  void includeExternalAuthnAddsClaimForExternalAuthentication() {
+    Builder claims = mock(Builder.class);
+    OAuth2AccessTokenEntity accessToken = mock(OAuth2AccessTokenEntity.class);
+
+    SavedUserAuthentication authentication = mock(SavedUserAuthentication.class);
+
+    when(authentication.getSourceClass())
+      .thenReturn(OidcExternalAuthenticationToken.class.getName());
+
+    AuthenticationHolderEntity entity = mock(AuthenticationHolderEntity.class);
+    OAuth2Authentication oauth2auth = mock(OAuth2Authentication.class);
+
+    when(accessToken.getAuthenticationHolder()).thenReturn(entity);
+    when(entity.getAuthentication()).thenReturn(oauth2auth);
+    when(oauth2auth.getUserAuthentication()).thenReturn(authentication);
+
+    Object externalAuthnClaim = mock(Object.class);
+
+    when(claimValueHelper.resolveClaim(eq(IamExtraClaimNames.EXTERNAL_AUTHN), eq(oauth2auth),
+        eq(Optional.of(account)))).thenReturn(externalAuthnClaim);
+
+    customizer.testIncludeExternalAuthnInIdToken(claims, accessToken, account);
+
+    verify(claims).claim(IamExtraClaimNames.EXTERNAL_AUTHN, externalAuthnClaim);
+  }
+
+  @Test
+  void includeExternalAuthnDoesNothingForNonExternalAuthentication() {
+    Builder claims = mock(Builder.class);
+    OAuth2AccessTokenEntity accessToken = mock(OAuth2AccessTokenEntity.class);
+
+    AuthenticationHolderEntity entity = mock(AuthenticationHolderEntity.class);
+    OAuth2Authentication oauth2auth = mock(OAuth2Authentication.class);
+    SavedUserAuthentication authentication = mock(SavedUserAuthentication.class);
+
+    when(authentication.getSourceClass())
+      .thenReturn(UsernamePasswordAuthenticationToken.class.getName());
+    when(accessToken.getAuthenticationHolder()).thenReturn(entity);
+    when(entity.getAuthentication()).thenReturn(oauth2auth);
+    when(oauth2auth.getUserAuthentication()).thenReturn(authentication);
+
+    customizer.testIncludeExternalAuthnInIdToken(claims, accessToken, account);
+
+    verify(claimValueHelper, never()).resolveClaim(eq(IamExtraClaimNames.EXTERNAL_AUTHN), any(),
+        any());
+
+    verify(claims, never()).claim(eq(IamExtraClaimNames.EXTERNAL_AUTHN), any());
+  }
+
+  @Test
+  void includeLabelsAddsConfiguredLabelToIdToken() {
+    Builder claims = mock(Builder.class);
+    IncludeLabelProperties includeLabel = mock(IncludeLabelProperties.class);
+    IamTokenEnhancerProperties tokenEnhancer = mock(IamTokenEnhancerProperties.class);
+
+    LabelDescriptor descriptor = new LabelDescriptor();
+    descriptor.setPrefix("example");
+    descriptor.setName("role");
+
+    when(properties.getTokenEnhancer()).thenReturn(tokenEnhancer);
+
+    when(tokenEnhancer.getIncludeLabels()).thenReturn(List.of(includeLabel));
+
+    when(includeLabel.getContext()).thenReturn(EnumSet.of(TokenContext.ID_TOKEN));
+
+    when(includeLabel.getLabel()).thenReturn(descriptor);
+
+    when(includeLabel.getClaimName()).thenReturn("example_role");
+
+    IamLabel label = mock(IamLabel.class);
+    when(label.getValue()).thenReturn("admin");
+
+    when(account.getLabelByPrefixAndName("example", "role")).thenReturn(Optional.of(label));
+
+    customizer.testIncludeLabelsInIdToken(claims, account);
+
+    verify(claims).claim("example_role", "admin");
+  }
+
+  @Test
+  void includeLabelsDoesNotAddClaimWhenLabelIsMissing() {
+    Builder claims = mock(Builder.class);
+    IncludeLabelProperties includeLabel = mock(IncludeLabelProperties.class);
+    IamTokenEnhancerProperties tokenEnhancer = mock(IamTokenEnhancerProperties.class);
+
+    LabelDescriptor descriptor = new LabelDescriptor();
+    descriptor.setPrefix("example");
+    descriptor.setName("role");
+
+    when(properties.getTokenEnhancer()).thenReturn(tokenEnhancer);
+
+    when(tokenEnhancer.getIncludeLabels()).thenReturn(List.of(includeLabel));
+
+    when(includeLabel.getContext()).thenReturn(EnumSet.of(TokenContext.ID_TOKEN));
+
+    when(includeLabel.getLabel()).thenReturn(descriptor);
+
+    when(account.getLabelByPrefixAndName("example", "role")).thenReturn(Optional.empty());
+
+    customizer.testIncludeLabelsInIdToken(claims, account);
+
+    verify(claims, never()).claim(any(), any());
+  }
+
+  @Test
+  void includeLabelsIgnoresLabelsNotConfiguredForIdToken() {
+    Builder claims = mock(Builder.class);
+    IncludeLabelProperties includeLabel = mock(IncludeLabelProperties.class);
+    IamTokenEnhancerProperties tokenEnhancer = mock(IamTokenEnhancerProperties.class);
+    LabelDescriptor descriptor = new LabelDescriptor();
+    descriptor.setPrefix("example");
+    descriptor.setName("role");
+
+    when(properties.getTokenEnhancer()).thenReturn(tokenEnhancer);
+    when(tokenEnhancer.getIncludeLabels()).thenReturn(List.of(includeLabel));
+    when(includeLabel.getLabel()).thenReturn(descriptor);
+
+    when(includeLabel.getContext()).thenReturn(EnumSet.of(TokenContext.USERINFO));
+
+    customizer.testIncludeLabelsInIdToken(claims, account);
+
+    verify(account, never()).getLabelByPrefixAndName(any(), any());
+
+    verify(claims, never()).claim(any(), any());
+  }
+
+  private static class TestIamIdTokenCustomizer extends IamIdTokenCustomizer {
+
+    TestIamIdTokenCustomizer(IamProperties properties, ClaimValueHelper claimValueHelper,
+        ScopeClaimTranslationService scopeClaimTranslationService) {
+
+      super(properties, claimValueHelper, scopeClaimTranslationService);
+    }
+
+    boolean testIsExternalAuthn(Authentication authentication) {
+      return isExternalAuthn(authentication);
+    }
+
+    void testIncludeExternalAuthnInIdToken(Builder claims, OAuth2AccessTokenEntity accessToken,
+        IamAccount account) {
+
+      includeExternalAuthnInIdToken(claims, accessToken, account);
+    }
+
+    void testIncludeLabelsInIdToken(Builder claims, IamAccount account) {
+      includeLabelsInIdToken(claims, account);
+    }
+  }
+}

--- a/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/userinfo/UserInfoEndpointTests.java
+++ b/iam-login-service/src/test/java/it/infn/mw/iam/test/oauth/userinfo/UserInfoEndpointTests.java
@@ -15,7 +15,6 @@
  */
 package it.infn.mw.iam.test.oauth.userinfo;
 
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -141,8 +140,6 @@ class UserInfoEndpointTests {
       .andExpect(jsonPath("$.scope").exists())
       .andExpect(jsonPath("$.scope", Matchers.hasSize(2)))
       .andExpect(jsonPath("$.scope", containsInAnyOrder("openid", "profile")))
-      .andExpect(jsonPath("$.external_authn").exists())
-      .andExpect(jsonPath("$.external_authn.type", equalTo("oidc")))
       .andReturn();
 
     checkNoRootKeyDuplicates(result.getResponse().getContentAsString());


### PR DESCRIPTION
This PR revises how the `external_authn` claim is exposed in OIDC tokens and responses.

In particular, it:

* includes `external_authn` in access tokens only when explicitly requested;
* adds `external_authn` information to ID tokens;
* removes `external_authn` from the UserInfo response.

This makes the exposure of external authentication information more consistent with the requested scopes and the intended purpose of each OIDC response.
