### PR TITLE
Align ui min length for name/surname/username with backend (min 2)

### DIFF
--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/edit/edit-user.dialog.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/user/edit/edit-user.dialog.html
@@ -29,7 +29,7 @@
                 ng-class="{'has-error': userUpdateForm.name.$dirty && userUpdateForm.name.$invalid, 'has-success': userUpdateForm.name.$dirty && userUpdateForm.name.$valid}">
                 <div class="col-sm-10">
                     <input class="form-control" id="name" name="name" placeholder="First name" required type="text"
-                        ng-minlength="3" ng-maxlength="64" ng-model="$ctrl.eUser.name" ng-pattern="$ctrl.pattern"
+                        ng-minlength="2" ng-maxlength="64" ng-model="$ctrl.eUser.name" ng-pattern="$ctrl.pattern"
                         ng-disabled="!$ctrl.isAdmin() && !$ctrl.isUserEditableField('NAME')" />
                     <span class="glyphicon form-control-feedback"
                         ng-class="{'glyphicon-remove': userUpdateForm.name.$dirty && userUpdateForm.name.$invalid, 'glyphicon-ok': userUpdateForm.name.$dirty && userUpdateForm.name.$valid}"
@@ -55,7 +55,7 @@
                 ng-class="{'has-error': userUpdateForm.surname.$dirty && userUpdateForm.surname.$invalid, 'has-success': userUpdateForm.surname.$dirty && userUpdateForm.surname.$valid}">
                 <div class="col-sm-10">
                     <input class="form-control" id="surname" name="surname" placeholder="Family name" required
-                        type="text" ng-minlength="3" ng-maxlength="64" ng-model="$ctrl.eUser.surname"
+                        type="text" ng-minlength="2" ng-maxlength="64" ng-model="$ctrl.eUser.surname"
                         ng-pattern="$ctrl.pattern"
                         ng-disabled="!$ctrl.isAdmin() && !$ctrl.isUserEditableField('SURNAME')" />
                     <span class="glyphicon form-control-feedback"

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/users/userslist/user.add.dialog.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/components/users/userslist/user.add.dialog.html
@@ -30,7 +30,7 @@
         ng-class="{'has-error': userCreationForm.name.$dirty && userCreationForm.name.$invalid, 'has-success': userCreationForm.name.$dirty && userCreationForm.name.$valid}">
         <div class="col-sm-10">
           <input class="form-control" name="name" id="name" type="text" ng-model="$ctrl.user.name"
-            placeholder="First name" required ng-minlength="3" />
+            placeholder="First name" required ng-minlength="2" />
           <span class="glyphicon form-control-feedback"
             ng-class="{'glyphicon-remove': userCreationForm.name.$dirty && userCreationForm.name.$invalid, 'glyphicon-ok': userCreationForm.name.$dirty && userCreationForm.name.$valid}"
             style="right: 15px"></span>
@@ -49,7 +49,7 @@
         ng-class="{'has-error': userCreationForm.surname.$dirty && userCreationForm.surname.$invalid, 'has-success': userCreationForm.surname.$dirty && userCreationForm.surname.$valid}">
         <div class="col-sm-10">
           <input class="form-control" name="surname" id="surname" type="text" ng-model="$ctrl.user.surname"
-            placeholder="Surname" required ng-minlength="3" />
+            placeholder="Surname" required ng-minlength="2" />
           <span class="glyphicon form-control-feedback"
             ng-class="{'glyphicon-remove': userCreationForm.surname.$dirty && userCreationForm.surname.$invalid, 'glyphicon-ok': userCreationForm.surname.$dirty && userCreationForm.surname.$valid}"
             style="right: 15px"></span>

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/templates/home/edituser.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/templates/home/edituser.html
@@ -28,11 +28,11 @@
             <label class="control-label col-sm-2" for="name">Name</label>
             <div ng-class="{'has-error': userUpdateForm.name.$dirty && userUpdateForm.name.$invalid, 'has-success': userUpdateForm.name.$dirty && userUpdateForm.name.$valid}">
                 <div class="col-sm-10">
-                    <input class="form-control" name="name" id="name" type="text" ng-model="editMeCtrl.eUser.name" placeholder="First name" required ng-minlength="3"/>
+                    <input class="form-control" name="name" id="name" type="text" ng-model="editMeCtrl.eUser.name" placeholder="First name" required ng-minlength="2"/>
                     <span class="glyphicon form-control-feedback" ng-class="{'glyphicon-remove': userUpdateForm.name.$dirty && userUpdateForm.name.$invalid, 'glyphicon-ok': userUpdateForm.name.$dirty && userUpdateForm.name.$valid}" style="right: 15px"></span>
                     <span class="help-block" ng-show="userUpdateForm.name.$dirty && userUpdateForm.name.$error.required">
                         This is a required field</span>
-                    <span class="help-block" ng-show="userUpdateForm.name.$dirty && userUpdateForm.name.$error.minlength">Minimum length required is 3</span>
+                    <span class="help-block" ng-show="userUpdateForm.name.$dirty && userUpdateForm.name.$error.minlength">Minimum length required is 2</span>
                 </div>
             </div>
         </div>
@@ -41,11 +41,11 @@
             <label class="control-label col-sm-2" for="surname">Surname</label>
             <div ng-class="{'has-error': userUpdateForm.surname.$dirty && userUpdateForm.surname.$invalid, 'has-success': userUpdateForm.surname.$dirty && userUpdateForm.surname.$valid}">
                 <div class="col-sm-10">
-                    <input class="form-control" name="surname" id="surname" type="text" ng-model="editMeCtrl.eUser.surname" placeholder="Family name" required ng-minlength="3"/>
+                    <input class="form-control" name="surname" id="surname" type="text" ng-model="editMeCtrl.eUser.surname" placeholder="Family name" required ng-minlength="2"/>
                     <span class="glyphicon form-control-feedback" ng-class="{'glyphicon-remove': userUpdateForm.surname.$dirty && userUpdateForm.surname.$invalid, 'glyphicon-ok': userUpdateForm.surname.$dirty && userUpdateForm.surname.$valid}" style="right: 15px"></span>
                     <span class="help-block" ng-show="userUpdateForm.surname.$dirty && userUpdateForm.surname.$error.required">
                         This is a required field</span>
-                    <span class="help-block" ng-show="userUpdateForm.surname.$dirty && userUpdateForm.surname.$error.minlength">Minimum length required is 3</span>
+                    <span class="help-block" ng-show="userUpdateForm.surname.$dirty && userUpdateForm.surname.$error.minlength">Minimum length required is 2</span>
                 </div>
             </div>
         </div>

--- a/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/templates/user/edituser.html
+++ b/iam-login-service/src/main/webapp/resources/iam/apps/dashboard-app/templates/user/edituser.html
@@ -35,12 +35,12 @@
                         placeholder="First name"
                         required
                         type="text"
-                        ng-minlength="3"
+                        ng-minlength="2"
                         ng-maxlength="64"
                         ng-model="editUserCtrl.eUser.name"
                         ng-pattern="editUserCtrl.pattern" />
                     <span class="help-block" ng-show="userUpdateForm.name.$dirty && userUpdateForm.name.$error.required"> This is a required field </span>
-                    <span class="help-block" ng-show="userUpdateForm.name.$dirty && userUpdateForm.name.$error.minlength"> Minimum length required is 3 </span>
+                    <span class="help-block" ng-show="userUpdateForm.name.$dirty && userUpdateForm.name.$error.minlength"> Minimum length required is 2 </span>
                     <span class="help-block" ng-show="userUpdateForm.name.$dirty && userUpdateForm.name.$error.maxlength"> Maximum length is 64 </span>
                     <span class="help-block" ng-show="userUpdateForm.name.$dirty && userUpdateForm.name.$error.pattern"> Invalid characters </span>
                 </div>
@@ -58,13 +58,13 @@
                         placeholder="Family name"
                         required
                         type="text"
-                        ng-minlength="3"
+                        ng-minlength="2"
                         ng-maxlength="64"
                         ng-model="editUserCtrl.eUser.surname"
                         ng-pattern="editUserCtrl.pattern" />
                     <span class="glyphicon form-control-feedback" ng-class="{'glyphicon-remove': userUpdateForm.surname.$dirty && userUpdateForm.surname.$invalid, 'glyphicon-ok': userUpdateForm.surname.$dirty && userUpdateForm.surname.$valid}" style="right: 15px"></span>
                     <span class="help-block" ng-show="userUpdateForm.surname.$dirty && userUpdateForm.surname.$error.required"> This is a required field </span>
-                    <span class="help-block" ng-show="userUpdateForm.surname.$dirty && userUpdateForm.surname.$error.minlength"> Minimum length required is 3 </span>
+                    <span class="help-block" ng-show="userUpdateForm.surname.$dirty && userUpdateForm.surname.$error.minlength"> Minimum length required is 2 </span>
                     <span class="help-block" ng-show="userUpdateForm.surname.$dirty && userUpdateForm.surname.$error.maxlength"> Maximum length is 64 </span>
                     <span class="help-block" ng-show="userUpdateForm.surname.$dirty && userUpdateForm.surname.$error.pattern"> Invalid characters </span>
                 </div>
@@ -107,7 +107,7 @@
                         ng-model="editUserCtrl.eUser.username"
                         placeholder="Username"
                         required
-                        ng-minlength="3"
+                        ng-minlength="2"
                         ng-maxlength="128"
                         iam-username-available-validator
                         ng-pattern="editUserCtrl.pattern" />
@@ -117,7 +117,7 @@
                         style="right: 15px"></span>
                     <span class="help-block" ng-show="userUpdateForm.username.$dirty && userUpdateForm.username.$error.required">
                         This is a required field</span>
-                    <span class="help-block" ng-show="userUpdateForm.username.$dirty && userUpdateForm.username.$error.minlength"> Minimum length required is 3 </span>
+                    <span class="help-block" ng-show="userUpdateForm.username.$dirty && userUpdateForm.username.$error.minlength"> Minimum length required is 2 </span>
                     <span class="help-block" ng-show="userUpdateForm.username.$dirty && userUpdateForm.username.$error.maxlength"> Maximum length required is 128 </span>
                     <span class="help-block" ng-show="userUpdateForm.username.$dirty && userUpdateForm.username.$error.usernameAvailable"> Username already in use </span>
                     <span class="help-block" ng-show="userUpdateForm.username.$dirty && userUpdateForm.username.$error.pattern"> Invalid characters </span>

--- a/iam-login-service/src/main/webapp/resources/iam/template/registration.html
+++ b/iam-login-service/src/main/webapp/resources/iam/template/registration.html
@@ -33,11 +33,11 @@
             <label class="control-label col-sm-2" for="name">Name</label>
             <div ng-class="{'has-error': registrationForm.name.$dirty && registrationForm.name.$invalid, 'has-success': registrationForm.name.$dirty && registrationForm.name.$valid}">
                 <div class="col-sm-10">
-                    <input class="form-control" name="name" id="name" type="text" ng-model="request.givenname" placeholder="First name" required ng-minlength="3"/>
+                    <input class="form-control" name="name" id="name" type="text" ng-model="request.givenname" placeholder="First name" required ng-minlength="2"/>
                     <span class="glyphicon form-control-feedback" ng-class="{'glyphicon-remove': registrationForm.name.$dirty && registrationForm.name.$invalid, 'glyphicon-ok': registrationForm.name.$dirty && registrationForm.name.$valid}" style="right: 15px"></span>
                     <span class="help-block" ng-show="registrationForm.name.$dirty && registrationForm.name.$error.required">
                         This is a required field</span>
-                    <span class="help-block" ng-show="registrationForm.name.$dirty && registrationForm.name.$error.minlength">Minimum length required is 3</span>
+                    <span class="help-block" ng-show="registrationForm.name.$dirty && registrationForm.name.$error.minlength">Minimum length required is 2</span>
                 </div>
             </div>
         </div>
@@ -46,14 +46,14 @@
             <label class="control-label col-sm-2" for="surname">Surname</label>
             <div ng-class="{'has-error': registrationForm.surname.$dirty && registrationForm.surname.$invalid, 'has-success': registrationForm.surname.$dirty && registrationForm.surname.$valid}">
                 <div class="col-sm-10">
-                    <input class="form-control" name="surname" id="surname" type="text" ng-model="request.familyname" placeholder="Family name" required ng-minlength="3"/>
+                    <input class="form-control" name="surname" id="surname" type="text" ng-model="request.familyname" placeholder="Family name" required ng-minlength="2"/>
                     <span
                         class="glyphicon form-control-feedback"
                         ng-class="{'glyphicon-remove': registrationForm.surname.$dirty && registrationForm.surname.$invalid, 'glyphicon-ok': registrationForm.surname.$dirty && registrationForm.surname.$valid}"
                         style="right: 15px"></span>
                     <span class="help-block" ng-show="registrationForm.surname.$dirty && registrationForm.surname.$error.required">
                         This is a required field</span>
-                    <span class="help-block" ng-show="registrationForm.surname.$dirty && registrationForm.surname.$error.minlength">Minimum length required is 3</span>
+                    <span class="help-block" ng-show="registrationForm.surname.$dirty && registrationForm.surname.$error.minlength">Minimum length required is 2</span>
                 </div>
             </div>
         </div>
@@ -83,7 +83,7 @@
             <div ng-class="{'has-error': registrationForm.username.$dirty && registrationForm.username.$invalid, 'has-success': registrationForm.username.$dirty && registrationForm.username.$valid}">
                 <div class="col-sm-10">
                     <input class="form-control" id="username" name="username" type="text" ng-model="request.username" placeholder="Username" required 
-                    ng-minlength="3" 
+                    ng-minlength="2" 
                     iam-username-available-validator ng-model-options="{ debounce : { 'default' : 500 } }"/>
                     <span
                         class="glyphicon form-control-feedback"


### PR DESCRIPTION
## What

Align the frontend `ng-minlength` (and the "Minimum length required" messages) for **given name**, **family name** and **username** fields from `3` to `2`, matching the existing backend validations:

- `ScimName`: `@Length(min = 2, max = 64)` on `givenName` / `familyName`
- `RegistrationRequestDto`: `@Size(min = 2, ...)` on `username` / `givenname` / `familyname`

## Why

The UI rejects valid 2-character values that the backend accepts — e.g. pinyin surnames/given names such as "Bi" (毕), "Li" (李), "Wu" (吴). Affected users cannot register or edit their details in the browser, while the API (registration / SCIM PATCH) succeeds, forcing admins to work around it via API.

## Files changed (5)

- `templates/user/edituser.html` — name, surname, username
- `templates/home/edituser.html` — name, surname
- `components/user/edit/edit-user.dialog.html` — name, surname
- `components/users/userslist/user.add.dialog.html` — name, surname
- `iam/template/registration.html` — name, surname, username

(The email field keeps its `ng-minlength="3"` — the minimum length of a valid email is 3.)

Fixes #1340